### PR TITLE
Feature/tgv old

### DIFF
--- a/algos/tgv_old/combine_to_4d.jl
+++ b/algos/tgv_old/combine_to_4d.jl
@@ -1,0 +1,83 @@
+#!/usr/bin/env julia
+# combine_to_4d.jl
+# Combine 3D multi-echo phase images and magnitude images into a 4D time-series
+
+import Pkg
+Pkg.activate("/workdir/tgv_old_env")
+
+using JSON3, NIfTI
+
+if length(ARGS) < 1
+    println("Usage: julia combine_to_4d.jl <output_dir>")
+    exit(1)
+end
+
+outdir = ARGS[1]
+isdir(outdir) || mkpath(outdir)
+
+println("[INFO] Loading inputs.json...")
+d = JSON3.read(open("inputs.json"))
+
+#  JSON3.Array to Vector{String}
+phase_files = collect(String.(d["phase_nii"]))
+mag_files   = collect(String.(d["mag_nii"]))
+
+println("[INFO] Phase files: ", join(phase_files, ", "))
+println("[INFO] Magnitude files: ", join(mag_files, ", "))
+
+function combine_to_4d(in_files::Vector{String}, out_file::String)
+    imgs  = [NIfTI.niread(f) for f in in_files]
+    datas = [Array(img) for img in imgs]
+
+    shapes = unique(size.(datas))
+    if length(shapes) != 1
+        error("[ERROR] Inconsistent input shapes: $shapes")
+    end
+
+    stacked = cat(datas...; dims=ndims(datas[1])+1)
+
+# Header from first Echo
+hdr = imgs[1].header
+desc = hdr.descrip
+if desc isa NTuple{80,UInt8}
+    desc = String(collect(desc))
+end
+
+# --- Create Volume with voxel + qform ---
+out_img = NIfTI.NIVolume(
+    stacked;
+    voxel_size = Tuple(hdr.pixdim[2:4]),
+    descrip    = desc,
+    qfac       = hdr.pixdim[1],
+    quatern_b  = hdr.quatern_b,
+    quatern_c  = hdr.quatern_c,
+    quatern_d  = hdr.quatern_d,
+    qoffset_x  = hdr.qoffset_x,
+    qoffset_y  = hdr.qoffset_y,
+    qoffset_z  = hdr.qoffset_z
+)
+
+# --- Set affine (srow) ---
+out_img.header.srow_x     = hdr.srow_x
+out_img.header.srow_y     = hdr.srow_y
+out_img.header.srow_z     = hdr.srow_z
+out_img.header.sform_code = hdr.sform_code
+
+# --- Set qform code as well ---
+out_img.header.qform_code = hdr.qform_code
+
+# --- Save ---
+NIfTI.niwrite(out_file, out_img)
+
+println("[INFO] Created 4D NIfTI: $out_file with size ", size(stacked))
+
+end
+
+
+combine_to_4d(phase_files, joinpath(outdir, "sub-1_phase_4D.nii"))
+combine_to_4d(mag_files,   joinpath(outdir, "sub-1_mag_4D.nii"))
+
+println("[INFO] Saved:")
+println("  → $(joinpath(outdir, "sub-1_phase_4D.nii"))")
+println("  → $(joinpath(outdir, "sub-1_mag_4D.nii"))")
+println("[INFO] Converting to 4D done.")

--- a/algos/tgv_old/fieldmap_to_radians.jl
+++ b/algos/tgv_old/fieldmap_to_radians.jl
@@ -1,0 +1,106 @@
+#!/usr/bin/env julia
+# Convert B0 fieldmap (Hz) to radians at arbitrary TE
+
+import Pkg
+Pkg.activate("/workdir/tgv_old_env")
+
+using NIfTI, JSON3
+
+if length(ARGS) < 2
+    println("Usage: julia fieldmap_to_radians.jl <B0_fieldmap.nii> <output_dir>")
+    exit(1)
+end
+
+b0_file = abspath(ARGS[1])           
+outdir  = abspath(ARGS[2])
+isdir(outdir) || mkpath(outdir)
+
+# --- EchoTime + B0 from inputs.json ---
+json_file = joinpath(dirname(outdir), "inputs.json")
+if !isfile(json_file)
+    println("[ERROR] inputs.json not found: $json_file")
+    exit(1)
+end
+data = JSON3.read(open(json_file, "r"), Dict)
+
+TE = Float64(data["EchoTime"][1])   
+B0 = Float64(data["MagneticFieldStrength"])  
+println("[INFO] Using EchoTime: $TE s")
+println("[INFO] Using B0: $B0 T")
+
+# TE and B0 saved for main.sh
+open(joinpath(outdir, "te_used.txt"), "w") do f
+    write(f, string(TE))
+end
+open(joinpath(outdir, "b0_used.txt"), "w") do f
+    write(f, string(B0))
+end
+
+println("[INFO] Converting fieldmap to radians...")
+println("  Input:  $b0_file")
+println("  Output: $outdir")
+
+# --- Load B0 Fieldmap (Hz) ---
+b0_img  = NIfTI.niread(b0_file)
+b0_data = Array(b0_img)  # in Hz
+hdr     = b0_img.header
+
+# --- Convert Hz to Radians ---
+radian_data = 2π .* b0_data .* TE
+
+# --- Clean NaNs/Infs ---
+n_nan = count(isnan, radian_data)
+n_inf = count(isinf, radian_data)
+if n_nan > 0 || n_inf > 0
+    println("[WARN] Found $n_nan NaN and $n_inf Inf voxels → setting to 0.0")
+    radian_data[.!isfinite.(radian_data)] .= 0.0
+end
+
+# --- Copy description safely ---
+desc = hdr.descrip
+if desc isa NTuple{80,UInt8}
+    desc = String(collect(desc))
+elseif desc isa SubString{String}
+    desc = String(desc)
+else
+    desc = String(desc)
+end
+
+# --- New NIfTI-Volume ---
+radian_volume = NIfTI.NIVolume(
+    radian_data;
+    voxel_size = Tuple(hdr.pixdim[2:4]),
+    descrip    = desc,
+    qfac       = hdr.pixdim[1],
+    quatern_b  = hdr.quatern_b,
+    quatern_c  = hdr.quatern_c,
+    quatern_d  = hdr.quatern_d,
+    qoffset_x  = hdr.qoffset_x,
+    qoffset_y  = hdr.qoffset_y,
+    qoffset_z  = hdr.qoffset_z
+)
+
+# --- Copy geometry from mask ---
+mask_file = abspath("bids/derivatives/qsm-forward/sub-1/anat/sub-1_mask.nii")
+if isfile(mask_file)
+    mask_img = NIfTI.niread(mask_file)
+    hdr_mask = mask_img.header
+
+    radian_volume.header.srow_x     = hdr_mask.srow_x
+    radian_volume.header.srow_y     = hdr_mask.srow_y
+    radian_volume.header.srow_z     = hdr_mask.srow_z
+    radian_volume.header.sform_code = hdr_mask.sform_code
+    radian_volume.header.qform_code = hdr_mask.qform_code
+    radian_volume.header.pixdim     = hdr_mask.pixdim
+    radian_volume.header.xyzt_units = hdr_mask.xyzt_units
+
+    println("[INFO] Copied qform/sform geometry from mask: $mask_file")
+else
+    println("[WARN] Mask file not found: $mask_file (skipping geometry copy)")
+end
+
+# --- Save ---
+out_file = joinpath(outdir, "sub-1_radians.nii")
+NIfTI.niwrite(out_file, radian_volume)
+
+println("[INFO] Saved radians fieldmap → $out_file")

--- a/algos/tgv_old/fieldmap_to_radians.py
+++ b/algos/tgv_old/fieldmap_to_radians.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+import sys, os, json
+import nibabel as nib
+import numpy as np
+
+if len(sys.argv) < 3:
+    print("Usage: python fieldmap_to_radians.py <B0_fieldmap.nii> <output_dir>")
+    sys.exit(1)
+
+b0_file = sys.argv[1]
+outdir  = sys.argv[2]
+if not os.path.exists(outdir):
+    os.makedirs(outdir)
+
+# --- EchoTime aus inputs.json lesen ---
+with open("inputs.json", "r") as f:
+    d = json.load(f)
+TE = float(d["EchoTime"][0])   # erstes TE aus Array nehmen
+print("[INFO] Using EchoTime from inputs.json: {} sec".format(TE))
+
+# --- B0 laden ---
+b0_img  = nib.load(b0_file)
+b0_data = b0_img.get_fdata()
+
+# --- Hz → Radian ---
+radian_data = 2*np.pi * b0_data * TE
+
+# --- Header übernehmen ---
+hdr = b0_img.header.copy()
+radian_img = nib.Nifti1Image(radian_data.astype(np.float32), b0_img.affine, hdr)
+
+# --- Maske laden für Konsistenz ---
+mask_file = "bids/derivatives/qsm-forward/sub-1/anat/sub-1_mask.nii"
+if os.path.exists(mask_file):
+    mask_img = nib.load(mask_file)
+    rad_hdr  = radian_img.header
+    rad_hdr.set_qform(mask_img.affine, code=int(mask_img.header['qform_code']))
+    rad_hdr.set_sform(mask_img.affine, code=int(mask_img.header['sform_code']))
+    print("[INFO] Copied qform/sform from mask.")
+
+# --- Speichern ---
+out_file = os.path.join(outdir, "sub-1_radians.nii")
+nib.save(radian_img, out_file)
+print("[INFO] Saved radians fieldmap -> {}".format(out_file))
+print("[INFO] Done.")

--- a/algos/tgv_old/main.sh
+++ b/algos/tgv_old/main.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#DOCKER_IMAGE=ubuntu:18.04
+
+set -euo pipefail
+set -x
+
+echo "[INFO] Starting TGV_QSM (old) pipeline"
+
+input_dir=${1:-/workdir}
+output_dir=${2:-/workdir/output}
+
+mkdir -p "$output_dir/tmp" "$output_dir"
+
+# --- Julia Setup ---
+JULIA_BIN=/workdir/julia-1.9.4/bin/julia
+$JULIA_BIN --version
+
+# --- Setup Julia environment ---
+ $JULIA_BIN --project=/workdir/tgv_old_env /workdir/tgv_old_env/install_packages_tgv_old.jl
+
+# --- Step 1: Combine to 4D ---
+echo "[INFO] Running combine_to_4d.jl..."
+$JULIA_BIN --project=/workdir/tgv_old_env /workdir/combine_to_4d.jl $output_dir
+echo "[INFO] Combine step finished successfully."
+
+# --- Step 2: Run ROMEO ---
+$JULIA_BIN --project=/workdir/tgv_old_env /workdir/romeo_unwrapping.jl \
+  --phase "$output_dir/sub-1_phase_4D.nii" \
+  --mag "$output_dir/sub-1_mag_4D.nii" \
+  --mask "bids/derivatives/qsm-forward/sub-1/anat/sub-1_mask.nii" \
+  --compute-B0 "$output_dir/sub-1_B0.nii" \
+  --correct-global \
+  --phase-offset-correction bipolar
+
+echo "[INFO] ROMEO step finished successfully."
+
+
+
+
+echo "[INFO] Converting B0 fieldmap to radians..."
+
+$JULIA_BIN --project=/workdir/tgv_old_env /workdir/fieldmap_to_radians.jl \
+    "$output_dir/sub-1_B0.nii" \
+    "$output_dir"
+
+
+
+# --- 3) Header check ---
+echo "[DEBUG] Checking header match between radians and mask..."
+/workdir/miniconda2/bin/python - <<'EOF'
+import nibabel as nib
+phase = nib.load("output/sub-1_radians.nii")
+mask  = nib.load("bids/derivatives/qsm-forward/sub-1/anat/sub-1_mask.nii")
+
+print("Phase shape:", phase.shape, "zooms:", phase.header.get_zooms())
+print("Mask  shape:", mask.shape, "zooms:", mask.header.get_zooms())
+print("Affine diff:\n", phase.affine - mask.affine)
+EOF
+echo "[DEBUG] Header check done."
+
+# --- 4) Run TGV ---
+
+# -------------------------
+# 1) Basic tools
+# -------------------------
+echo "[INFO] Installing base packages (wget, bzip2, jq, git, build-essential)..."
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    wget \
+    bzip2 \
+    jq \
+    git \
+    build-essential
+
+# -------------------------
+# 3) Compiler Toolchain
+# -------------------------
+
+# cc Symlink
+if command -v cc &> /dev/null; then
+  echo "[INFO] cc already exists: $(which cc)"
+else
+  echo "[INFO] Linking /usr/bin/cc -> gcc..."
+  ln -s /usr/bin/gcc /usr/bin/cc
+fi
+
+#should be in container already
+# echo "[INFO] Installing Miniconda2..."
+# wget https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh
+# bash Miniconda2-4.6.14-Linux-x86_64.sh -b -p miniconda2
+# miniconda2/bin/conda install -y -c anaconda cython==0.29.4
+# miniconda2/bin/conda install -y numpy
+# miniconda2/bin/conda install -y pyparsing
+# miniconda2/bin/pip install scipy==0.17.1 nibabel==2.1.0
+# miniconda2/bin/pip install --upgrade cython
+
+# Miniconda-symlink check
+if [ -L "/workdir/miniconda2/bin/cc" ]; then
+  target=$(readlink /workdir/miniconda2/bin/cc || true)
+  if [ "$target" != "/usr/bin/gcc" ]; then
+    echo "[INFO] Fixing wrong symlink in miniconda2/bin/cc..."
+    rm -f /workdir/miniconda2/bin/cc
+    ln -s /usr/bin/gcc /workdir/miniconda2/bin/cc
+  else
+    echo "[INFO] miniconda2/bin/cc symlink is correct."
+  fi
+else
+  echo "[INFO] Creating symlink miniconda2/bin/cc..."
+  ln -s /usr/bin/gcc /workdir/miniconda2/bin/cc
+fi
+
+echo "[DEBUG] After symlinks:"
+ls -l /usr/bin/cc || true
+ls -l /workdir/miniconda2/bin/cc || true
+
+# -------------------------
+# 4) Clone / Install TGV_QSM
+# -------------------------
+if [ ! -d "/workdir/TGV_QSM" ]; then
+  echo "[INFO] Cloning TGV_QSM..."
+  git clone https://github.com/QSMxT/TGV_QSM.git /workdir/TGV_QSM
+else
+  echo "[INFO] TGV_QSM already exists, pulling latest..."
+  cd /workdir/TGV_QSM && git pull || true
+fi
+
+cd /workdir/TGV_QSM
+echo "[DEBUG] Files in TGV_QSM:"
+ls -lh
+
+# Test: Compiler aus Python heraus
+echo "[DEBUG] Testing gcc from Python..."
+/workdir/miniconda2/bin/python -c "import subprocess; print('Running gcc from Python...'); subprocess.call(['/usr/bin/gcc','--version'])"
+
+echo "[INFO] Installing TGV_QSM via Python..."
+PATH=/usr/bin:$PATH /workdir/miniconda2/bin/python setup.py install
+
+
+# -------------------------
+# 5) Run TGV_QSM
+# -------------------------
+TE=$(jq '.EchoTime[0]' /workdir/inputs.json)
+B0=$(jq '.MagneticFieldStrength' /workdir/inputs.json)
+cd /workdir
+/workdir/miniconda2/bin/tgv_qsm \
+  -p /workdir/output/sub-1_radians.nii \
+  -m /workdir/bids/derivatives/qsm-forward/sub-1/anat/sub-1_mask.nii \
+  -f $B0 \
+  -t $TE \
+  -o sub-1_QSM \
+  --no-resampling
+
+# Move output to output_dir
+mkdir -p "$output_dir/test_copies"
+mv "$output_dir/sub-1_phase_4D.nii"    "$output_dir/test_copies/" || true
+mv "$output_dir/sub-1_mag_4D.nii"      "$output_dir/test_copies/" || true
+mv "$output_dir/sub-1_B0.nii"          "$output_dir/test_copies/" || true
+mv "$output_dir/sub-1_radians.nii"     "$output_dir/test_copies/" || true
+cp "$output_dir"/sub-1*QSM*.nii* "$output_dir/test_copies/" 2>/dev/null || true
+
+
+echo "[INFO] TGV_QSM finished. Output: $output_dir/sub-1_QSM.nii.gz"

--- a/algos/tgv_old/main.sh
+++ b/algos/tgv_old/main.sh
@@ -43,20 +43,7 @@ $JULIA_BIN --project=/workdir/tgv_old_env /workdir/fieldmap_to_radians.jl \
     "$output_dir/sub-1_B0.nii" \
     "$output_dir"
 
-
-
-# --- 3) Header check ---
-echo "[DEBUG] Checking header match between radians and mask..."
-/workdir/miniconda2/bin/python - <<'EOF'
-import nibabel as nib
-phase = nib.load("output/sub-1_radians.nii")
-mask  = nib.load("bids/derivatives/qsm-forward/sub-1/anat/sub-1_mask.nii")
-
-print("Phase shape:", phase.shape, "zooms:", phase.header.get_zooms())
-print("Mask  shape:", mask.shape, "zooms:", mask.header.get_zooms())
-print("Affine diff:\n", phase.affine - mask.affine)
-EOF
-echo "[DEBUG] Header check done."
+echo "[INFO] Conversion to radians finished successfully."
 
 # --- 4) Run TGV ---
 
@@ -84,15 +71,18 @@ else
   ln -s /usr/bin/gcc /usr/bin/cc
 fi
 
-#should be in container already
-# echo "[INFO] Installing Miniconda2..."
-# wget https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh
-# bash Miniconda2-4.6.14-Linux-x86_64.sh -b -p miniconda2
-# miniconda2/bin/conda install -y -c anaconda cython==0.29.4
-# miniconda2/bin/conda install -y numpy
-# miniconda2/bin/conda install -y pyparsing
-# miniconda2/bin/pip install scipy==0.17.1 nibabel==2.1.0
-# miniconda2/bin/pip install --upgrade cython
+echo "[INFO] Installing Miniconda2..."
+
+if [ ! -f "Miniconda2-4.6.14-Linux-x86_64.sh" ]; then
+  wget https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh -O Miniconda2-4.6.14-Linux-x86_64.sh
+fi
+#instal miniconda
+bash Miniconda2-4.6.14-Linux-x86_64.sh -b -u -p miniconda2
+miniconda2/bin/conda install -y -c anaconda cython==0.29.4
+miniconda2/bin/conda install -y numpy
+miniconda2/bin/conda install -y pyparsing
+miniconda2/bin/pip install scipy==0.17.1 nibabel==2.1.0
+miniconda2/bin/pip install --upgrade cython
 
 # Miniconda-symlink check
 if [ -L "/workdir/miniconda2/bin/cc" ]; then

--- a/algos/tgv_old/romeo_unwrapping.jl
+++ b/algos/tgv_old/romeo_unwrapping.jl
@@ -1,0 +1,66 @@
+#!/usr/bin/env julia
+import Pkg
+Pkg.activate("/workdir/tgv_old_env")
+
+using ROMEO, MriResearchTools, ArgParse, JSON3
+
+println("[INFO] Unwrapping with ROMEO...")
+
+# -------------------------
+# CLI Argument Parsing
+# -------------------------
+s = ArgParseSettings()
+@add_arg_table s begin
+    "--phase"
+        help = "4D phase NIfTI"
+        arg_type = String
+    "--mag"
+        help = "4D magnitude NIfTI"
+        arg_type = String
+    "--mask"
+        help = "Brain mask NIfTI"
+        arg_type = String
+    "--compute-B0"
+        help = "Output path for B0 fieldmap"
+        arg_type = String
+        required = true
+    "--correct-global"
+        help = "Enable global phase correction"
+        action = :store_true
+    "--phase-offset-correction"
+        help = "Method for phase offset correction (e.g. bipolar)"
+        arg_type = String
+        default = ""
+end
+
+parsed_args = parse_args(ARGS, s)
+
+# -------------------------
+# Load EchoTimes from inputs.json
+# -------------------------
+inputs_file = "inputs.json"   
+if !isfile(inputs_file)
+    error("[ERROR] inputs.json not found in current dir")
+end
+
+d = JSON3.read(open(inputs_file))
+TEs_sec = Float64.(d["EchoTime"])   # in seconds
+TEs_ms  = TEs_sec .* 1000.0         # convert to ms
+
+println("[INFO] Found EchoTimes in inputs.json: ", TEs_ms)
+
+# -------------------------
+# Run ROMEO
+# -------------------------
+@time msg = ROMEO.unwrapping_main([
+    "--phase", parsed_args["phase"],
+    "--mag",   parsed_args["mag"],
+    "--mask",  parsed_args["mask"],
+    "-t",      "[" * join(string.(TEs_ms), " ") * "]",
+    "--compute-B0", parsed_args["compute-B0"],
+    "--correct-global",
+    "--phase-offset-correction", parsed_args["phase-offset-correction"]
+])
+
+println(msg)
+println("[INFO] ROMEO step finished successfully.")

--- a/algos/tgv_old/tgv_old_env/install_packages_tgv_old.jl
+++ b/algos/tgv_old/tgv_old_env/install_packages_tgv_old.jl
@@ -1,0 +1,27 @@
+import Pkg
+
+println("[INFO] Activating local project environment for TGV_QSM (old)...")
+Pkg.activate("/workdir/tgv_old_env")
+
+println("[INFO] Updating registries...")
+try
+    Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"))
+catch
+    println("[INFO] Registry already exists")
+end
+Pkg.Registry.update()
+
+#  Packages
+Pkg.add("JSON3")
+Pkg.add("NIfTI")
+Pkg.add("MriResearchTools")
+Pkg.add(Pkg.PackageSpec(name="ROMEO", version=v"1.1.1"))
+# Add ArgParse for CLI parsing in romeo_step.jl
+Pkg.add("ArgParse")
+
+println("[INFO] Instantiating environment...")
+Pkg.instantiate()
+Pkg.precompile()
+Pkg.status()
+
+println("[INFO] Install finished for TGV_QSM (old)...")


### PR DESCRIPTION
This PR adds the old TGV_QSM pipeline as a new algorithm under algos/tgv_old/.

Steps implemented:
- Combine 3D multi-echo phase and magnitude images into a 4D time-series
- Run ROMEO.jl on the 4D data (phase + magnitude) to produce a 3D fieldmap in Hz
- Convert fieldmap to radians using arbitrary TE (e.g. 0.005s) and real field strength (e.g. B0 = 3T)
- Run old TGV_QSM using TE and B0 values to generate a single QSM map in ppm
- Uses Miniconda2 and Python 2.7 as required by the legacy TGV_QSM implementation

