### PR TITLE
harperella: emit ppm not radians (pass --te/--field-strength, bump qsmxt v9.7.0)

### DIFF
--- a/algorithms/harperella/algorithm.yml
+++ b/algorithms/harperella/algorithm.yml
@@ -8,7 +8,7 @@ citation: Li et al., NeuroImage 2014
 doi: 10.1016/j.neuroimage.2014.08.029
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
-image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0
+image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.7.0
 run: bash run.sh
 parameters:
   - name: radius

--- a/algorithms/harperella/run.sh
+++ b/algorithms/harperella/run.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 IN="${1:-/input}"; OUT="${2:-/output}"
 
+# HARPERELLA operates on the first echo's phase; --te (that echo's TE) and --field-strength convert
+# its tissue-phase output from radians to ppm (qsmxt >= v9.7.0).
+B0=$(jq -r '.B0' "$IN/params.json")
+TE=$(jq -r '.TE[0]' "$IN/params.json")
+
 # Parameter overrides (qsm-ci run --set NAME=VALUE) arrive as /input/config.json.
 SET=""
 CFG="$IN/config.json"
@@ -11,4 +16,5 @@ if [ -f "$CFG" ]; then
   V=$(jq -r '.max_iter // empty' "$CFG"); [ -n "$V" ] && SET="$SET --max-iter $V"
   V=$(jq -r '.tol // empty' "$CFG"); [ -n "$V" ] && SET="$SET --tol $V"
 fi
-qsmxt bgremove harperella "$IN/phase.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/localfield.nii.gz" $SET
+qsmxt bgremove harperella "$IN/phase.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/localfield.nii.gz" \
+  --te "$TE" --field-strength "$B0" $SET

--- a/algorithms/iharperella/algorithm.yml
+++ b/algorithms/iharperella/algorithm.yml
@@ -8,7 +8,7 @@ citation: Li et al., NeuroImage 2014
 doi: 10.1016/j.neuroimage.2014.08.029
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
-image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0
+image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.7.0
 run: bash run.sh
 parameters:
   - name: radius

--- a/algorithms/iharperella/run.sh
+++ b/algorithms/iharperella/run.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 IN="${1:-/input}"; OUT="${2:-/output}"
 
+# iHARPERELLA operates on the first echo's phase; --te (that echo's TE) and --field-strength convert
+# its tissue-phase output from radians to ppm (qsmxt >= v9.7.0).
+B0=$(jq -r '.B0' "$IN/params.json")
+TE=$(jq -r '.TE[0]' "$IN/params.json")
+
 # Parameter overrides (qsm-ci run --set NAME=VALUE) arrive as /input/config.json.
 SET=""
 CFG="$IN/config.json"
@@ -11,4 +16,5 @@ if [ -f "$CFG" ]; then
   V=$(jq -r '.max_iter // empty' "$CFG"); [ -n "$V" ] && SET="$SET --max-iter $V"
   V=$(jq -r '.tol // empty' "$CFG"); [ -n "$V" ] && SET="$SET --tol $V"
 fi
-qsmxt bgremove iharperella "$IN/phase.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/localfield.nii.gz" $SET
+qsmxt bgremove iharperella "$IN/phase.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/localfield.nii.gz" \
+  --te "$TE" --field-strength "$B0" $SET


### PR DESCRIPTION
HARPERELLA and iHARPERELLA output their tissue-phase local field in **radians**, so on the leaderboard their composed results (dipole fed a radian-scaled field) were wrong. `qsmxt v9.7.0` converts the output to **ppm** when given the echo's TE and B0 — but the QSM-CI `run.sh` never passed them.

**Fix:**
- Both `run.sh` now pass `--te $(TE[0]) --field-strength $(B0)` from `params.json`. HARPERELLA reads only the first echo (`qsm_core::bgremove::harperella` runs on a 3D grid), so `TE[0]` is the right echo time.
- Bumped both `algorithm.yml` images `qsmxt:v9.4.0 → v9.7.0`.

**Verified locally** on a qsm-forward phantom: the output scale equals `radians × 1e6/(2·π·γ·B0·TE)` **exactly** (0.1335 for B0=7, TE=0.004), landing in ppm (std 0.058) matching the ground-truth local field (std 0.047). Isolated-field correlation is unchanged (a scale fix; that's HARPERELLA's real single-echo accuracy) — the win is in composition.

**Needs:** a rescore of `harperella`/`iharperella` to refresh the leaderboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)