### PR TITLE
ci(score): serialize rescores with a concurrency group

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -23,6 +23,12 @@ on:
         description: "all | <comma-separated slugs> (default: auto-detect from the diff)"
         default: "auto"
 
+# One rescore at a time — a new run queues behind the in-progress one instead of racing it (both
+# commit results/index.json, so overlapping runs could clobber each other / fail to push).
+concurrency:
+  group: score
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
`score.yml` commits `results/index.json`, but had no concurrency guard — so two rescores triggered close together (e.g. merging two PRs that touch `algorithms/**`) run in parallel and race on that commit/push.

Add a `concurrency: { group: score, cancel-in-progress: false }` so a new rescore **queues** behind the in-progress one instead of racing or cancelling it. Small, self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)