### PR TITLE
ci: fix Pages registry.json copy + stop score.yml edits triggering a full rescore

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -43,7 +43,7 @@ jobs:
           cp -r results _site/results
           cp -r docs _site/docs           # the Submit page renders docs/submitting.md
           rm -rf _site/examples; cp -r examples _site/examples   # Run page showcases the engine examples
-          cp qsm_ci/registry.json _site/registry.json           # method DOIs shown on the leaderboard
+          rm -f _site/registry.json; cp qsm_ci/registry.json _site/registry.json  # method DOIs (drop the web/ symlink first)
 
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -16,7 +16,8 @@ on:
       - "scripts/pipeline.py"
       - "scripts/publish_volumes.py"
       - "stages.yml"
-      - ".github/workflows/score.yml"
+      # NB: score.yml itself is intentionally NOT here — editing the workflow (e.g. concurrency)
+      # shouldn't rescore the world. For a real scoring-logic change, dispatch with scope=all.
   workflow_dispatch:
     inputs:
       scope:
@@ -56,7 +57,7 @@ jobs:
           fi
           changed=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null \
                     || git diff --name-only HEAD~1 HEAD)
-          if echo "$changed" | grep -qE '^(eval/|scripts/pipeline\.py|scripts/publish_volumes\.py|stages\.yml|\.github/workflows/score\.yml)'; then
+          if echo "$changed" | grep -qE '^(eval/|scripts/pipeline\.py|scripts/publish_volumes\.py|stages\.yml)'; then
             echo "full=true"  >>"$GITHUB_OUTPUT"; echo "slugs=[]" >>"$GITHUB_OUTPUT"
           else
             slugs=$(echo "$changed" | grep '^algorithms/' | cut -d/ -f2 | grep -v '^_' | sort -u | jq -R . | jq -sc .)


### PR DESCRIPTION
Two small CI fixes surfaced right after #27 merged.

**1. Pages deploy fails** — `Error: cp: 'qsm_ci/registry.json' and '_site/registry.json' are the same file`. `cp -r web/*` copies the `web/registry.json` symlink (→ `../qsm_ci/registry.json`) into `_site/`, so the explicit `cp qsm_ci/registry.json _site/registry.json` sees source == symlink target. Fix: `rm -f _site/registry.json` first (same pattern already used for `examples/`).

**2. `score.yml` edits trigger a full rescore** — the scope logic listed `.github/workflows/score.yml` in its "orchestration changed → re-run everything" set, so merging a cosmetic workflow tweak (e.g. the concurrency guard in #29) kicked off a multi-hour full rescore. Drop `score.yml` from both the `paths` filter and the full-rescore regex — a real scoring-logic change can still be forced via `workflow_dispatch` scope=all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)