### PR TITLE
ci(evaluate): skip deleted submissions

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -34,8 +34,12 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "slugs=[\"${{ inputs.slug }}\"]" >> "$GITHUB_OUTPUT"
           else
+            # Candidate slugs from the diff, then keep only those that still exist — a submission
+            # that was *deleted* (or a non-submission file under algorithms/) has no algorithm.yml
+            # and can't be evaluated, so drop it instead of failing on it.
             git diff --name-only origin/${{ github.base_ref }}... \
               | grep '^algorithms/' | cut -d/ -f2 | grep -v '^_' | sort -u \
+              | while read -r slug; do [ -f "algorithms/$slug/algorithm.yml" ] && echo "$slug"; done \
               | jq -R . | jq -sc . | sed 's/^/slugs=/' >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
When a PR **deletes** a method, its slug still appears in `git diff` under `algorithms/`, so `evaluate` tried to score a folder that no longer exists and failed (seen on #31, which removed `algorithms/my-method`).

Filter the diff-derived slugs to those whose `algorithm.yml` is still present — so deletions (and any non-submission files under `algorithms/`) are dropped instead of failing the check. Verified: a diff of `tkd` (exists) + `my-method` (deleted) + a stray `README` → `["tkd"]`; empty → `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)