### PR TITLE
web: fix submission-page method cards + "Run this yourself" command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Scorer selfcheck + unit tests
         run: |
           python eval/qsm_eval.py --selfcheck
-          pytest -q eval/test_metrics.py
+          pytest -q eval/test_metrics.py tests/test_manifest.py
 
       - name: Scaffold check (qsm-ci new)
         run: |

--- a/scripts/gen_manifest.py
+++ b/scripts/gen_manifest.py
@@ -28,11 +28,13 @@ def entry(meta: dict) -> dict:
         "code_url": meta.get("code_url"),
         "license": meta.get("license"),
         "authors": author_names,
-        "parameters": meta.get("parameters") or [],
+        # `parameters:` is the canonical key; tolerate a stray `params:` so a mistyped
+        # submission still shows its parameter rows instead of silently dropping them.
+        "parameters": meta.get("parameters") or meta.get("params") or [],
     }
 
 
-def main() -> None:
+def build() -> dict:
     algos = []
     for d in sorted((ROOT / "algorithms").glob("*/")):
         mfile = d / "algorithm.yml"
@@ -41,9 +43,18 @@ def main() -> None:
         meta = yaml.safe_load(mfile.read_text())
         meta.setdefault("slug", d.name)
         algos.append(entry(meta))
+    return {"algorithms": algos}
+
+
+def render(manifest: dict) -> str:
+    return json.dumps(manifest, indent=2) + "\n"
+
+
+def main() -> None:
+    manifest = build()
     out = ROOT / "web" / "algorithms.json"
-    out.write_text(json.dumps({"algorithms": algos}, indent=2) + "\n")
-    print(f"wrote {out} ({len(algos)} algorithms)")
+    out.write_text(render(manifest))
+    print(f"wrote {out} ({len(manifest['algorithms'])} algorithms)")
 
 
 if __name__ == "__main__":

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,36 @@
+"""Drift guard: the committed web/algorithms.json must match algorithms/*/algorithm.yml.
+
+The site fetches web/algorithms.json to render each method's card (name, description,
+parameters, DOI) on the leaderboard + submission pages. It's a generated file
+(scripts/gen_manifest.py) that nothing regenerates automatically, so it silently goes
+stale when a submission is added or edited — a missing/incomplete method card is the
+symptom. This test fails the PR instead: run `python scripts/gen_manifest.py` to refresh.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location("gen_manifest", ROOT / "scripts" / "gen_manifest.py")
+gen_manifest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen_manifest)
+
+
+def test_algorithms_manifest_is_current():
+    committed = (ROOT / "web" / "algorithms.json").read_text()
+    expected = gen_manifest.render(gen_manifest.build())
+    assert committed == expected, (
+        "web/algorithms.json is stale — run `python scripts/gen_manifest.py` and commit."
+    )
+
+
+def test_every_submission_is_in_the_manifest():
+    import yaml
+
+    manifest = {a["slug"] for a in gen_manifest.build()["algorithms"]}
+    for d in sorted((ROOT / "algorithms").glob("*/")):
+        yml = d / "algorithm.yml"
+        if d.name.startswith("_") or not yml.exists():
+            continue
+        slug = (yaml.safe_load(yml.read_text()) or {}).get("slug") or d.name
+        assert slug in manifest, f"submission {d.name} (slug {slug}) missing from manifest"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -146,6 +146,131 @@
       ]
     },
     {
+      "slug": "matlab-medi",
+      "name": "MEDI (MATLAB)",
+      "stage": "bfr+dipole",
+      "engine": null,
+      "description": "Morphology Enabled Dipole Inversion (Cornell MEDI toolbox), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field, removes the background field with PDF, then solves the L1 morphology-regularized dipole inversion.",
+      "citation": null,
+      "doi": "10.1002/mrm.26946",
+      "code_url": null,
+      "license": "See Cornell MEDI toolbox license",
+      "authors": [
+        "QSM-CI"
+      ],
+      "parameters": [
+        {
+          "name": "lambda",
+          "default": 100,
+          "description": "data-fidelity weight (larger = closer data fit, less regularization)"
+        },
+        {
+          "name": "smv_radius",
+          "default": 5,
+          "description": "spherical-mean-value radius (mm) for extra background removal; 0 disables"
+        },
+        {
+          "name": "percentage",
+          "default": 0.9,
+          "description": "fraction of voxels kept as edges in the morphology gradient mask"
+        },
+        {
+          "name": "merit",
+          "default": 0,
+          "description": "model-error reduction (iterative reweighting); 1 enables"
+        }
+      ]
+    },
+    {
+      "slug": "matlab-sti-iharperella",
+      "name": "iHARPERELLA (STI Suite)",
+      "stage": "unwrap+bfr",
+      "engine": null,
+      "description": "Integrated phase unwrapping + background field removal (iHARPERELLA) from STI Suite v3, compiled from MATLAB and run on the license-free MATLAB Runtime. Operates on wrapped multi-echo phase and yields the local tissue field (echoes combined with optimal TE^2 weights).",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2014.08.029",
+      "code_url": null,
+      "license": "See STI Suite license",
+      "authors": [
+        "Wei Li and Chunlei Liu"
+      ],
+      "parameters": [
+        {
+          "name": "niter",
+          "default": 40,
+          "description": "iHARPERELLA iteration count"
+        },
+        {
+          "name": "padsize",
+          "default": 12,
+          "description": "zero-pad size (voxels, isotropic) for numerical accuracy"
+        }
+      ]
+    },
+    {
+      "slug": "matlab-sti-ilsqr",
+      "name": "iLSQR (STI Suite)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "Iterative LSQR dipole inversion from STI Suite v3 (the reference iLSQR implementation), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the local field and solves for susceptibility with streaking-artifact reduction.",
+      "citation": null,
+      "doi": "10.1002/nbm.3056",
+      "code_url": null,
+      "license": "See STI Suite license",
+      "authors": [
+        "Wei Li and Chunlei Liu"
+      ],
+      "parameters": [
+        {
+          "name": "padsize",
+          "default": 12,
+          "description": "zero-pad size (voxels, isotropic) to improve numerical accuracy of the inversion"
+        }
+      ]
+    },
+    {
+      "slug": "matlab-sti-star",
+      "name": "STAR-QSM (STI Suite)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "STAR-QSM (streaking artifact reduction) dipole inversion from STI Suite v3, compiled from MATLAB and run on the license-free MATLAB Runtime. Fast two-level susceptibility inversion of the local field.",
+      "citation": null,
+      "doi": "10.1002/nbm.3383",
+      "code_url": null,
+      "license": "See STI Suite license",
+      "authors": [
+        "Hongjiang Wei and Chunlei Liu"
+      ],
+      "parameters": [
+        {
+          "name": "padsize",
+          "default": 12,
+          "description": "zero-pad size (voxels, isotropic) to improve numerical accuracy of the inversion"
+        }
+      ]
+    },
+    {
+      "slug": "matlab-sti-vsharp",
+      "name": "V-SHARP (STI Suite)",
+      "stage": "bfr",
+      "engine": null,
+      "description": "V-SHARP background field removal from STI Suite v3 (spatially-varying SMV deconvolution), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field and removes the background field to yield the local tissue field.",
+      "citation": null,
+      "doi": "10.1002/nbm.3056",
+      "code_url": null,
+      "license": "See STI Suite license",
+      "authors": [
+        "Hongjiang Wei and Chunlei Liu"
+      ],
+      "parameters": [
+        {
+          "name": "smvsize",
+          "default": 12,
+          "description": "maximum spherical-mean-value kernel size (voxels) for the SMV deconvolution"
+        }
+      ]
+    },
+    {
       "slug": "matlab-tkd",
       "name": "TKD (MATLAB)",
       "stage": "dipole",
@@ -258,6 +383,21 @@
           "description": "Tikhonov regularization"
         }
       ]
+    },
+    {
+      "slug": "romeo-fieldmap",
+      "name": "ROMEO field mapping",
+      "stage": "field-mapping",
+      "engine": null,
+      "description": "Multi-echo B0 field mapping by ROMEO phase unwrapping (via the QSMxT/QSM.rs engine) with a per-voxel linear fit of unwrapped phase over echoes. Alternative to Laplacian field mapping.",
+      "citation": null,
+      "doi": "10.1002/mrm.28563",
+      "code_url": null,
+      "license": "MIT",
+      "authors": [
+        "Dymerska and Eckstein et al."
+      ],
+      "parameters": []
     },
     {
       "slug": "rts",


### PR DESCRIPTION
Two bugs kept composed-pipeline submission pages (e.g. `?run=gt~vsharp~matlab-sti-ilsqr-cmp`) from showing method info and a runnable command.

## 1. Stale `web/algorithms.json`

Method cards fetch `web/algorithms.json`, generated by `scripts/gen_manifest.py` — but nothing regenerated it, so it went stale (last built Jul 8). The 6 methods added since (`matlab-medi`, `matlab-sti-*`, `romeo-fieldmap`) had no entry, so a composed run rendered its background-removal card but a **blank dipole-inversion slot**.

- regenerate `web/algorithms.json` (now 26 methods)
- `gen_manifest`: tolerate a stray `params:` key (the newest MATLAB ymls use it; canonical is `parameters:`) so parameter rows aren't silently dropped — fixes the cards without editing those ymls (which would trigger a pointless composed rescore)
- add `tests/test_manifest.py` drift guard (committed manifest == generated) + wire into the `cli` CI job

## 2. "Run this yourself" section never showed

`renderHowToRun()` already builds the `qsm-ci run` command (single line for isolated methods, `bfr → dipole` chain for composed pipelines), but `#how-to-run` ships with Tailwind's `hidden` class and the code revealed it via `el.style.display = ""` — which never overrides the class. Toggle the class instead.

Together, a composed pipeline now shows its full command chain (and every stage line resolves thanks to the manifest fix).

No files under `algorithms/` change → `evaluate`/`score` don't fire, only `pages` + `ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)