### PR TITLE
web: show the "Run this yourself" command on submission pages

### DIFF
--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -50,8 +50,8 @@ function renderHowToRun() {
   } else if (bySlug[run.slug]) {
     lines.push(runLine(run.slug, run.stage, true));
   }
-  if (!lines.length) { el.style.display = "none"; return; }
-  el.style.display = "";
+  if (!lines.length) { el.classList.add("hidden"); return; }
+  el.classList.remove("hidden");  // the div ships with Tailwind `hidden`; clear the class, not just inline style
   const full = "pip install qsm-ci\n" + lines.join("\n");
   const chained = lines.length > 1;
   el.innerHTML = `


### PR DESCRIPTION
Follow-up to #33 (its manifest regen merged; this visibility fix landed on the branch *after* the squash-merge, so it never reached `main`).

`renderHowToRun()` already builds the `qsm-ci run` command for a run (a single line for isolated methods, a `bfr → dipole` chain for composed pipelines), but the `#how-to-run` section ships with Tailwind's `hidden` class and the code revealed it via `el.style.display = ""` — which clears only the inline style and never overrides the class. So the panel has been invisible on every submission page. Toggle the class instead.

With #33 already on `main`, a composed run like `?run=gt~vsharp~matlab-sti-ilsqr-cmp` now shows a **"Run this yourself"** card with the full `bfr → dipole` command chain and a Copy button.

web-only change → only `pages` + `ci` fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)