### PR TITLE
zenodo: deterministic method zips so unchanged methods skip (stop re-minting DOIs every release)

### DIFF
--- a/.github/scripts/publish-zenodo.py
+++ b/.github/scripts/publish-zenodo.py
@@ -99,13 +99,20 @@ def method_zip(slug, algo_dir):
     pinned = None
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
-        for f in files:
+        for f in sorted(files):
             arcname = os.path.relpath(f, os.path.dirname(algo_dir.rstrip("/")))  # <slug>/<file>
             text = open(f, "rb").read()
             if f.endswith("algorithm.yml"):
                 new, pinned = pin_image(text.decode())
                 text = new.encode()
-            z.writestr(arcname, text)
+            # Deterministic entry: a fixed timestamp + mode so an unchanged method yields a
+            # STABLE checksum across runs. Otherwise writestr(arcname, ...) stamps the current
+            # time into the zip, the checksum differs every run, the "skip if unchanged" guard
+            # never fires, and every publish re-mints a Zenodo version DOI for all 26 methods.
+            info = zipfile.ZipInfo(arcname, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            z.writestr(info, text)
     return buf.getvalue(), pinned
 
 


### PR DESCRIPTION
## Problem

Cutting the v0.1.0 release fired `publish-zenodo` (on release → production), and it reported `published=26 skipped=0` — it re-minted a **new version DOI for every method** despite no method content changing. The registry now shows methods at v2/v3 purely from republish churn.

Root cause: `method_zip` wrote each entry with `zipfile.writestr(arcname, data)`, which stamps the **current time** into the archive. The zip bytes — and therefore the SHA-256 the script uses to detect "unchanged since last publish" — differ on every run, so the skip guard never fires and every release/dispatch republishes all 26 methods.

```python
>>> # same content, two runs, 1s apart
>>> deterministic?  False   # before
>>> deterministic?  True    # after
```

## Fix

Build each entry from a `ZipInfo` with a fixed `date_time=(1980,1,1,0,0,0)` and mode, and sort entries — so the checksum depends only on file contents + the pinned image digest.

## Note

The **next** publish run will republish once more (the stored checksums came from the old non-deterministic zips), then checksums are stable and future releases correctly skip unchanged methods. Already-minted DOIs are permanent on Zenodo; this just stops the bleeding going forward.

Touches only `.github/scripts/` → no `algorithms/**`, so no `evaluate`/`score`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)