### PR TITLE
cli: make `qsm-ci list` work from a bare pip install

### DIFF
--- a/.github/scripts/publish-zenodo.py
+++ b/.github/scripts/publish-zenodo.py
@@ -224,6 +224,13 @@ def main():
         entry = mapping.get(slug, {"versions": {}})
         versions = entry.get("versions", {})
 
+        # Carry display metadata so the shipped registry is self-describing — `qsm-ci list` reads
+        # it (name/stage) when there's no local checkout. Set before the skip so unchanged methods
+        # get backfilled too; it doesn't affect the checksum, so it won't cause a republish.
+        entry["name"] = meta.get("name") or slug
+        entry["stage"] = meta.get("stage")
+        mapping[slug] = entry
+
         # Unchanged since the last publish → skip. Otherwise the version is publish-assigned: the
         # next integer, which we also set as Zenodo's version metadata (so they never drift).
         if versions and versions.get(entry.get("latest"), {}).get("checksum") == ck:

--- a/qsm_ci/registry.json
+++ b/qsm_ci/registry.json
@@ -3,6 +3,8 @@
     "concept_doi": "10.5281/zenodo.21386693",
     "concept_recid": "21386693",
     "latest": "3",
+    "name": "HARPERELLA",
+    "stage": "unwrap+bfr",
     "versions": {
       "1": {
         "checksum": "sha256:d684e2a41e484c1c22f043183288a04262f6aa2ee7019dd2d8365b3cbc2c7c0d",
@@ -31,6 +33,8 @@
     "concept_doi": "10.5281/zenodo.21386695",
     "concept_recid": "21386695",
     "latest": "3",
+    "name": "iHARPERELLA",
+    "stage": "unwrap+bfr",
     "versions": {
       "1": {
         "checksum": "sha256:9c18f3fe87299fe75caa78deb6fd13fe4f2ea404d58e541412f3386832e6cfb0",
@@ -59,6 +63,8 @@
     "concept_doi": "10.5281/zenodo.21386697",
     "concept_recid": "21386697",
     "latest": "3",
+    "name": "iLSQR",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:b88ac0d38f889a7e73560aaad51ac5a3a17235a0071ec96826e5191c96a883b7",
@@ -87,6 +93,8 @@
     "concept_doi": "10.5281/zenodo.21386699",
     "concept_recid": "21386699",
     "latest": "3",
+    "name": "iSMV",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:b8243d0c5b7d97cb6598291a05026d2e42c596ab92e153cc91942fd46727fb03",
@@ -115,6 +123,8 @@
     "concept_doi": "10.5281/zenodo.21386702",
     "concept_recid": "21386702",
     "latest": "3",
+    "name": "Laplacian field mapping",
+    "stage": "field-mapping",
     "versions": {
       "1": {
         "checksum": "sha256:91f3e205df3e1163e86104e228e1015f4d728ee3b0301ba1ab83fc6b6ffe4422",
@@ -143,6 +153,8 @@
     "concept_doi": "10.5281/zenodo.21386704",
     "concept_recid": "21386704",
     "latest": "3",
+    "name": "LBV",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:a7eda563b2b8b13a9c13d4d2ee2d06890fd94e55dff476f935759c45b5e0f196",
@@ -171,6 +183,8 @@
     "concept_doi": "10.5281/zenodo.21386902",
     "concept_recid": "21386902",
     "latest": "2",
+    "name": "MEDI (MATLAB)",
+    "stage": "bfr+dipole",
     "versions": {
       "1": {
         "checksum": "sha256:5358837eaa7d4f281c75a91ae853cd198115d009825352ca7fd3b477e5103727",
@@ -192,6 +206,8 @@
     "concept_doi": "10.5281/zenodo.21386906",
     "concept_recid": "21386906",
     "latest": "2",
+    "name": "iHARPERELLA (STI Suite)",
+    "stage": "unwrap+bfr",
     "versions": {
       "1": {
         "checksum": "sha256:195bbb04962a032f33c77226a91d97dcf807edcd725d723cff2b1efe4f34790b",
@@ -213,6 +229,8 @@
     "concept_doi": "10.5281/zenodo.21386908",
     "concept_recid": "21386908",
     "latest": "2",
+    "name": "iLSQR (STI Suite)",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:b194b8b870d0508418014786230e43a24f31c1da2ce47cd55f2b9e8c143b9e51",
@@ -234,6 +252,8 @@
     "concept_doi": "10.5281/zenodo.21386910",
     "concept_recid": "21386910",
     "latest": "2",
+    "name": "STAR-QSM (STI Suite)",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:ffc1ad295e95c87a0df634fadc6c7759210818bd6252125d89f20f6b74401359",
@@ -255,6 +275,8 @@
     "concept_doi": "10.5281/zenodo.21386912",
     "concept_recid": "21386912",
     "latest": "2",
+    "name": "V-SHARP (STI Suite)",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:b57b4b0f1636b5730e1bba89747a355c21967f113d0c88f258280b7e7a2b22ff",
@@ -276,6 +298,8 @@
     "concept_doi": "10.5281/zenodo.21386716",
     "concept_recid": "21386716",
     "latest": "3",
+    "name": "TKD (MATLAB)",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:3e3f83a7a7e6ab9ea9a1dcadd454319e3902e9e84a63ee498c5c4a2085e87fda",
@@ -304,6 +328,8 @@
     "concept_doi": "10.5281/zenodo.21386720",
     "concept_recid": "21386720",
     "latest": "3",
+    "name": "MEDI",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:076ec076fb91759ddc60e2d2275181430ce2e35712f9f21593fcd45c6f9d5822",
@@ -332,6 +358,8 @@
     "concept_doi": "10.5281/zenodo.21386725",
     "concept_recid": "21386725",
     "latest": "3",
+    "name": "NLTV",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:6a164851e5296795fbfe596a0078e5e6901c12b3882e38a38f0e696a1fb93cab",
@@ -360,6 +388,8 @@
     "concept_doi": "10.5281/zenodo.21386727",
     "concept_recid": "21386727",
     "latest": "3",
+    "name": "PDF",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:5077f70ece8005b2eb3598b4678bad50d467fe3b34ce1beb172067a892dbc76a",
@@ -388,6 +418,8 @@
     "concept_doi": "10.5281/zenodo.21386729",
     "concept_recid": "21386729",
     "latest": "3",
+    "name": "QSMART",
+    "stage": "bfr+dipole",
     "versions": {
       "1": {
         "checksum": "sha256:284e49237f953910aeefa14778b6e3533f046e70027e684f7cebedf7442f9d8f",
@@ -416,6 +448,8 @@
     "concept_doi": "10.5281/zenodo.21386731",
     "concept_recid": "21386731",
     "latest": "3",
+    "name": "RESHARP",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:1604e0ce3b54ad1e228ff0433b2c1ecbacc012a8a2f0e334acd10c7b50f1dfe8",
@@ -444,6 +478,8 @@
     "concept_doi": "10.5281/zenodo.21386733",
     "concept_recid": "21386733",
     "latest": "3",
+    "name": "ROMEO field mapping",
+    "stage": "field-mapping",
     "versions": {
       "1": {
         "checksum": "sha256:fc556e229d91b063b9886266448188ae335e74fd85c651d8343a19e721a3d60c",
@@ -472,6 +508,8 @@
     "concept_doi": "10.5281/zenodo.21386735",
     "concept_recid": "21386735",
     "latest": "3",
+    "name": "RTS",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:4253eacb3fb5d2750e5907bd247b0c4b9aacc41b2c1b96cbedee40817a6e86aa",
@@ -500,6 +538,8 @@
     "concept_doi": "10.5281/zenodo.21386737",
     "concept_recid": "21386737",
     "latest": "3",
+    "name": "SHARP",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:f9a6e1e5e1d36b5a523bd6b0affde5222d0c7dc8207bfd1e164c67e804106132",
@@ -528,6 +568,8 @@
     "concept_doi": "10.5281/zenodo.21386739",
     "concept_recid": "21386739",
     "latest": "3",
+    "name": "TGV",
+    "stage": "bfr+dipole",
     "versions": {
       "1": {
         "checksum": "sha256:1ff909f3bc712e8f3a9ff2575b5e55d2cc0b7a9895f5cb7a016b61038fa9c1f0",
@@ -556,6 +598,8 @@
     "concept_doi": "10.5281/zenodo.21386741",
     "concept_recid": "21386741",
     "latest": "3",
+    "name": "Tikhonov",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:a9f858bf9af9088e6473aa1296924ad55973006c3488249d6f96cb2891f2306b",
@@ -584,6 +628,8 @@
     "concept_doi": "10.5281/zenodo.21386743",
     "concept_recid": "21386743",
     "latest": "3",
+    "name": "TKD",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:9a303a77aa9fbdf98bdf39eba210625c5981372214402335527665b7a3e2a694",
@@ -612,6 +658,8 @@
     "concept_doi": "10.5281/zenodo.21386745",
     "concept_recid": "21386745",
     "latest": "3",
+    "name": "TSVD",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:fadc22b5c9f48b4f0209e7cc8d154410db8dfde5aa49188194384820450d0500",
@@ -640,6 +688,8 @@
     "concept_doi": "10.5281/zenodo.21386747",
     "concept_recid": "21386747",
     "latest": "3",
+    "name": "TV (ADMM)",
+    "stage": "dipole",
     "versions": {
       "1": {
         "checksum": "sha256:cc48928b0a60c0fd2923997a00e7d79f780336422e0629c32213990464b5f154",
@@ -668,6 +718,8 @@
     "concept_doi": "10.5281/zenodo.21386749",
     "concept_recid": "21386749",
     "latest": "3",
+    "name": "V-SHARP",
+    "stage": "bfr",
     "versions": {
       "1": {
         "checksum": "sha256:095fdf4e44569ef63ee4a690cb76e79adcc0f79179a16009f108f75e6e06f6c6",

--- a/qsm_ci/runner.py
+++ b/qsm_ci/runner.py
@@ -87,11 +87,26 @@ def _algorithms_root() -> "Path | None":
     return None
 
 
+def _registry_algorithms() -> "list[tuple[str, str, str]]":
+    """(slug, stage, name) from the shipped Zenodo registry — the published methods a bare
+    pip install can fetch and run, used when there's no local checkout."""
+    try:
+        from .registry import load_mapping
+        mapping = load_mapping()
+    except Exception:  # noqa: BLE001 — best-effort; an unreadable registry just yields nothing
+        return []
+    return [(slug, mapping[slug].get("stage") or "?", mapping[slug].get("name") or slug)
+            for slug in sorted(mapping)]
+
+
 def _list_algorithms() -> "list[tuple[str, str, str]]":
-    """(slug, stage, name) for every runnable submission under ./algorithms (skips _internal)."""
+    """(slug, stage, name) for every runnable submission under ./algorithms (skips _internal).
+
+    With no local checkout (a bare pip install), fall back to the shipped registry — those are
+    exactly the methods `qsm-ci run <slug>` can fetch from Zenodo."""
     root = _algorithms_root()
     if root is None:
-        return []
+        return _registry_algorithms()
     out = []
     for d in sorted(root.iterdir()):
         if d.name.startswith("_") or not (d / "algorithm.yml").exists():
@@ -111,13 +126,16 @@ def _algorithms_help() -> str:
     """A grouped listing of runnable slugs, or guidance if there's no algorithms/ here."""
     algos = _list_algorithms()
     if not algos:
-        return ("No algorithms/ directory found here. Run qsm-ci from a QSM-CI checkout\n"
+        return ("No algorithms found. Run qsm-ci from a QSM-CI checkout\n"
                 "(git clone https://github.com/QSMxT/QSM-CI), or pass a path to a submission folder.")
     width = max(len(slug) for slug, _, _ in algos)
     by_stage: dict[str, list[tuple[str, str]]] = {}
     for slug, stage, name in algos:
         by_stage.setdefault(stage, []).append((slug, name))
-    lines = ["Available algorithms — run  qsm-ci run <slug>  to see the inputs each needs:", ""]
+    header = ("Published methods (fetched from Zenodo on first run) — run  qsm-ci run <slug>  to see the inputs each needs:"
+              if _algorithms_root() is None else
+              "Available algorithms — run  qsm-ci run <slug>  to see the inputs each needs:")
+    lines = [header, ""]
     for stage in sorted(by_stage):
         lines.append(f"  {stage}:")
         for slug, name in by_stage[stage]:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -62,3 +62,17 @@ def test_describe_for_citation():
 def test_resolve_unknown_returns_none():
     # a slug not in the registry (and no network hit) resolves to None
     assert registry.resolve("definitely-not-a-method") is None
+
+
+def test_list_falls_back_to_registry_without_checkout(monkeypatch):
+    # A bare pip install (no ./algorithms) lists the published methods from the shipped registry.
+    from qsm_ci import runner
+    monkeypatch.setattr(registry, "_mapping_cache", {
+        "tkd": {"latest": "2", "stage": "dipole", "name": "TKD", "versions": {}},
+        "sharp": {"latest": "1", "stage": "bfr", "name": "SHARP", "versions": {}},
+    })
+    monkeypatch.setattr(runner, "_algorithms_root", lambda: None)
+    assert set(runner._list_algorithms()) == {("sharp", "bfr", "SHARP"), ("tkd", "dipole", "TKD")}
+    help_text = runner._algorithms_help()
+    assert "Published methods (fetched from Zenodo" in help_text
+    assert "tkd" in help_text and "SHARP" in help_text


### PR DESCRIPTION
## Problem

After `pip install qsm-ci` (no checkout), `qsm-ci list` errors:

```
No algorithms/ directory found here. Run qsm-ci from a QSM-CI checkout …
```

But that's inconsistent with `run`: the wheel ships `registry.json`, and `qsm-ci run <slug>` already resolves+fetches any published method from Zenodo. `list` just never consulted that registry — it only scanned a local `./algorithms`.

## Fix

- `_list_algorithms` falls back to the shipped registry when there's no checkout — semantically correct, since the registry *is* the set of methods a pip install can fetch and run.
- Registry entries now carry `name` + `stage` so the offline listing groups by stage with readable names (enriched at publish time in `publish-zenodo.py`; the current `registry.json` is backfilled here so it works without waiting for a republish).
- A checkout still lists local `algorithms/` submissions exactly as before.

```
Published methods (fetched from Zenodo on first run) — run  qsm-ci run <slug>  …

  bfr:
    sharp                    SHARP
    vsharp                   V-SHARP
  dipole:
    tkd                      TKD
    …
```

Touches only `qsm_ci/`, `.github/scripts/`, tests → `ci` runs; no `evaluate`/`score`.

Needs a **0.1.1 release** to reach PyPI users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)