### PR TITLE
cli: clearer `run` help — surface -o, stop implying TE/B0 for ppm stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Scorer selfcheck + unit tests
         run: |
           python eval/qsm_eval.py --selfcheck
-          pytest -q eval/test_metrics.py tests/test_manifest.py
+          pytest -q eval/test_metrics.py tests/test_manifest.py tests/test_runner_help.py
 
       - name: Scaffold check (qsm-ci new)
         run: |

--- a/qsm_ci/runner.py
+++ b/qsm_ci/runner.py
@@ -229,6 +229,16 @@ def _params_dict(args, stage: str) -> dict:
             "B0_dir": [float(x) for x in b0_dir], "voxel_size": [float(v) for v in voxel]}
 
 
+def _params_summary(params: dict, stage: str) -> str:
+    """One-line echo of the params actually used by a stage. Field-mapping consumes TE + B0;
+    BFR/dipole work in ppm and use only B0 direction + voxel size, so don't imply otherwise."""
+    if "phase" in STAGES[stage]["consumes"]:
+        return (f"TE={params['TE']} B0={params['B0']} "
+                f"B0_dir={params['B0_dir']} voxel_size={params['voxel_size']}")
+    return (f"B0_dir={params['B0_dir']} voxel_size={params['voxel_size']}  "
+            f"(TE / field strength not used by this stage)")
+
+
 def _looks_like_sidecar(obj: dict) -> bool:
     """A BIDS MEGRE sidecar carries these keys; a QSM-CI params.json does not."""
     return isinstance(obj, dict) and ("EchoTime" in obj or "MagneticFieldStrength" in obj)
@@ -291,18 +301,29 @@ def _inputs_summary(slug: str, algo: dict) -> str:
             continue
         opt = "  [optional]" if art in OPTIONAL_ARTIFACTS else ""
         lines.append(f"  --{art} PATH".ljust(22) + f"{ARTIFACT_FILE[art]} (NIfTI){opt}")
-    lines += ["", "Acquisition parameters — give a params.json OR the flags (either works):",
-              "  --params PATH".ljust(22) + "params.json"]
-    tag = "   [required here]"
-    lines.append("  --te SEC [SEC ...]".ljust(22) + "echo times, seconds" + (tag if needs_echo else ""))
-    lines.append("  --field-strength T".ljust(22) + "B0 in tesla" + (tag if needs_echo else ""))
-    lines.append("  --b0-dir X Y Z".ljust(22) + "unit B0 direction (default: 0 0 1)")
-    lines.append("  --voxel-size X Y Z".ljust(22) + "mm (default: from the input header)")
+    if needs_echo:
+        lines += ["", "Acquisition parameters — give a params.json OR the flags (either works):",
+                  "  --params PATH".ljust(22) + "params.json (or a BIDS phase sidecar)",
+                  "  --te SEC [SEC ...]".ljust(22) + "echo times, seconds   [required here]",
+                  "  --field-strength T".ljust(22) + "B0 in tesla   [required here]",
+                  "  --b0-dir X Y Z".ljust(22) + "unit B0 direction (default: 0 0 1)",
+                  "  --voxel-size X Y Z".ljust(22) + "mm (default: from the input header)"]
+    else:
+        # BFR/dipole take a field already in ppm — echo times and field strength don't enter the
+        # maths (the dipole kernel depends only on B0 direction + voxel size), so all of these are
+        # optional with sane defaults; a bare run works.
+        lines += ["", "Acquisition parameters (optional — a ppm field; echo times / field strength aren't used):",
+                  "  --b0-dir X Y Z".ljust(22) + "unit B0 direction (default: 0 0 1)",
+                  "  --voxel-size X Y Z".ljust(22) + "mm (default: from the input header)",
+                  "  --params PATH".ljust(22) + "params.json or a BIDS sidecar (optional)"]
     req_imgs = [a for a in consumes if a not in OPTIONAL_ARTIFACTS and a != "params"]
     example = " ".join(f"--{a} {a}.nii.gz" for a in req_imgs)
     if needs_echo:
         example += " --te 0.004 0.012 0.02 0.028 --field-strength 7"
-    lines += ["",
+    lines += ["", "Output:",
+              "  -o PATH".ljust(22) + f"where to write {produced}.nii.gz "
+              f"(default: ./{produced}.nii.gz; a directory is fine)",
+              "",
               f"Example:  qsm-ci run {slug} {example}",
               f"Add  --truth {produced}.nii.gz  [--seg dseg.nii.gz]  to score the output.",
               f"See   qsm-ci run {slug} --help  for runner/scoring options and method parameters."]
@@ -638,15 +659,13 @@ def run_command(argv, log=print) -> int:
                     if _looks_like_sidecar(obj):
                         params = _sidecar_to_params(src, obj, args, stage)
                         dest.write_text(json.dumps(params, indent=2) + "\n")
-                        log(f"  params (from BIDS sidecar): TE={params['TE']} B0={params['B0']} "
-                            f"B0_dir={params['B0_dir']} voxel_size={params['voxel_size']}")
+                        log("  params (from BIDS sidecar): " + _params_summary(params, stage))
                     else:
                         shutil.copy(src, dest)  # already a params.json — use verbatim
                 else:
                     params = _params_dict(args, stage)
                     dest.write_text(json.dumps(params, indent=2) + "\n")
-                    log(f"  params: TE={params['TE']} B0={params['B0']} "
-                        f"B0_dir={params['B0_dir']} voxel_size={params['voxel_size']}")
+                    log("  params: " + _params_summary(params, stage))
                 continue
             value = getattr(args, art, None)
             if not value:

--- a/tests/test_runner_help.py
+++ b/tests/test_runner_help.py
@@ -1,0 +1,36 @@
+"""The `qsm-ci run <slug>` inputs help + params echo: correct per-stage guidance.
+
+A ppm stage (BFR/dipole) must NOT ask for echo times / field strength (they don't enter the
+maths), must advertise the -o output flag, and its params echo must not imply TE/B0 were used.
+Field-mapping still requires echo times + field strength.
+"""
+import types
+
+from qsm_ci.runner import _inputs_summary, _params_summary
+
+
+def _algo(stage, name="X"):
+    return {"stage": stage, "name": name}
+
+
+def test_dipole_help_is_ppm_aware_and_shows_output():
+    h = _inputs_summary("ilsqr", _algo("dipole", "iLSQR"))
+    assert "echo times / field strength aren't used" in h
+    assert "--te" not in h and "--field-strength" not in h  # not offered for a ppm stage
+    assert "-o PATH" in h and "chimap.nii.gz" in h          # output flag is discoverable
+    assert "--localfield localfield.nii.gz --mask mask.nii.gz" in h  # bare run works
+
+
+def test_field_mapping_help_requires_echo_and_b0():
+    h = _inputs_summary("laplacian-fieldmap", _algo("field-mapping", "Laplacian"))
+    assert "--te" in h and "[required here]" in h
+    assert "--field-strength" in h
+    assert "-o PATH" in h  # output flag shown for every stage
+
+
+def test_params_summary_omits_unused_fields_for_ppm_stages():
+    p = {"TE": [], "B0": 3.0, "B0_dir": [0, 0, 1], "voxel_size": [1, 1, 1]}
+    assert "TE / field strength not used by this stage" in _params_summary(p, "dipole")
+    assert "TE=" not in _params_summary(p, "dipole")
+    # field-mapping does use them, so they appear
+    assert "TE=" in _params_summary(p, "field-mapping")


### PR DESCRIPTION
Running a dipole method (`qsm-ci run ilsqr …`) surfaced two papercuts. Both are messaging, not missing capability.

## 1. `-o`/`--out` was undiscoverable

The output flag exists (and even accepts a directory), but the friendly inputs help shown when you run without inputs never mentioned it — so the output location looked unspecifiable. Added an **Output:** line.

## 2. TE / field strength looked required for a ppm field

For `bfr`/`dipole` the input field is already in ppm — echo times and field strength don't enter the maths (the dipole kernel depends only on B0 direction + voxel size), and `_params_dict` already treats them as unused (a bare `run ilsqr --localfield … --mask …` works). But:
- the inputs help still listed `--te`/`--field-strength` under "give a params.json OR the flags", and
- the run summary printed `TE=… B0=…`,

so they read as required/consumed. Now, for ppm stages the help marks the acquisition section optional and drops TE/field-strength, and the echo shows only the fields actually used (`B0_dir`, `voxel_size`) with a "(TE / field strength not used by this stage)" note.

Field-mapping is unchanged — it still requires `--te` + `--field-strength`.

New `tests/test_runner_help.py` guards both; wired into the `cli` CI job. `qsm_ci/` + tests only.

### Before / after (dipole)
```
- Acquisition parameters — give a params.json OR the flags (either works):
-   --params PATH       params.json
-   --te SEC [SEC ...]  echo times, seconds
-   --field-strength T  B0 in tesla
-   --b0-dir X Y Z      unit B0 direction (default: 0 0 1)
-   --voxel-size X Y Z  mm (default: from the input header)
+ Acquisition parameters (optional — a ppm field; echo times / field strength aren't used):
+   --b0-dir X Y Z      unit B0 direction (default: 0 0 1)
+   --voxel-size X Y Z  mm (default: from the input header)
+   --params PATH       params.json or a BIDS sidecar (optional)
+
+ Output:
+   -o PATH             where to write chimap.nii.gz (default: ./chimap.nii.gz; a directory is fine)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)