### PR TITLE
web: fix Zenodo algorithm links + polish labels (submission doi, source code, Algorithm)

### DIFF
--- a/.github/scripts/publish-zenodo.py
+++ b/.github/scripts/publish-zenodo.py
@@ -142,7 +142,7 @@ def upload(base, token, dep, blob, filename):
 
 def metadata(meta, slug, version, site_base):
     authors = [a.get("name") for a in (meta.get("authors") or []) if a.get("name")] or ["QSM-CI"]
-    page = f"{site_base}/leaderboard.html?method={slug}"
+    page = f"{site_base}/submission.html?method={slug}"
     desc = (f"{meta.get('description') or ''}<br><br>"
             f"QSM-CI reconstruction method <code>{slug}</code>. "
             f'Browse and run it at <a href="{page}">{page}</a>.')

--- a/web/index.html
+++ b/web/index.html
@@ -92,7 +92,7 @@
     <section class="mx-auto max-w-6xl px-6 pt-6">
       <div class="rounded-2xl border border-gray-200 bg-white p-5 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
         <span class="font-semibold text-gray-900 dark:text-gray-100">Data.</span>
-        Methods are evaluated on the <strong>Realistic In Silico Head Phantom</strong> from the QSM
+        Algorithms are evaluated on the <strong>Realistic In Silico Head Phantom</strong> from the QSM
         Reconstruction Challenge 2.0 — Marques J.P., Meineke J., Milovic C., et al.,
         <em>Magnetic Resonance in Medicine</em> 2021;86(1):526–542
         (<a href="https://doi.org/10.1002/mrm.28716" class="text-emerald-600 hover:underline">doi:10.1002/mrm.28716</a>),

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -57,7 +57,7 @@ function renderHowToRun() {
   el.innerHTML = `
     <div class="flex items-baseline justify-between gap-3">
       <h2 class="font-semibold text-gray-900 dark:text-gray-100">Run this yourself</h2>
-      <a href="running.html" class="text-xs text-emerald-600 hover:underline">Guide to running methods →</a>
+      <a href="running.html" class="text-xs text-emerald-600 hover:underline">Guide to running algorithms →</a>
     </div>
     <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
       Reproduce it with the <a href="running.html" class="text-emerald-600 hover:underline"><code>qsm-ci</code></a> CLI —
@@ -157,9 +157,9 @@ function methodCard(a) {
   if (!a) return "";
   const links = [];
   const zdoi = doiFor(registry, a.slug);
-  if (zdoi) links.push(`<a href="${zdoi.url}" class="text-emerald-600 hover:underline" title="Cite this QSM-CI submission (Zenodo v${zdoi.version})">submission doi (v${zdoi.version})</a>`);
+  if (zdoi) links.push(`<a href="${zdoi.url}" class="text-emerald-600 hover:underline" title="Cite this QSM-CI submission (Zenodo v${zdoi.version})">submission doi</a>`);
   if (a.doi) links.push(`<a href="https://doi.org/${a.doi}" class="text-indigo-600 hover:underline">paper doi</a>`);
-  if (a.code_url) links.push(`<a href="${a.code_url}" class="text-indigo-600 hover:underline">source</a>`);
+  if (a.code_url) links.push(`<a href="${a.code_url}" class="text-indigo-600 hover:underline">source code</a>`);
   const params = (a.parameters || []).map((p) =>
     `<tr class="border-t border-gray-100 dark:border-gray-800"><td class="py-1 pr-3 font-mono text-gray-700 dark:text-gray-300">${p.name}</td><td class="py-1 pr-3 tabular-nums text-gray-500 dark:text-gray-400">${p.default}</td><td class="py-1 text-gray-400 dark:text-gray-500">${p.description || ""}</td></tr>`).join("");
   return `<div>
@@ -324,8 +324,13 @@ async function showLayer(layer) {
 // ---- boot -------------------------------------------------------------------
 async function init() {
   [allRuns, algos, registry] = await Promise.all([loadRuns(), loadAlgos(), loadRegistry()]);
-  const id = new URLSearchParams(location.search).get("run");
-  run = allRuns.find((r) => r.id === id) || allRuns.find((r) => r.status !== "DNF") || allRuns[0];
+  // Accept ?run=<run-id> (e.g. ismv-iso), or a bare slug via ?run= / ?method= (e.g. ?method=ismv,
+  // the form Zenodo records link to) → resolve to that algorithm's isolated run.
+  const q = new URLSearchParams(location.search);
+  const want = q.get("run") || q.get("method");
+  run = allRuns.find((r) => r.id === want)
+    || allRuns.find((r) => r.mode === "isolated" && r.slug === want)
+    || allRuns.find((r) => r.status !== "DNF") || allRuns[0];
   if (!run) { $("sub-title").textContent = "No runs"; return; }
   navMode = run.mode === "composed" ? "pipelines" : "stages";
   $("run-filter").addEventListener("input", (e) => { filter = e.target.value; buildSidebar(); });

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script>
+    // Older Zenodo records link here as leaderboard.html?method=<slug>; the per-algorithm page is
+    // submission.html. Redirect so those citation links land on the algorithm's page.
+    (function () {
+      var m = new URLSearchParams(location.search).get("method");
+      if (m) location.replace("submission.html?method=" + encodeURIComponent(m));
+    })();
+  </script>
   <title>QSM-CI — Leaderboard</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
@@ -123,7 +131,7 @@
         <table class="w-full text-sm whitespace-nowrap">
           <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
             <tr>
-              <th class="px-5 py-3 text-left font-medium sticky left-0 bg-gray-50" x-text="view==='composed' ? 'Pipeline' : 'Method'"></th>
+              <th class="px-5 py-3 text-left font-medium sticky left-0 bg-gray-50" x-text="view==='composed' ? 'Pipeline' : 'Algorithm'"></th>
               <template x-for="c in displayCols" :key="c">
                 <th @click="sort(c)" class="px-4 py-3 text-right font-medium cursor-pointer select-none hover:text-gray-800">
                   <span x-text="METRICS[c].label"></span>


### PR DESCRIPTION
Addresses several submission-page / leaderboard papercuts.

## Broken Zenodo "browse and run it" links
Zenodo records linked to `leaderboard.html?method=<slug>`, which nothing read — and `submission.html` only accepted an exact run id (`ismv-iso`), so `?run=ismv` fell back to a random run.

- `submission.html` now resolves `?method=<slug>` (and a bare slug via `?run=`) to that algorithm's isolated run.
- `leaderboard.html` redirects `?method=<slug>` → `submission.html` — so the links **already minted in Zenodo records** work now, with no republish.
- `publish-zenodo.py` points new records straight at `submission.html?method=<slug>`.

## Label polish
- method card: `submission doi (v2)` → `submission doi`; `source` → `source code`.
- User-facing "Method(s)" → "Algorithm(s)" (leaderboard column header, homepage copy, viewer "Guide to running algorithms" link).

web/** + one script; `pages` + `ci` only, no rescore.

> Note: this is a first pass on the Method→Algorithm rename (the prominent labels). Happy to sweep the remaining prose in `submit.html`/`running.html` if you want it fully consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)