### PR TITLE
fix(matlab-sti-iharperella): center-preserving odd-dim pad (fixes near-random score)

### DIFF
--- a/algorithms/matlab-sti-iharperella/recon.m
+++ b/algorithms/matlab-sti-iharperella/recon.m
@@ -32,14 +32,21 @@ function recon(inp, out)
     GYRO = 42.576e6;                                             % Hz/T
     % STI Suite's SMVFiltering (inside iHARPERELLA) indexes with size/2, which is fractional on
     % odd dims (e.g. 205) -> "Integer operands required for colon operator" and a corrupted filter.
-    % Pad odd dims to even before the call and crop back after (the pad is outside the mask).
-    sz0 = size(Mask); po = mod(sz0, 2);
+    % Pad odd dims to the next even size before the call and crop back after (the pad is outside
+    % the mask). The pad MUST preserve the array/FFT center: iHARPERELLA's SMV/dipole kernels place
+    % the frequency origin at floor(N/2)+1, so an even N moves that origin +1 voxel vs the odd N.
+    % A one-sided 'post' pad leaves the data content on the old indices -> its true center no longer
+    % coincides with the kernel origin (1-voxel misregistration on every SMV/dipole convolution) ->
+    % geometry corrupted, correlation ~random. Adding the extra voxel on the FRONT ('pre') shifts
+    % the content so its center maps to floor(Neven/2)+1 == the kernel origin; cropping the SAME
+    % 'pre' offset back out restores alignment. Robust for any combination of odd dims.
+    sz0 = size(Mask); po = mod(sz0, 2);          % +1 per axis that is odd, e.g. [1 0 1]
     num = zeros(size(Mask)); den = 0;
     for e = 1:ne
-        pe = padarray(phase(:,:,:,e), po, 0, 'post');
-        Mk = padarray(double(Mask), po, 0, 'post');
+        pe = padarray(phase(:,:,:,e), po, 0, 'pre');
+        Mk = padarray(double(Mask), po, 0, 'pre');
         tp = iHARPERELLA(pe, Mk, 'voxelsize', vox, 'padsize', padsize, 'niter', niter);  % rad, local
-        tp = tp(1:sz0(1), 1:sz0(2), 1:sz0(3));
+        tp = tp(po(1)+1 : po(1)+sz0(1), po(2)+1 : po(2)+sz0(2), po(3)+1 : po(3)+sz0(3));
         field_e = double(tp) / (2*pi * GYRO * B0 * TE(e)) * 1e6;                   % ppm
         w = TE(e)^2;                                          % optimal weight for field-from-phase
         num = num + w * field_e; den = den + w;


### PR DESCRIPTION
## Diagnosis

`matlab-sti-iharperella` (STI Suite iHARPERELLA, an `unwrap+bfr` stage: raw wrapped phase → localfield in ppm) scored **xsim 0.155 / correlation 0.099**, vs the known-good QSM.rs `iharperella` at **xsim 0.535 / correlation 0.673**. Every composed pipeline built on it was wrecked too.

It is **not** a units/scaling error. The ppm conversion in `recon.m` (`field_e = tp / (2*pi*GYRO*B0*TE(e)) * 1e6`, `GYRO=42.576e6`) is bit-identical to the known-good engine formula. Decisively, the scorer's `correlation` (`eval/qsm_eval.py`) is **scale- and sign-invariant** (Pearson within the mask), yet it collapses to ~0.10 — so the spatial field **pattern** is wrong, not its magnitude.

**Root cause — odd-dimension padding shifts the FFT center.** iHARPERELLA is an FFT-domain integrated unwrap + SMV/dipole deconvolution whose k-space kernels place the frequency origin at `floor(N/2)+1`. To dodge a crash in STI Suite's `SMVFiltering` on odd dims (it indexes with `size/2`), `recon.m` padded odd axes with a **one-sided `'post'`** zero-pad, then cropped `[1:N]` back:

```matlab
sz0 = size(Mask); po = mod(sz0, 2);           % e.g. [1 0 1]
pe  = padarray(phase(:,:,:,e), po, 0, 'post');
Mk  = padarray(double(Mask),   po, 0, 'post');
tp  = iHARPERELLA(pe, Mk, ...);
tp  = tp(1:sz0(1), 1:sz0(2), 1:sz0(3));
```

Padding to an even size moves the kernel origin from `floor(N/2)+1` to `floor(Neven/2)+1` (+1 voxel), but the one-sided `'post'` pad leaves the data content on its **old** indices. So the content center no longer coincides with the kernel origin — a **1-voxel misregistration** applied on every SMV/dipole convolution across the volume → geometry corrupted → correlation ≈ random.

Contrast the padding-free sibling `matlab-sti-vsharp/recon.m`, which passes the odd-dim array straight to `V_SHARP` and scores fine.

## The fix

Add the extra voxel on the **FRONT** (`'pre'`) so the content center maps to `floor(Neven/2)+1` == the kernel origin, and crop the **same** `'pre'` offset back out. Robust for any combination of odd dims.

```diff
-    sz0 = size(Mask); po = mod(sz0, 2);
+    sz0 = size(Mask); po = mod(sz0, 2);          % +1 per axis that is odd, e.g. [1 0 1]
     num = zeros(size(Mask)); den = 0;
     for e = 1:ne
-        pe = padarray(phase(:,:,:,e), po, 0, 'post');
-        Mk = padarray(double(Mask), po, 0, 'post');
+        pe = padarray(phase(:,:,:,e), po, 0, 'pre');
+        Mk = padarray(double(Mask), po, 0, 'pre');
         tp = iHARPERELLA(pe, Mk, 'voxelsize', vox, 'padsize', padsize, 'niter', niter);
-        tp = tp(1:sz0(1), 1:sz0(2), 1:sz0(3));
+        tp = tp(po(1)+1 : po(1)+sz0(1), po(2)+1 : po(2)+sz0(2), po(3)+1 : po(3)+sz0(3));
```

Center-mismatch check (kernel origin `floor(Npad/2)` vs cropped content center), 0-based:

| N | pad | Npad | kernel origin | content center | mismatch |
|---|----|------|---------------|----------------|----------|
| 51  | +1 | 52  | 26  | 26  | **0** |
| 205 | +1 | 206 | 103 | 103 | **0** |
| 50  | +0 | 50  | 25  | 25  | **0** |
| 100 | +0 | 100 | 50  | 50  | **0** |

(The old `'post'` pad gives mismatch **1** on every odd axis.) The multi-echo loop, ppm conversion, TE² weighting, and IO are unchanged.

## Mechanism verification (standalone numpy demo, not committed)

The compiled MATLAB method can't be run locally (recon.m is baked into the container; `iHARPERELLA` is an encrypted STI Suite `.p`). To verify the **mechanism**, a self-contained numpy demo reproduces an iHARPERELLA-class operation on an odd 51³ grid — iterated SMV background removal + regularized dipole inversion — with the kernel origin shifted by the misregistration each padding scheme induces, then correlates the cropped result against the correctly-registered reference and against ground-truth χ:

```
odd grid (51,51,51), +1 pad per axis
(a) one-sided 'post' pad  -> corr to iHARPERELLA-ref = 0.377 ,  corr to true chi = 0.441
(b) center-preserving pad -> corr to iHARPERELLA-ref = 1.000 ,  corr to true chi = 0.863
```

A minimal single-step dipole inversion isolates just the 1-voxel kernel offset:
```
(b) 0-voxel offset (center-preserving) -> corr to chi = 0.908
(a) 1-voxel offset (one-sided post pad) -> corr to chi = 0.618
```

The one-sided pad corrupts geometry (correlation collapses); the center-preserving pad preserves it. This confirms the fix targets the diagnosed cause.

## ⚠️ Required maintainer steps — this change does nothing until recompiled

`matlab-sti-iharperella` is a **compiled** MATLAB method: `recon.m` is compiled into the image `ghcr.io/astewartau/qsm-ci/matlab-sti-iharperella:v1` (`algorithm.yml` → `image:`). Both `evaluate.yml` (this PR) and `score.yml` (on merge) pull that **fixed `:v1` tag**, so:

- **Until the image is recompiled, the `evaluate` CI on this PR runs the OLD binary and will show NO score change.** Do not read the unchanged PR metrics as a regression of the fix.

To actually realize the improved score, a maintainer must:

1. **Recompile + push the image.** Run the `matlab-compile` workflow (`.github/workflows/matlab-compile.yml`) via **Actions → matlab-compile → Run workflow**, with input `slug = matlab-sti-iharperella`. It runs `mcc -m recon.m -o recon -d .` on a hosted runner (needs the `MATLAB_BATCH_TOKEN` secret), bakes `recon` into `FROM matlab-runtime:r2026a`, and pushes over the same `:v1` tag. (Equivalently, follow `algorithms/matlab-sti-iharperella/BUILD.md` locally — note it bundles `sti/`, `nifti/`, and `shims/`.) Best run **after** merge so `:v1` reflects the fixed source; if run from this branch, re-run after merge so the tag isn't later overwritten by an old-source rebuild.
2. **Re-score.** Merging to `main` with a change under `algorithms/**` triggers `score.yml`, which re-runs the isolated + composed matrix for the changed slug and commits `results/index.json`. Because the recompile pushes to `:v1` **without** touching `algorithms/**`, it does **not** auto-trigger scoring — after recompiling, dispatch `score.yml` manually (**Actions → score → Run workflow**, `scope = matlab-sti-iharperella`) to pull the new `:v1` and rescore this method plus every composed combo that includes it.

Expected after recompile + rescore: iHARPERELLA and its composed pipelines recover toward the QSM.rs `iharperella` baseline (~xsim 0.535 / corr 0.673) instead of the current ~0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)