### PR TITLE
algorithms: add iQSM (end-to-end) submission

### DIFF
--- a/algorithms/iqsm/Dockerfile
+++ b/algorithms/iqsm/Dockerfile
@@ -1,0 +1,40 @@
+# iQSM environment image — CPU-only, single-step QSM from raw phase.
+#
+# iQSM is a single-step deep network (LoT-Unet): raw wrapped MRI phase -> susceptibility chi,
+# doing phase unwrapping + background-field removal + dipole inversion in one pass. We clone the
+# upstream repo into /opt/iqsm, install the CPU-only torch wheel + the repo's Python deps, then
+# BAKE the pretrained weights into the image via `run.py --download-checkpoints` so the scoring run
+# works fully offline (--network none).
+#
+# The algorithm folder is mounted read-only at /algo at run time; run.sh invokes the baked
+# /opt/iqsm/run.py (iQSM resolves its checkpoints/ relative to its own source dir, so the source
+# and weights must live together inside the image, not in the mounted /algo).
+#
+# Build & push once (see algorithms/iqsm/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/iqsm:v1 algorithms/iqsm
+#   docker push ghcr.io/astewartau/qsm-ci/iqsm:v1
+FROM python:3.11-slim
+
+# jq is used by run.sh to read params.json; git to clone the iQSM source.
+RUN apt-get update && apt-get install -y --no-install-recommends git jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# iQSM source (CLI is run.py; pure-Python inference in inference.py — no MATLAB).
+# Pin to a specific commit for reproducibility.
+ARG IQSM_COMMIT=bb163ef
+RUN git clone https://github.com/sunhongfu/iQSM /opt/iqsm \
+    && git -C /opt/iqsm checkout "$IQSM_COMMIT"
+
+# CPU-only PyTorch wheel (no CUDA libs), then the repo's runtime deps (CLI only, no web stack).
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir -r /opt/iqsm/requirements.txt
+
+# Bake the four pretrained checkpoints (~16 MB each) into the image so the run phase needs no
+# network. `run.py --download-checkpoints` pulls them from HuggingFace sunhongfu/iQSM into
+# /opt/iqsm/checkpoints/, then exits.
+RUN cd /opt/iqsm && python run.py --download-checkpoints
+
+# Force CPU inference at run time (the code falls back to CPU when CUDA is unavailable; this makes
+# it explicit and belt-and-braces).
+ENV CUDA_VISIBLE_DEVICES="-1" \
+    IQSM_HOME="/opt/iqsm"

--- a/algorithms/iqsm/README.md
+++ b/algorithms/iqsm/README.md
@@ -1,0 +1,84 @@
+# iQSM
+
+Instant single-step quantitative susceptibility mapping from raw MRI phase using Laplacian-enabled
+deep neural networks (LoT-Unet).
+
+- **Stage:** `end-to-end` (phase → chimap, ppm)
+- **Engine:** [iQSM](https://github.com/sunhongfu/iQSM) — PyTorch, **CPU-only**
+- **Reference:** Gao Y., Xiong Z., Fazlollahi A., Nestor P.J., Vegh V., Nasrallah F., Winter C., Pike G.B., Crozier S., Liu F., Sun H. (2022). *Instant tissue field and magnetic susceptibility mapping from MRI raw phase using Laplacian enhanced deep neural networks.* NeuroImage, 259, 119410. (DOI: [10.1016/j.neuroimage.2022.119410](https://doi.org/10.1016/j.neuroimage.2022.119410))
+
+## Why `end-to-end`
+
+iQSM is a **single-step** deep network: a large-stencil Laplacian-preprocessed LoT-Unet maps the
+**raw wrapped phase** straight to susceptibility χ. Phase unwrapping, background-field removal, and
+dipole inversion all happen inside the network — there is no separate field-mapping / BFR / dipole
+stage. So the method consumes `phase`, `magnitude`, `mask`, `params` and produces `chimap`, i.e. the
+`end-to-end` span (see `stages.yml`). Evidence in the source: `inference.py::run_iqsm()` loads the
+wrapped phase NIfTI and feeds it (plus TE and B0) to the network, whose output is saved as
+`iQSM.nii.gz` — no field map is ever consumed.
+
+## Units
+
+- **Input** is **raw wrapped phase in radians**, which is exactly what iQSM ingests (it applies the
+  sign convention and Laplacian preprocessing internally). QSM-CI's `phase.nii.gz` is in radians, so
+  it is passed through unchanged. iQSM does **not** take a field map — do not convert to ppm.
+- **Output** χ is already in **ppm** (the network is trained to output ppm susceptibility). No
+  rescaling is applied; `run.sh` copies iQSM's `iQSM.nii.gz` verbatim to `chimap.nii.gz`.
+
+## Multi-echo handling
+
+iQSM runs the network **per echo** and combines the per-echo χ maps with **magnitude × TE²**
+weighting (falling back to TE²-only weighting when magnitude is absent). `run.sh` hands the 4D
+`phase.nii.gz` and 4D `magnitude.nii.gz` to the repo's own CLI (`run.py --echo_4d --mag --te …`),
+which performs exactly that combination — it is **not** re-implemented here. A 3D (single-echo)
+`phase.nii.gz` is handled by the same code path.
+
+## B0 direction
+
+Base iQSM assumes an **axial** acquisition (B0 ≈ `[0, 0, 1]`); the network takes no B0-direction
+argument, so `QSMCI_B0_DIR` is informational only and is not passed through. Only the field strength
+(`QSMCI_B0` / `params.json` `B0`) and the echo time(s) (`QSMCI_TE` / `params.json` `TE`) are fed to
+the network.
+
+## How QSM-CI runs it
+
+```bash
+python /opt/iqsm/run.py \
+  --echo_4d /input/phase.nii.gz \
+  --te <TE …> \
+  --mag /input/magnitude.nii.gz \
+  --mask /input/mask.nii.gz \
+  --b0 <B0> --no-iqfm \
+  --output /output/iqsm_run
+cp /output/iqsm_run/iQSM.nii.gz /output/chimap.nii.gz
+```
+
+`--no-iqfm` skips the optional tissue-field (iQFM) output — QSM-CI only scores `chimap.nii.gz`.
+
+The four pretrained checkpoints (~16 MB each) are **baked into the image** at build time
+(`run.py --download-checkpoints`, pulling from HuggingFace `sunhongfu/iQSM`) so the scoring run works
+fully offline (`--network none`). The iQSM source and its `checkpoints/` are baked together under
+`/opt/iqsm` because iQSM resolves the checkpoint directory relative to its own source location, not
+relative to the mounted `/algo`.
+
+## Parameters
+
+iQSM has no runtime tunables exposed here — it uses fixed pretrained weights. The acquisition-derived
+inputs are the field strength `B0` and echo time(s) `TE`, taken from `params.json` /
+`QSMCI_B0` / `QSMCI_TE`. Mask erosion (iQSM default 3 voxels) and phase-sign convention (iQSM default)
+are left at their upstream defaults.
+
+## Building the image
+
+The environment image is built from this folder's `Dockerfile` at score time (QSM-CI's
+`pipeline.build_env` builds any folder that has a `Dockerfile`), so a manual push is not required for
+the leaderboard. To build/push manually (e.g. for later Zenodo publishing):
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/iqsm:v1 algorithms/iqsm
+docker push  ghcr.io/astewartau/qsm-ci/iqsm:v1
+```
+
+_Citations/DOIs are auto-generated best-effort references and should be verified. The DOI here was
+verified against CrossRef (NeuroImage 259, 119410); note the upstream repo's README BibTeX lists a
+different DOI, which does not resolve to this paper._

--- a/algorithms/iqsm/algorithm.yml
+++ b/algorithms/iqsm/algorithm.yml
@@ -1,0 +1,27 @@
+name: iQSM
+slug: iqsm
+stage: end-to-end
+engine: iQSM (PyTorch)
+description: >
+  iQSM — instant single-step QSM from raw MRI phase using Laplacian-enabled deep neural networks
+  (LoT-Unet). A single deep network maps raw wrapped phase directly to susceptibility, performing
+  phase unwrapping, background-field removal, and dipole inversion in one pass. Multi-echo phase is
+  reconstructed per echo and combined with magnitude x TE^2 weighting. Runs CPU-only with a
+  CPU-only PyTorch wheel; pretrained weights (HuggingFace sunhongfu/iQSM) are baked into the image.
+authors:
+- name: Gao Y.
+- name: Xiong Z.
+- name: Fazlollahi A.
+- name: Nestor P.J.
+- name: Vegh V.
+- name: Nasrallah F.
+- name: Winter C.
+- name: Pike G.B.
+- name: Crozier S.
+- name: Liu F.
+- name: Sun H.
+doi: 10.1016/j.neuroimage.2022.119410
+code_url: https://github.com/sunhongfu/iQSM
+license: See repository (used with author permission)
+image: ghcr.io/astewartau/qsm-ci/iqsm:v1
+run: bash run.sh

--- a/algorithms/iqsm/run.sh
+++ b/algorithms/iqsm/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# QSM-CI submission — iQSM (end-to-end span), CPU-only.
+#
+# iQSM is a single-step deep network (LoT-Unet) that goes straight from raw wrapped MRI phase to
+# susceptibility chi — phase unwrapping, background-field removal, and dipole inversion all happen
+# inside the network. Hence stage = end-to-end:
+#   consumes  phase.nii.gz, magnitude.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units:
+#   * Input phase is RAW WRAPPED phase in radians — exactly what iQSM ingests (it multiplies by the
+#     sign convention and Laplacian-preprocesses internally). QSM-CI's phase.nii.gz is in radians,
+#     so it is passed through unchanged (no ppm conversion — iQSM does NOT take a field map).
+#   * Output chi is already in ppm (the network is trained to output ppm susceptibility). No
+#     rescaling is applied; iQSM.nii.gz is copied verbatim to chimap.nii.gz.
+#
+# Multi-echo: iQSM runs the net per echo and combines them with magnitude x TE^2 weighting. We hand
+# the 4D phase + 4D magnitude to run.py's own CLI (--echo_4d --mag), which reproduces exactly that
+# combination — we do not re-implement it. A 3D (single-echo) phase is handled by the same code path.
+#
+# B0 direction: base iQSM assumes an axial acquisition (B0 ~ [0,0,1]); the network takes no B0_dir
+# argument, so QSMCI_B0_DIR is informational only and is not passed through.
+#
+# Acquisition parameters are injected as env vars (see CONTRACT.md):
+#   $QSMCI_B0 (T)   $QSMCI_TE / $QSMCI_TE0 (s)   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm)
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+IQSM_HOME="${IQSM_HOME:-/opt/iqsm}"
+
+# Force CPU (belt-and-braces; also set in the image).
+export CUDA_VISIBLE_DEVICES="-1"
+
+mkdir -p "$OUT"
+
+# B0 field strength (T): prefer env var, fall back to params.json, default 3 T.
+if [ -n "${QSMCI_B0:-}" ]; then
+  B0="$QSMCI_B0"
+else
+  B0="$(jq -r '.B0 // 3' "$IN/params.json")"
+fi
+
+# Echo time(s) in SECONDS, one per phase echo. Prefer env var (space-separated), else params.json.
+if [ -n "${QSMCI_TE:-}" ]; then
+  read -r -a TE_S <<< "$QSMCI_TE"
+else
+  # shellcheck disable=SC2207
+  TE_S=($(jq -r '.TE | if type=="array" then .[] else . end' "$IN/params.json"))
+fi
+if [ "${#TE_S[@]}" -eq 0 ]; then
+  echo "iQSM: no TE found in params.json / QSMCI_TE" >&2
+  exit 1
+fi
+
+# Optional magnitude (used for magnitude x TE^2 multi-echo combination).
+MAG_ARG=()
+if [ -f "$IN/magnitude.nii.gz" ]; then
+  MAG_ARG=(--mag "$IN/magnitude.nii.gz")
+fi
+
+# run.py's --echo_4d path splits a 4D phase into per-echo volumes and combines them; a 3D phase is
+# treated as single-echo by the same flag. --te is in seconds. We only need chi, so skip iQFM.
+python "$IQSM_HOME/run.py" \
+  --echo_4d "$IN/phase.nii.gz" \
+  --te "${TE_S[@]}" \
+  "${MAG_ARG[@]}" \
+  --mask "$IN/mask.nii.gz" \
+  --b0 "$B0" \
+  --no-iqfm \
+  --output "$OUT/iqsm_run"
+
+# iQSM writes the susceptibility map as iQSM.nii.gz (in ppm). Publish it under the canonical name.
+cp "$OUT/iqsm_run/iQSM.nii.gz" "$OUT/chimap.nii.gz"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -83,6 +83,31 @@
       ]
     },
     {
+      "slug": "iqsm",
+      "name": "iQSM",
+      "stage": "end-to-end",
+      "engine": "iQSM (PyTorch)",
+      "description": "iQSM \u2014 instant single-step QSM from raw MRI phase using Laplacian-enabled deep neural networks (LoT-Unet). A single deep network maps raw wrapped phase directly to susceptibility, performing phase unwrapping, background-field removal, and dipole inversion in one pass. Multi-echo phase is reconstructed per echo and combined with magnitude x TE^2 weighting. Runs CPU-only with a CPU-only PyTorch wheel; pretrained weights (HuggingFace sunhongfu/iQSM) are baked into the image.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2022.119410",
+      "code_url": "https://github.com/sunhongfu/iQSM",
+      "license": "See repository (used with author permission)",
+      "authors": [
+        "Gao Y.",
+        "Xiong Z.",
+        "Fazlollahi A.",
+        "Nestor P.J.",
+        "Vegh V.",
+        "Nasrallah F.",
+        "Winter C.",
+        "Pike G.B.",
+        "Crozier S.",
+        "Liu F.",
+        "Sun H."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "ismv",
       "name": "iSMV",
       "stage": "bfr",


### PR DESCRIPTION
## What

Adds **iQSM** as a QSM-CI algorithm submission under `algorithms/iqsm/`, modelled on the merged `nextqsm/` submission (Dockerfile + run.sh + algorithm.yml + README) and following `CONTRACT.md` / `stages.yml`.

iQSM (upstream: https://github.com/sunhongfu/iQSM, pinned commit `bb163ef`) is a **single-step deep network** (Laplacian-enabled LoT-Unet) that maps **raw wrapped MRI phase → susceptibility χ**, doing phase unwrapping, background-field removal, and dipole inversion in one pass.

## Stage: `end-to-end` — evidence

- The network consumes the **raw wrapped phase** (plus TE + B0) and emits χ directly — no field map is ever consumed. See `inference.py::run_iqsm()`: it loads the phase NIfTI, feeds `(phase, mask, te, b0)` to the net, and saves the output as `iQSM.nii.gz`.
- `stages.yml` `end-to-end` span = `consumes: [phase, magnitude, mask, params] → produces: [chimap]`, which matches exactly. This is QSM-CI's first `end-to-end` submission.

## Units & multi-echo handling

- **Input**: passed through as **radians** (raw wrapped phase) — iQSM ingests phase, *not* a ppm field map, so no conversion is applied.
- **Output**: iQSM's `iQSM.nii.gz` is already **ppm** susceptibility; `run.sh` copies it verbatim to `chimap.nii.gz` (no rescaling).
- **Multi-echo**: `run.sh` hands the 4D phase + 4D magnitude to the repo's own CLI (`run.py --echo_4d --mag --te …`), which runs the net per echo and combines with **magnitude × TE²** weighting (TE²-only fallback when magnitude absent). Not re-implemented here. A 3D single-echo phase uses the same code path.
- **B0 direction**: base iQSM assumes axial B0 ≈ `[0,0,1]` and the net takes no B0-dir argument, so `QSMCI_B0_DIR` is informational only and not passed. Only `B0` (T) and `TE` (s) are fed to the net.

## Image

CPU-only. `Dockerfile` installs the CPU-only torch wheel, clones iQSM, and **bakes the four pretrained checkpoints** (~16 MB each, from HuggingFace `sunhongfu/iQSM`) at build time via `run.py --download-checkpoints`, so the scoring run works fully offline (`--network none`). Source + `checkpoints/` are baked together under `/opt/iqsm` because iQSM resolves its checkpoint dir relative to its own source location (the algo folder is mounted read-only at `/algo`).

Scoring builds this folder's `Dockerfile` at score-time (`pipeline.build_env` builds any folder with a Dockerfile), so **a manual `ghcr.io` push is not required for the leaderboard** — only for later Zenodo publishing.

## DOI note

`doi: 10.1016/j.neuroimage.2022.119410` — **verified against CrossRef** (NeuroImage vol 259, article 119410, 2022; full author list from CrossRef). Note the upstream repo's README BibTeX lists a *different* DOI that does not resolve to this paper.

## License

Upstream repo has **no LICENSE file**; set to `See repository (used with author permission)` per the maintainer arrangement.

## What a maintainer should verify

- [ ] **Local `docker build algorithms/iqsm`** succeeds (image build is untested here — no ghcr creds / heavy). In particular the CPU torch wheel install and the `run.py --download-checkpoints` HF fetch at build time.
- [ ] A smoke inference run produces a plausible `chimap.nii.gz` in ppm (single-echo and multi-echo).
- [ ] Confirm the DOI / license / author list are acceptable.

## Checks

- `python scripts/gen_manifest.py` regenerated `web/algorithms.json` (28 algorithms).
- `pytest -q tests/test_manifest.py` → 2 passed.

Draft because the container image build could not be exercised in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)