### PR TITLE
ci: rebase-before-push in score.yml + drop stale my-method result

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -120,4 +120,12 @@ jobs:
           git config user.email "qsm-ci@users.noreply.github.com"
           git add results/index.json
           git commit -m "Update results" || { echo "no changes"; exit 0; }
-          git push
+          # main can advance while this long scoring job runs (a PR merge, a registry commit),
+          # which would reject a plain push as non-fast-forward and LOSE the scores. Rebase the
+          # results commit onto latest main and retry. Only score writes results/index.json (and
+          # score runs are serialised by the concurrency group), so the rebase applies cleanly.
+          for attempt in 1 2 3 4 5; do
+            git pull --rebase origin main && git push && exit 0
+            echo "push attempt $attempt rejected — retrying"; sleep $((attempt * 5))
+          done
+          echo "::error::could not push results after 5 attempts"; exit 1

--- a/results/index.json
+++ b/results/index.json
@@ -11197,16 +11197,6 @@
       }
     },
     {
-      "name": "my-method",
-      "track": "sim",
-      "stage": "dipole",
-      "mode": "isolated",
-      "status": "DNF",
-      "metrics": {},
-      "id": "my-method-iso",
-      "slug": "my-method"
-    },
-    {
       "name": "iharperella",
       "track": "sim",
       "stage": "unwrap+bfr",


### PR DESCRIPTION
## Why
A matlab-sti-iharperella rescore ran, computed the new score, and then **lost it**: `score.yml`'s commit step does a plain `git push`, and because `main` advanced during the (long) run, the push was rejected non-fast-forward.

## Fix
Rebase the `Update results` commit onto latest `main` and retry (up to 5×) before giving up. Only `score` writes `results/index.json`, and score runs are serialised by the `concurrency: group: score`, so the rebase applies cleanly over concurrent commits to other files. This removes the "don't merge anything while a score runs" constraint.

Also drops the stale **`my-method-iso`** run from `results/index.json` — a deleted submission that lingered and showed up in the submission-page sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)