### PR TITLE
Add iQSM+ (orientation-adaptive, end-to-end) submission

### DIFF
--- a/algorithms/iqsm-plus/Dockerfile
+++ b/algorithms/iqsm-plus/Dockerfile
@@ -1,0 +1,40 @@
+# iQSM+ environment image — CPU-only single-step QSM inference (no GPU).
+#
+# iQSM+ (Gao et al., Medical Image Analysis 2024) is an orientation-adaptive deep network that maps
+# raw wrapped phase straight to susceptibility (unwrap + background removal + dipole inversion in one
+# pass). It is not published as a pip package, so we `git clone` the repo into the image, install its
+# CPU dependencies, and bake the pretrained weights in — the scoring run has no network
+# (`--network none`), so nothing can be fetched at run time.
+#
+# The submission's own code (run.sh) is mounted at /algo at run time; the cloned iQSM+ engine lives
+# at $IQSM_PLUS_HOME and run.sh drives it from there.
+#
+# Build & push once (see algorithms/iqsm-plus/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/iqsm-plus:v1 algorithms/iqsm-plus
+#   docker push ghcr.io/astewartau/qsm-ci/iqsm-plus:v1
+FROM python:3.11-slim
+
+# git to clone the engine; the Python deps below are pure wheels (no build toolchain needed).
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV IQSM_PLUS_HOME=/opt/iQSM_Plus
+
+# Clone the iQSM+ engine at a pinned commit for reproducibility.
+RUN git clone https://github.com/sunhongfu/iQSM_Plus.git "$IQSM_PLUS_HOME" \
+    && git -C "$IQSM_PLUS_HOME" checkout a534d94ab6a24b70d3041b3d0164c7a13fb0d2d0
+
+# CPU-only PyTorch wheel (the CUDA build would pull hundreds of MB of unused GPU libs). Inference is
+# forced onto CPU at run time via CUDA_VISIBLE_DEVICES=-1 below.
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+
+# iQSM+ core (CLI) dependencies — numpy / scipy / nibabel / h5py / pydicom / huggingface_hub / pyyaml.
+RUN pip install --no-cache-dir -r "$IQSM_PLUS_HOME/requirements.txt"
+
+# Bake the pretrained weights into the image (scoring runs offline; weights cannot download at
+# runtime). This fetches iQSM_plus.pth + LoTLayer_chi.pth from HuggingFace (sunhongfu/iQSM_Plus) into
+# $IQSM_PLUS_HOME/checkpoints/, then exits.
+RUN cd "$IQSM_PLUS_HOME" && python run.py --download-checkpoints
+
+# Force CPU at run time (belt-and-braces; also set by run.sh).
+ENV CUDA_VISIBLE_DEVICES="-1"

--- a/algorithms/iqsm-plus/README.md
+++ b/algorithms/iqsm-plus/README.md
@@ -1,0 +1,86 @@
+# iQSM+
+
+An orientation-adaptive, single-step deep-learning method that reconstructs susceptibility directly
+from the raw wrapped MRI phase.
+
+- **Stage:** `end-to-end` (phase → chimap, ppm)
+- **Engine:** [iQSM+](https://github.com/sunhongfu/iQSM_Plus) — PyTorch, **CPU-only** (no GPU)
+- **Reference:** Gao Y., Xiong Z., Shan S., Liu Y., Rong P., Li M., Wilman A.H., Pike G.B., Liu F., Sun H. (2024). *Plug-and-Play Latent Feature Editing for Orientation-Adaptive Quantitative Susceptibility Mapping Neural Networks.* Medical Image Analysis, 95, 103160. (DOI: [10.1016/j.media.2024.103160](https://doi.org/10.1016/j.media.2024.103160))
+
+## Why `end-to-end`
+
+iQSM+ is a **single-step** network: a single forward pass takes the raw wrapped phase and produces
+susceptibility, folding phase unwrapping, background-field removal and dipole inversion into one
+learned model (`inference.run_iqsm_plus` runs the LoT-Unet on the wrapped phase and returns χ). So it
+consumes **phase** (+ magnitude, mask, params) and produces **chimap** — the `end-to-end` span, not a
+single pipeline stage.
+
+## Orientation-adaptive
+
+iQSM+ extends iQSM with **orientation-adaptive latent feature editing (OA-LFE)** blocks that learn to
+encode the acquisition-orientation vector and inject it into the network's latent features. This lets
+non-axial acquisitions (oblique, sagittal, coronal) reconstruct correctly without any resampling. The
+B0 direction is therefore a genuine model input, not just a dipole-kernel parameter — `run.sh` passes
+it via `--b0-dir` from `$QSMCI_B0_DIR` (or `params.json` `B0_dir`), defaulting to axial `0 0 1`.
+
+## Units
+
+The QSM-CI `phase` artifact is the **raw wrapped phase in radians**, which is exactly what iQSM+
+expects — the network does its own unwrapping (`run_iqsm_plus`'s phase convention is
+`phase = -ΔB·γ·TE`, matching the default `phase_sign = -1`). **No conversion to ppm is applied on
+input.** The output χ is already in **ppm**, the QSM-CI `chimap` unit.
+
+## Multi-echo
+
+QSM-CI's `phase` is 4D (`x, y, z, echo`). It is handed to iQSM+ via `--echo_4d`, and the engine's own
+CLI runs inference once per echo and combines the per-echo χ with **magnitude × TE² weighted
+averaging** (the magnitude and echo times come from `magnitude.nii.gz` and `$QSMCI_TE`). Single-echo
+(3D) phase uses the same flag. The per-echo combination is intentionally left to the upstream CLI
+rather than re-implemented here.
+
+## How QSM-CI runs it
+
+```bash
+python /opt/iQSM_Plus/run.py \
+  --echo_4d /input/phase.nii.gz \
+  --te <TE_s …> \
+  --mag /input/magnitude.nii.gz \
+  --mask /input/mask.nii.gz \
+  --b0 <B0_T> \
+  --b0-dir <B0_dir> \
+  [--voxel-size <x y z>] \
+  --output /output
+mv /output/iQSM_plus.nii.gz /output/chimap.nii.gz
+```
+
+`--te` is in seconds (from `$QSMCI_TE`), `--b0` in Tesla (`$QSMCI_B0`), `--b0-dir` from
+`$QSMCI_B0_DIR`, and `--voxel-size` from `$QSMCI_VOXEL_SIZE` (iQSM+ otherwise reads the NIfTI header).
+The engine writes `iQSM_plus.nii.gz`; `run.sh` renames it to the canonical `chimap.nii.gz`.
+
+The pretrained weights (`iQSM_plus.pth`, `LoTLayer_chi.pth`) are **baked into the image** at build
+time (`python run.py --download-checkpoints`, from HuggingFace `sunhongfu/iQSM_Plus`) so the scoring
+run works fully offline (`--network none`).
+
+## Parameters
+
+iQSM+ has no runtime tunables exposed here — it uses fixed pretrained weights. The acquisition-derived
+inputs (B0 direction, B0 strength, echo times, voxel size) come from `params.json` /
+`QSMCI_*` env vars.
+
+## Building the image
+
+The environment image bundles the iQSM+ engine (`git clone` at a pinned commit) and its weights; it
+must be built before scoring works (the run phase has no network, so weights cannot be fetched at run
+time). QSM-CI builds this folder's `Dockerfile` at score time, so no manual push is required for the
+leaderboard — a push is only needed for later Zenodo publishing:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/iqsm-plus:v1 algorithms/iqsm-plus
+docker push  ghcr.io/astewartau/qsm-ci/iqsm-plus:v1
+```
+
+## License
+
+The upstream repository ships no license file; used here **with the authors' permission**.
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/iqsm-plus/algorithm.yml
+++ b/algorithms/iqsm-plus/algorithm.yml
@@ -1,0 +1,27 @@
+name: iQSM+
+slug: iqsm-plus
+stage: end-to-end
+description: >
+  iQSM+ — an orientation-adaptive, single-step deep-learning method that reconstructs susceptibility
+  directly from the raw wrapped MRI phase (unwrapping, background-field removal and dipole inversion
+  in one network pass). It extends iQSM with orientation-adaptive latent feature editing (OA-LFE)
+  blocks that consume the B0 direction vector, so oblique / sagittal / coronal acquisitions
+  reconstruct correctly, not just axial scans. Consumes phase, magnitude, mask and params and
+  produces the susceptibility map. Multi-echo phase is handled by the engine's own per-echo inference
+  with magnitude x TE^2 weighted combination. Runs CPU-only with a CPU PyTorch wheel (no GPU).
+authors:
+- name: Gao Y.
+- name: Xiong Z.
+- name: Shan S.
+- name: Liu Y.
+- name: Rong P.
+- name: Li M.
+- name: Wilman A.H.
+- name: Pike G.B.
+- name: Liu F.
+- name: Sun H.
+doi: 10.1016/j.media.2024.103160
+code_url: https://github.com/sunhongfu/iQSM_Plus
+license: Used with author permission (no license file in the upstream repository)
+image: ghcr.io/astewartau/qsm-ci/iqsm-plus:v1
+run: bash run.sh

--- a/algorithms/iqsm-plus/run.sh
+++ b/algorithms/iqsm-plus/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# QSM-CI submission — iQSM+ (end-to-end stage), CPU-only.
+#
+# iQSM+ is a single-step, orientation-adaptive deep network: it takes the RAW WRAPPED phase and
+# produces susceptibility directly (unwrap + background-field removal + dipole inversion in one
+# forward pass). Hence stage = end-to-end:
+#   consumes  phase.nii.gz, magnitude.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units: QSM-CI `phase` is the RAW WRAPPED phase in radians — exactly iQSM+'s expected input (the
+# network unwraps internally). No conversion to ppm is applied on input. The output χ is in ppm,
+# which is the QSM-CI chimap unit.
+#
+# Orientation: iQSM+ is orientation-adaptive — its OA-LFE blocks consume the B0 direction vector, so
+# oblique/sagittal/coronal acquisitions reconstruct correctly. We pass it via --b0-dir.
+#
+# Multi-echo: QSM-CI `phase` is 4D (x,y,z,echo). We hand iQSM+ the 4D phase via --echo_4d and let its
+# own CLI do the per-echo inference + magnitude×TE² weighted combination (rather than re-implementing
+# it here). Single-echo (3D) phase is handled by the same flag.
+#
+# Acquisition parameters are injected as env vars (see CONTRACT.md):
+#   $QSMCI_B0 (T)   $QSMCI_TE (s, space-separated)   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm)
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+# Force CPU-only torch (belt-and-braces; also set in the image).
+export CUDA_VISIBLE_DEVICES="-1"
+
+# The iQSM+ engine (cloned + weights baked at build time) lives here.
+IQSM_PLUS_HOME="${IQSM_PLUS_HOME:-/opt/iQSM_Plus}"
+
+# ── B0 direction (orientation-adaptive input) ───────────────────────────────
+# Prefer the env var; fall back to params.json; default axial [0 0 1].
+if [ -n "${QSMCI_B0_DIR:-}" ]; then
+  B0_DIR="$QSMCI_B0_DIR"
+elif command -v jq >/dev/null 2>&1 && [ -f "$IN/params.json" ]; then
+  B0_DIR="$(jq -r '.B0_dir | join(" ")' "$IN/params.json")"
+else
+  B0_DIR="0 0 1"
+fi
+# shellcheck disable=SC2086
+set -- $B0_DIR
+BDX="${1:-0}"; BDY="${2:-0}"; BDZ="${3:-1}"
+
+# ── Echo times (seconds) ────────────────────────────────────────────────────
+# QSM-CI provides TE(s) in seconds; iQSM+ --te takes seconds. Length must match the phase echo dim.
+if [ -n "${QSMCI_TE:-}" ]; then
+  TE_S="$QSMCI_TE"
+elif command -v jq >/dev/null 2>&1 && [ -f "$IN/params.json" ]; then
+  TE_S="$(jq -r '.TE | map(tostring) | join(" ")' "$IN/params.json")"
+else
+  echo "ERROR: no echo time(s) available (QSMCI_TE / params.json TE)" >&2
+  exit 1
+fi
+
+# ── B0 field strength (Tesla) ───────────────────────────────────────────────
+B0_T="${QSMCI_B0:-3.0}"
+
+# ── Voxel size (mm) — optional; iQSM+ reads the NIfTI header otherwise ───────
+VOXEL_ARG=()
+if [ -n "${QSMCI_VOXEL_SIZE:-}" ]; then
+  # shellcheck disable=SC2206
+  VOX=($QSMCI_VOXEL_SIZE)
+  if [ "${#VOX[@]}" -eq 3 ]; then
+    VOXEL_ARG=(--voxel-size "${VOX[0]}" "${VOX[1]}" "${VOX[2]}")
+  fi
+fi
+
+mkdir -p "$OUT"
+
+# ── Run iQSM+ ───────────────────────────────────────────────────────────────
+# --echo_4d takes the 4D (or 3D single-echo) wrapped phase; --te lists per-echo TEs in seconds.
+# The engine writes iQSM_plus.nii.gz (combined χ, ppm) into --output; we rename it to chimap.nii.gz.
+# shellcheck disable=SC2086
+python "$IQSM_PLUS_HOME/run.py" \
+  --echo_4d "$IN/phase.nii.gz" \
+  --te $TE_S \
+  --mag "$IN/magnitude.nii.gz" \
+  --mask "$IN/mask.nii.gz" \
+  --b0 "$B0_T" \
+  --b0-dir "$BDX" "$BDY" "$BDZ" \
+  "${VOXEL_ARG[@]}" \
+  --output "$OUT"
+
+# The engine's canonical output filename is iQSM_plus.nii.gz; QSM-CI scores chimap.nii.gz.
+mv -f "$OUT/iQSM_plus.nii.gz" "$OUT/chimap.nii.gz"
+
+# Per-echo iQSM_plus_e<i>.nii.gz and echo<i>_output/ folders may be left behind by the multi-echo
+# combiner — harmless; QSM-CI only reads the canonical chimap.nii.gz.

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -83,6 +83,30 @@
       ]
     },
     {
+      "slug": "iqsm-plus",
+      "name": "iQSM+",
+      "stage": "end-to-end",
+      "engine": null,
+      "description": "iQSM+ \u2014 an orientation-adaptive, single-step deep-learning method that reconstructs susceptibility directly from the raw wrapped MRI phase (unwrapping, background-field removal and dipole inversion in one network pass). It extends iQSM with orientation-adaptive latent feature editing (OA-LFE) blocks that consume the B0 direction vector, so oblique / sagittal / coronal acquisitions reconstruct correctly, not just axial scans. Consumes phase, magnitude, mask and params and produces the susceptibility map. Multi-echo phase is handled by the engine's own per-echo inference with magnitude x TE^2 weighted combination. Runs CPU-only with a CPU PyTorch wheel (no GPU).",
+      "citation": null,
+      "doi": "10.1016/j.media.2024.103160",
+      "code_url": "https://github.com/sunhongfu/iQSM_Plus",
+      "license": "Used with author permission (no license file in the upstream repository)",
+      "authors": [
+        "Gao Y.",
+        "Xiong Z.",
+        "Shan S.",
+        "Liu Y.",
+        "Rong P.",
+        "Li M.",
+        "Wilman A.H.",
+        "Pike G.B.",
+        "Liu F.",
+        "Sun H."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "ismv",
       "name": "iSMV",
       "stage": "bfr",


### PR DESCRIPTION
## What

Adds **iQSM+** as a QSM-CI algorithm submission under `algorithms/iqsm-plus/`, modeled closely on the merged `algorithms/nextqsm/` submission (Dockerfile + run.sh + algorithm.yml + README).

iQSM+ (Gao et al., *Medical Image Analysis* 2024) is the **orientation-adaptive** successor to iQSM: a **single-step** deep network that maps raw wrapped MRI phase straight to susceptibility χ (phase unwrapping + background-field removal + dipole inversion in one forward pass), adding OA-LFE blocks so oblique/sagittal/coronal B0 orientations reconstruct correctly.

## Stage + evidence

- **Stage = `end-to-end`** (consumes `phase`, `magnitude`, `mask`, `params`; produces `chimap.nii.gz`), per `stages.yml` / `CONTRACT.md`.
- Confirmed against the upstream source: `inference.run_iqsm_plus` runs the LoT-Unet directly on the **wrapped phase** and returns χ; `run.py` orchestrates per-echo inference + combination. There is no intermediate field-map artifact — it is genuinely single-step, so `end-to-end` (not a single pipeline stage) is correct.

## B0-direction + units handling

- **Orientation-adaptive:** iQSM+'s OA-LFE blocks take the B0 direction as a real model input (not just a dipole-kernel parameter). `run.sh` passes it via `--b0-dir` from `$QSMCI_B0_DIR` (fallback `params.json` `B0_dir`, default axial `0 0 1`).
- **Input units = raw wrapped phase (radians).** QSM-CI's `phase` artifact is exactly what iQSM+ expects (the network unwraps internally; `run_iqsm_plus` convention `phase = -ΔB·γ·TE`, default `phase_sign = -1`). **No ppm conversion on input.** Output χ is already **ppm** = the `chimap` unit.
- Also passes **TE(s)** (`--te`, seconds, from `$QSMCI_TE`), **B0 tesla** (`--b0`, `$QSMCI_B0`), and **voxel size** (`--voxel-size`, `$QSMCI_VOXEL_SIZE`; header used otherwise).
- **Multi-echo:** QSM-CI `phase` is 4D `(x,y,z,echo)` — handed to the engine via `--echo_4d`, letting iQSM+'s own CLI do per-echo inference + magnitude × TE² weighted combination rather than re-implementing it. Single-echo (3D) uses the same flag.
- The engine writes `iQSM_plus.nii.gz`; `run.sh` renames it to canonical `chimap.nii.gz`.

## Image / offline scoring

Scoring runs offline (`--network none`), so the Dockerfile bakes the weights at **build** time:
- `python:3.11-slim` (README requires Python 3.10/3.11), CPU-only (`CUDA_VISIBLE_DEVICES=-1`).
- `git clone`s the iQSM+ engine at a **pinned commit** into `/opt/iQSM_Plus` (it is not a pip package, and only this folder's `run.sh` is mounted at run time — the engine must live in the image).
- Installs the **CPU torch wheel** + engine `requirements.txt`.
- Bakes weights (`iQSM_plus.pth`, `LoTLayer_chi.pth`) via `python run.py --download-checkpoints` (HuggingFace `sunhongfu/iQSM_Plus`).

**No manual image push needed for the leaderboard:** scoring builds this folder's `Dockerfile` at score time. A push (`ghcr.io/astewartau/qsm-ci/iqsm-plus:v1`) is only needed later for Zenodo publishing.

## Metadata

- slug `iqsm-plus`; name **iQSM+**; DOI `10.1016/j.media.2024.103160` (verified: MIA 2024, *Plug-and-Play Latent Feature Editing for Orientation-Adaptive QSM Neural Networks*); code_url the upstream repo; authors Gao Y. … Sun H.
- **License:** upstream ships no license file — noted as **used with author permission**.
- Regenerated `web/algorithms.json`; `tests/test_manifest.py` passes.

## What to verify

- **Local docker build** of `algorithms/iqsm-plus/` (I can't build/push here): confirm the CPU torch wheel resolves, `run.py --download-checkpoints` succeeds, and an end-to-end run on a small phase/mag/mask/params fixture produces a sane `chimap.nii.gz` (ppm).
- Sanity-check the multi-echo path (4D phase via `--echo_4d`) against a known iQSM+ CLI run.
- Confirm the pinned engine commit is the intended one before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)