### PR TITLE
Add AutoQSM submission (bfr+dipole, single-step V-Net)

### DIFF
--- a/algorithms/autoqsm/Dockerfile
+++ b/algorithms/autoqsm/Dockerfile
@@ -1,0 +1,39 @@
+# AutoQSM environment image — CPU-only inference (TensorFlow 1.15 / Python 3.6).
+#
+# AutoQSM (Wei et al., NeuroImage 2019) is a single-step V-Net that maps a total field map straight
+# to susceptibility — no brain extraction, no separate background-field removal. Its published code
+# targets a *legacy* stack: Python 3.6, TensorFlow 1.15.0, Keras 2.2.5. We pin exactly that here and
+# run it CPU-only; we do NOT port it to a newer TF.
+#
+# The AutoQSM repo (code + the ~17 MB pretrained weights model_final_1.hdf5, committed in-repo, not
+# LFS) is baked into the image at build time so the scoring run works fully offline (--network none).
+# The submission's own run.sh + predict.py are mounted at /algo at run time (not baked).
+#
+# Build & push once (see algorithms/autoqsm/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/autoqsm:v1 algorithms/autoqsm
+#   docker push  ghcr.io/astewartau/qsm-ci/autoqsm:v1
+FROM python:3.6-slim
+
+# git: to clone the AutoQSM repo at build time.
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+# Legacy stack, pinned exactly to what AutoQSM was published against. TF 1.15.0 ships CPU + GPU in one
+# wheel; with no GPU libs / CUDA_VISIBLE_DEVICES=-1 it runs CPU-only. numpy is capped because TF 1.15
+# breaks against numpy>=1.19 (np.object / np.bool removals). h5py<3 for Keras 2.2.5 weight loading.
+RUN pip install --no-cache-dir \
+      tensorflow==1.15.0 \
+      keras==2.2.5 \
+      "numpy<1.19" \
+      "h5py<3.0" \
+      "scipy<1.6" \
+      nibabel
+
+# Bake the AutoQSM code + pretrained weights into the image (the run phase has no network, so nothing
+# can be fetched at run time). Pinned to the commit reviewed for this submission.
+RUN git clone https://github.com/AMRI-Lab/AutoQSM /opt/AutoQSM && \
+    cd /opt/AutoQSM && git checkout b59f5e74954d2c2c12626068fdca3160d7826348
+ENV AUTOQSM_HOME=/opt/AutoQSM
+
+# Force CPU + quiet TensorFlow logging at run time.
+ENV CUDA_VISIBLE_DEVICES="-1" \
+    TF_CPP_MIN_LOG_LEVEL="2"

--- a/algorithms/autoqsm/README.md
+++ b/algorithms/autoqsm/README.md
@@ -1,0 +1,61 @@
+# AutoQSM
+
+Learning-based **single-step** quantitative susceptibility mapping reconstruction **without brain
+extraction**.
+
+- **Stage:** `bfr+dipole` (totalfield → chimap, ppm)
+- **Engine:** [AutoQSM](https://github.com/AMRI-Lab/AutoQSM) — a V-Net, **TensorFlow 1.15 / Keras
+  2.2.5 / Python 3.6**, run **CPU-only** (no GPU)
+- **Reference:** Wei H., Cao S., Zhang Y., Guan X., Yan F., Yeom K.W., Liu C. (2019). *Learning-based
+  single-step quantitative susceptibility mapping reconstruction without brain extraction.*
+  NeuroImage, 202, 116064. (DOI: [10.1016/j.neuroimage.2019.116064](https://doi.org/10.1016/j.neuroimage.2019.116064);
+  arXiv: [1905.05953](https://arxiv.org/abs/1905.05953))
+
+## Why `bfr+dipole`
+
+AutoQSM is a **single-step** V-Net that goes straight from the **total field map** to susceptibility
+in one learned pass — it performs **no brain extraction** and **no separate background-field
+removal** (that is the paper's headline result). So it consumes the **total field** and produces
+**susceptibility**, i.e. the `bfr+dipole` span, not the `dipole`-only stage. The `mask` mounted for
+this span is unused: AutoQSM operates on the whole head.
+
+## Units
+
+QSM-CI's `totalfield.nii.gz` is an unwrapped field map already **in ppm** (normalized by B0). This is
+exactly the scale AutoQSM's `x_input` expects: the repo's `test_data/0.mat` `x_input` is a dense
+whole-head field map with values ≈ [−0.9, 0.5] and std ≈ 0.11 — the scale of a 3T total field in ppm,
+and dense (no zero background) as expected for a method that skips brain extraction. So the field is
+fed through **unchanged**. The V-Net's final activation is `tanh`, so its output susceptibility is in
+ppm as well and is written out unchanged. No Hz/rad/ppm rescaling is performed. The output preserves
+the input grid, voxel size, and affine.
+
+## How QSM-CI runs it
+
+```bash
+python predict.py /input/totalfield.nii.gz /output/chimap.nii.gz
+```
+
+`predict.py` reuses AutoQSM's own network (`model.vnet`) and its patch-based sliding-window inference
+(`util.data_predict`, which edge-pads to a multiple of `shift=24` and stitches 64³ → 32³ patches),
+loading the pretrained weights `models/vnet/model_final_1.hdf5`. AutoQSM has no acquisition-parameter
+inputs (no B0-direction / dipole-kernel term — orientation is baked into the trained weights), so
+`run.sh` passes none. CPU inference is author-reported at ~55 s.
+
+## Parameters
+
+AutoQSM has no runtime tunables — it uses fixed pretrained weights.
+
+## Building the image
+
+The environment image bakes the legacy stack **and** the AutoQSM code + pretrained weights (~17 MB,
+committed in-repo — not LFS), so the scoring run works fully offline (`--network none`). It must be
+built and pushed before scoring works:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/autoqsm:v1 algorithms/autoqsm
+docker push  ghcr.io/astewartau/qsm-ci/autoqsm:v1
+```
+
+The submission's own `run.sh` + `predict.py` are mounted read-only at `/algo` at run time (not baked).
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/autoqsm/algorithm.yml
+++ b/algorithms/autoqsm/algorithm.yml
@@ -1,0 +1,21 @@
+name: AutoQSM
+slug: autoqsm
+stage: bfr+dipole
+description: >
+  AutoQSM — learning-based single-step QSM reconstruction without brain extraction. A V-Net that maps
+  the total field map directly to susceptibility, doing neither brain extraction nor a separate
+  background-field-removal step. Consumes the total field and produces susceptibility. Runs CPU-only
+  on the legacy TensorFlow 1.15 / Keras 2.2.5 stack the method was published against.
+authors:
+- name: Wei H.
+- name: Cao S.
+- name: Zhang Y.
+- name: Guan X.
+- name: Yan F.
+- name: Yeom K.W.
+- name: Liu C.
+doi: 10.1016/j.neuroimage.2019.116064
+code_url: https://github.com/AMRI-Lab/AutoQSM
+license: none declared; used with author permission
+image: ghcr.io/astewartau/qsm-ci/autoqsm:v1
+run: bash run.sh

--- a/algorithms/autoqsm/predict.py
+++ b/algorithms/autoqsm/predict.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""AutoQSM inference for QSM-CI (bfr+dipole span): totalfield.nii.gz -> chimap.nii.gz.
+
+AutoQSM (Wei et al., NeuroImage 2019) is a single-step V-Net that maps a total field map directly to
+susceptibility with NO brain extraction and NO separate background-field removal. Its published
+`test.py` hardcodes a `.mat`-file workflow (key `x_input`) and a `results/` output dir; this wrapper
+reuses its network definition (`vnet`) and its patch-based sliding-window inference (`data_predict`,
+which zero-/edge-pads to a multiple of shift=24 and stitches 64^3 -> 32^3 patches) but plumbs the
+QSM-CI NIfTI artifacts through instead.
+
+Units. QSM-CI's totalfield.nii.gz is an unwrapped field map already in **ppm** (normalized by B0).
+AutoQSM's `x_input` is likewise a field map in ppm — the shipped test_data/0.mat `x_input` is a dense
+whole-head map with values ~[-0.9, 0.5], std ~0.11, exactly the scale of a 3T total field in ppm
+(and dense with no zero background, consistent with "no brain extraction"). So we feed the totalfield
+voxels through unchanged. The network's final activation is tanh, so its output susceptibility is in
+ppm as well; we write it out unchanged. No Hz/rad rescaling is applied.
+
+Usage:  predict.py <totalfield.nii.gz> <chimap.nii.gz>
+"""
+import os
+import sys
+
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")   # force CPU
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+import numpy as np
+import nibabel as nib
+
+# Make AutoQSM's own modules (model.py, util.py) importable from the baked repo.
+AUTOQSM_HOME = os.environ.get("AUTOQSM_HOME", "/opt/AutoQSM")
+sys.path.insert(0, os.path.join(AUTOQSM_HOME, "code"))
+
+from model import vnet            # noqa: E402  (AutoQSM V-Net definition)
+from util import data_predict     # noqa: E402  (AutoQSM patch inference / stitching)
+
+WEIGHTS = os.path.join(AUTOQSM_HOME, "models", "vnet", "model_final_1.hdf5")
+INPUT_PATCH_SHAPE = [64, 64, 64]
+OUTPUT_PATCH_SHAPE = [32, 32, 32]
+
+
+def main(in_path, out_path):
+    nii = nib.load(in_path)
+    field = np.asarray(nii.get_fdata(), dtype=np.float32)   # totalfield, ppm
+    if field.ndim != 3:
+        raise ValueError("expected a 3D totalfield, got shape {}".format(field.shape))
+
+    # Build the V-Net and load AutoQSM's pretrained weights (single-channel field -> chi).
+    model = vnet(INPUT_PATCH_SHAPE, OUTPUT_PATCH_SHAPE, 1)
+    model.load_weights(WEIGHTS)
+
+    # data_predict zero-/edge-pads to a multiple of shift=24 and runs the 64^3 -> 32^3 sliding window,
+    # returning the susceptibility map cropped back to the input grid.
+    chi, _patches = data_predict(model, field, INPUT_PATCH_SHAPE, OUTPUT_PATCH_SHAPE)
+    chi = np.asarray(chi, dtype=np.float32)                 # susceptibility, ppm
+
+    # Preserve the input grid / voxel size / affine (QSM-CI 3D artifacts all share the mask grid).
+    out = nib.Nifti1Image(chi, nii.affine, nii.header)
+    out.set_data_dtype(np.float32)
+    nib.save(out, out_path)
+    print("AutoQSM: wrote {} (shape {})".format(out_path, chi.shape))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("usage: predict.py <totalfield.nii.gz> <chimap.nii.gz>")
+    main(sys.argv[1], sys.argv[2])

--- a/algorithms/autoqsm/run.sh
+++ b/algorithms/autoqsm/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# QSM-CI submission — AutoQSM (bfr+dipole span), CPU-only.
+#
+# AutoQSM is a single-step V-Net that maps the TOTAL field map straight to susceptibility, with NO
+# brain extraction and NO separate background-field removal (Wei et al., NeuroImage 2019). Hence
+# stage = bfr+dipole:
+#   consumes  totalfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+# (The mask is mounted by the platform for this span but AutoQSM does not require it — it operates on
+# the whole head, which is the whole point of "without brain extraction".)
+#
+# Units: the QSM-CI totalfield is an unwrapped field map already in ppm (normalized by B0), which is
+# exactly the scale AutoQSM's `x_input` expects (its shipped test_data is a dense whole-head field map
+# with values ~[-0.9, 0.5] ppm). The V-Net output (tanh) is susceptibility in ppm. No Hz/rad/ppm
+# rescaling is applied. predict.py handles NIfTI<->array and preserves the mask grid / affine.
+#
+# Acquisition parameters are injected as env vars (see CONTRACT.md); AutoQSM needs none of them (it
+# has no dipole-kernel orientation input — orientation is baked into the trained weights).
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+# Force CPU-only TensorFlow (belt-and-braces; also set in the image).
+export CUDA_VISIBLE_DEVICES="-1"
+export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
+
+# predict.py lives beside this script (mounted read-only at /algo); the AutoQSM code + weights are
+# baked in the image at $AUTOQSM_HOME (default /opt/AutoQSM).
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+python "$HERE/predict.py" \
+  "$IN/totalfield.nii.gz" \
+  "$OUT/chimap.nii.gz"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -1,6 +1,27 @@
 {
   "algorithms": [
     {
+      "slug": "autoqsm",
+      "name": "AutoQSM",
+      "stage": "bfr+dipole",
+      "engine": null,
+      "description": "AutoQSM \u2014 learning-based single-step QSM reconstruction without brain extraction. A V-Net that maps the total field map directly to susceptibility, doing neither brain extraction nor a separate background-field-removal step. Consumes the total field and produces susceptibility. Runs CPU-only on the legacy TensorFlow 1.15 / Keras 2.2.5 stack the method was published against.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2019.116064",
+      "code_url": "https://github.com/AMRI-Lab/AutoQSM",
+      "license": "none declared; used with author permission",
+      "authors": [
+        "Wei H.",
+        "Cao S.",
+        "Zhang Y.",
+        "Guan X.",
+        "Yan F.",
+        "Yeom K.W.",
+        "Liu C."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "harperella",
       "name": "HARPERELLA",
       "stage": "unwrap+bfr",


### PR DESCRIPTION
Adds **AutoQSM** as a QSM-CI submission under `algorithms/autoqsm/`.

## Stage: `bfr+dipole` (totalfield → chimap, ppm)

AutoQSM (Wei et al., NeuroImage 2019) is a **single-step V-Net** that maps the **total field map directly to susceptibility**, with **no brain extraction** and **no separate background-field removal** — that is the paper's headline result.

**Evidence (verified against source, `github.com/AMRI-Lab/AutoQSM` @ `b59f5e7`):**
- `code/test.py` runs one network (`vnet`) via `data_predict` from a field-map input keyed `x_input` straight to the QSM output — no BFR / no skull-strip stage.
- `code/model.py` `vnet(...)` is a single U/V-Net (encoder–decoder, `tanh` output), one model, one pass.
- The shipped `test_data/0.mat` `x_input` is a **dense whole-head** field map (no zero background), consistent with "without brain extraction".

So it consumes the **total field** and produces **susceptibility** = the `bfr+dipole` span (per `stages.yml` / `CONTRACT.md`), not `dipole`-only. The `mask` mounted for the span is unused (whole-head operation).

## Units handling

QSM-CI's `totalfield.nii.gz` is an unwrapped field map already **in ppm** (normalized by B0). Verified against `util.py` / the shipped test data that AutoQSM's `x_input` is a field map at the **same ppm scale** — `test_data/0.mat` `x_input` has values ≈ [−0.9, 0.5], std ≈ 0.11 (a 3T total field in ppm). So the field is fed through **unchanged**. The V-Net's final activation is `tanh`, so its output susceptibility is in ppm as well and is written unchanged. **No Hz/rad/ppm rescaling.** Output preserves the input grid / voxel size / affine.

## Implementation

- **`Dockerfile`** pins the legacy stack the method was published against — `python:3.6-slim` + `tensorflow==1.15.0`, `keras==2.2.5`, `numpy<1.19`, `h5py<3`, `scipy<1.6`, `nibabel` — CPU-only (`CUDA_VISIBLE_DEVICES=-1`). **Not ported** to newer TF. It bakes the AutoQSM repo + its pretrained weights `models/vnet/model_final_1.hdf5` (~17 MB, a real committed HDF5 file — verified *not* LFS) so the run phase works offline (`--network none`).
- **`predict.py`** reuses AutoQSM's own `model.vnet` + `util.data_predict` (edge-pads to a multiple of `shift=24`, stitches 64³ → 32³ patches) on the NIfTI artifacts. Author-reported CPU runtime ~55 s.
- **`run.sh`**: `IN=${1:-/input} OUT=${2:-/output}`, forces CPU, calls `predict.py totalfield.nii.gz → chimap.nii.gz`. AutoQSM needs no acquisition params (no dipole-kernel orientation input — orientation is in the trained weights).
- **`algorithm.yml`**: slug `autoqsm`, stage `bfr+dipole`, image `ghcr.io/astewartau/qsm-ci/autoqsm:v1`, run `bash run.sh`, authors Wei H. et al., DOI `10.1016/j.neuroimage.2019.116064` (verified via CrossRef: NeuroImage 2019, vol 202, art 116064; arXiv 1905.05953), `code_url` the repo, license "none declared; used with author permission".
- Regenerated `web/algorithms.json`; `pytest -q tests/test_manifest.py` passes (2 passed).

## Note on scoring / image build

Per `CONTRACT.md`, scoring **builds the folder `Dockerfile` at score-time** (build phase, network ON) to produce the environment image, then runs `bash run.sh` with the code mounted at `/algo` and no network. The `image:` tag is where that built environment is published/consumed. The weights + AutoQSM code are baked into that image at build time so the offline run phase has everything it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)