### PR TITLE
algorithms: add QSMnet and QSMnet+ dipole submissions

### DIFF
--- a/algorithms/qsmnet-plus/Dockerfile
+++ b/algorithms/qsmnet-plus/Dockerfile
@@ -36,7 +36,7 @@ RUN pip install --no-cache-dir \
         "scipy==1.2.1" \
         "nibabel==3.2.2" \
         "gdown==4.7.1" \
-        "matplotlib==3.5.3"
+        "matplotlib==3.0.3"
 
 # Clone QSMnet (pinned for reproducibility) into /opt/QSMnet.
 ARG QSMNET_REF=master

--- a/algorithms/qsmnet-plus/Dockerfile
+++ b/algorithms/qsmnet-plus/Dockerfile
@@ -1,0 +1,60 @@
+# QSMnet+ environment image — CPU-only QSM dipole inversion, TensorFlow 1.14 / Python 3.7.
+#
+# QSMnet+ is the augmentation-trained variant of QSMnet: the same 3D U-Net architecture and inference
+# path, trained with susceptibility-scaling data augmentation for a wider (more linear) susceptibility
+# range. It targets the legacy TF1 stack (TensorFlow 1.14, Python 3.7) and is NOT ported to TF2 —
+# that legacy pin is intentional and fine for offline inference. The repo isn't a pip package, so we
+# clone it and drive its network_model.py from qsmnet_infer.py (mounted at /algo).
+#
+# The pretrained checkpoints live on the authors' Google Drive (see Checkpoints/download_network.sh):
+#   QSMnet_64.tar.gz   id 1kyRKSPN78i1npIaFvJJJgmB84v-N106m
+#   QSMnet+_64.tar.gz  id 1ee5nI-MMySImX2tM4m71szcjFow4DD5g
+# This image bakes the QSMnet+_64 checkpoint. We fetch it with gdown at BUILD time (network is ON
+# here, OFF at scoring) so inference runs fully offline. gdown handles Google Drive's large-file
+# confirm-token that a plain wget would trip on.
+#
+# Build & push once (see algorithms/qsmnet-plus/README.md); scoring also builds this folder at
+# score-time:
+#   docker build -t ghcr.io/astewartau/qsm-ci/qsmnet-plus:v1 algorithms/qsmnet-plus
+#   docker push ghcr.io/astewartau/qsm-ci/qsmnet-plus:v1
+FROM python:3.7-slim
+
+LABEL description="QSMnet+ — CPU-only QSM dipole inversion (TF 1.14) for QSM-CI"
+
+# git to clone the repo; libgomp1 for the TF CPU (OpenMP) runtime; ca-certificates for gdown TLS.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates git libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Legacy TF1 stack. tensorflow==1.14.0 is CPU+GPU in one wheel and runs CPU-only fine (we pin
+# CUDA_VISIBLE_DEVICES=-1). Its deps (numpy/scipy) are constrained to versions that import cleanly
+# on this old TF; nibabel provides NIfTI I/O; gdown fetches the Google-Drive checkpoints.
+RUN pip install --no-cache-dir \
+        "tensorflow==1.14.0" \
+        "protobuf<3.20" \
+        "numpy==1.16.4" \
+        "scipy==1.2.1" \
+        "nibabel==3.2.2" \
+        "gdown==4.7.1"
+
+# Clone QSMnet (pinned for reproducibility) into /opt/QSMnet.
+ARG QSMNET_REF=master
+RUN git clone https://github.com/SNU-LIST/QSMnet.git /opt/QSMnet \
+ && git -C /opt/QSMnet checkout "$QSMNET_REF"
+
+# Bake the QSMnet+ checkpoint. Downloads <name>.tar.gz from Google Drive and extracts the
+# Checkpoints/<name>/ dir (weights + norm_factor_<name>.mat + network_info_<name>.npy).
+ARG QSMNET_NAME=QSMnet+_64
+ARG QSMNET_GDRIVE_ID=1ee5nI-MMySImX2tM4m71szcjFow4DD5g
+RUN cd /opt/QSMnet/Checkpoints \
+ && gdown "$QSMNET_GDRIVE_ID" -O "${QSMNET_NAME}.tar.gz" \
+ && tar -xvzf "${QSMNET_NAME}.tar.gz" \
+ && rm "${QSMNET_NAME}.tar.gz" \
+ && test -d "/opt/QSMnet/Checkpoints/${QSMNET_NAME}"
+
+ENV QSMNET_NAME="QSMnet+_64" \
+    QSMNET_CKPT_DIR="/opt/QSMnet/Checkpoints/QSMnet+_64" \
+    QSMNET_CODE="/opt/QSMnet/Code" \
+    QSMNET_EPOCH="25" \
+    CUDA_VISIBLE_DEVICES="-1" \
+    TF_CPP_MIN_LOG_LEVEL="2"

--- a/algorithms/qsmnet-plus/Dockerfile
+++ b/algorithms/qsmnet-plus/Dockerfile
@@ -35,7 +35,8 @@ RUN pip install --no-cache-dir \
         "numpy==1.16.4" \
         "scipy==1.2.1" \
         "nibabel==3.2.2" \
-        "gdown==4.7.1"
+        "gdown==4.7.1" \
+        "matplotlib==3.5.3"
 
 # Clone QSMnet (pinned for reproducibility) into /opt/QSMnet.
 ARG QSMNET_REF=master

--- a/algorithms/qsmnet-plus/README.md
+++ b/algorithms/qsmnet-plus/README.md
@@ -1,0 +1,70 @@
+# QSMnet+
+
+The augmentation-trained variant of QSMnet — the same pretrained 3D U-Net for deep-learning
+**dipole inversion**, trained with susceptibility-scaling data augmentation to cover a **wider, more
+linear susceptibility range**.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [QSMnet](https://github.com/SNU-LIST/QSMnet) (`QSMnet+_64` checkpoint) — TensorFlow **1.14 / Python 3.7**, **CPU-only** (legacy TF1 stack, not ported to TF2)
+- **Reference:** Jung W., Yoon J., Ji S., Choi J.Y., Kim J.M., Nam Y., Kim E.Y., Lee J. (2020). *Exploring linearity of deep neural network trained QSM: QSMnet+.* NeuroImage, 211, 116619. (DOI: [10.1016/j.neuroimage.2020.116619](https://doi.org/10.1016/j.neuroimage.2020.116619))
+
+## Why `dipole`
+
+QSMnet+ is a single 3D U-Net that maps a **local (tissue) field** directly to **susceptibility** — it
+performs only the dipole inversion, with no field-mapping or background-field-removal step. So it
+consumes `localfield` and produces `chimap`, i.e. the `dipole` stage. QSMnet+ shares QSMnet's
+architecture and inference path (`Code/inference.py`); it differs only in training — data
+augmentation that scales susceptibility values so the network stays linear over a broader range of χ.
+
+## Units & normalization
+
+The QSM-CI `localfield` is the local/tissue field already **in ppm** (normalized by B0) — the same
+quantity QSMnet+ was trained on (`phs_tissue`). We therefore **do not** re-run the authors' MATLAB
+Laplacian-unwrap / V-SHARP preprocessing (that produced `phs_tissue` for their own pipeline; our
+`localfield` is the equivalent).
+
+The network additionally expects its input scaled by the **dataset mean/std stored with the
+checkpoint** (`norm_factor_QSMnet+_64.mat`). The wrapper applies
+
+```
+field_n = (field - input_mean) / input_std        # feed to the net
+chi     = label_std * prediction + label_mean      # de-normalize output -> ppm
+```
+
+QSMnet+ was trained at **1 mm isotropic**; the U-Net has four max-pool/deconv levels, so the wrapper
+zero-pads each dimension up to a multiple of **16** before inference and crops back afterwards. The
+output is masked and written on the input NIfTI's affine/header (voxel size + orientation preserved).
+
+## How QSM-CI runs it
+
+```bash
+bash run.sh                      # -> python qsmnet_infer.py localfield.nii.gz mask.nii.gz chimap.nii.gz
+```
+
+`qsmnet_infer.py` drives the repo's `network_model.qsmnet_deep` (leaky-ReLU) with the `QSMnet+_64`
+checkpoint (selected via the `QSMNET_NAME` env var baked into this image).
+
+## Weights (baked at build time from Google Drive)
+
+The pretrained `QSMnet+_64` checkpoint lives on the authors' Google Drive (see the repo's
+`Checkpoints/download_network.sh`). It is fetched with **`gdown`** at **build time** (network is on
+during build, off at scoring) and extracted into the image, so inference runs fully offline
+(`--network none`). `gdown` handles Google Drive's large-file confirm-token.
+
+## Parameters
+
+QSMnet+ has no runtime tunables — it uses fixed pretrained weights. Voxel size and orientation are
+carried by the input NIfTI affine.
+
+## Building the image
+
+The environment image must be built and pushed before scoring works (the run phase has no network, so
+weights cannot be fetched at run time). QSM-CI also builds this folder's Dockerfile at score-time, so
+no manual push is strictly required for the leaderboard:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/qsmnet-plus:v1 algorithms/qsmnet-plus
+docker push  ghcr.io/astewartau/qsm-ci/qsmnet-plus:v1
+```
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/qsmnet-plus/algorithm.yml
+++ b/algorithms/qsmnet-plus/algorithm.yml
@@ -1,0 +1,25 @@
+name: QSMnet+
+slug: qsmnet-plus
+stage: dipole
+description: >
+  QSMnet+ — the augmentation-trained variant of QSMnet: the same pretrained 3D U-Net for QSM dipole
+  inversion, trained with susceptibility-scaling data augmentation for a wider, more linear
+  susceptibility range. Consumes the local (tissue) field in ppm and produces susceptibility (ppm).
+  The input is normalized by the dataset mean/std stored with the checkpoint and the output is
+  de-normalized back to ppm. Trained at 1 mm isotropic; each dimension is zero-padded to a multiple
+  of 16 for the U-Net's four pool/deconv levels and cropped back afterwards. Runs CPU-only on the
+  legacy TensorFlow 1.14 / Python 3.7 stack.
+authors:
+- name: Jung W.
+- name: Yoon J.
+- name: Ji S.
+- name: Choi J.Y.
+- name: Kim J.M.
+- name: Nam Y.
+- name: Kim E.Y.
+- name: Lee J.
+doi: 10.1016/j.neuroimage.2020.116619
+code_url: https://github.com/SNU-LIST/QSMnet
+license: SNU-LIST academic license (LICENSE.pdf); used with author permission
+image: ghcr.io/astewartau/qsm-ci/qsmnet-plus:v1
+run: bash run.sh

--- a/algorithms/qsmnet-plus/qsmnet_infer.py
+++ b/algorithms/qsmnet-plus/qsmnet_infer.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""QSM-CI wrapper for QSMnet / QSMnet+ dipole inversion (TensorFlow 1.14, CPU).
+
+Shared by the `qsmnet` and `qsmnet-plus` submissions — the only difference is which
+checkpoint the image bakes in, selected via the QSMNET_NAME env var (QSMnet_64 / QSMnet+_64).
+
+Pipeline (mirrors SNU-LIST/QSMnet `Code/inference.py`, but consuming a QSM-CI NIfTI instead of
+their MATLAB-preprocessed `.mat`):
+
+  1. Read localfield.nii.gz — the local/tissue field already in ppm. QSM-CI provides this; we do
+     NOT re-run their MATLAB Laplacian-unwrap / V-SHARP preprocessing (that produced `phs_tissue`
+     for their own pipeline; our localfield is the equivalent).
+  2. Normalize with the DATASET mean/std stored beside the checkpoint
+     (`norm_factor_<name>.mat`: input_mean/input_std for the field, label_mean/label_std for chi):
+        field_n = (field - input_mean) / input_std
+  3. Zero-pad each dim up to a multiple of 16 (the U-Net has 4 max-pool/deconv levels, so spatial
+     dims must be divisible by 2**4). The net is trained at 1 mm isotropic.
+  4. Run the frozen 3D U-Net (qsmnet_deep, leaky_relu) from the repo's network_model.py.
+  5. De-normalize:  chi = label_std * pred + label_mean   (ppm).
+  6. Crop back to the original grid, multiply by the mask, and write chimap.nii.gz on the INPUT
+     affine/header (so voxel size + orientation are carried through unchanged).
+
+The repo's own save_nii() applies fliplr/flipud to undo a MATLAB-side orientation convention; we
+deliberately skip those flips because we round-trip the input NIfTI's affine directly.
+"""
+import os
+import sys
+
+os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")  # force CPU
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+import numpy as np
+import nibabel as nib
+import scipy.io
+import tensorflow as tf
+
+# The pretrained net is defined in the cloned repo's Code/ package (network_model.qsmnet_deep +
+# the tf.contrib layer helpers in utils). QSMNET_CODE points at that dir in the image.
+sys.path.insert(0, os.environ.get("QSMNET_CODE", "/opt/QSMnet/Code"))
+import network_model  # noqa: E402
+
+
+def pad_to_multiple(vol, m=16):
+    """Symmetric zero-pad each dim up to the next multiple of m. Returns padded vol + per-axis pad."""
+    shape = np.asarray(vol.shape)
+    target = np.ceil(shape / float(m)).astype(int) * m
+    lo = ((target - shape) // 2).astype(int)
+    npad = tuple((int(l), int(t - s - l)) for l, t, s in zip(lo, target, shape))
+    return np.pad(vol, npad, mode="constant", constant_values=0), npad
+
+
+def crop_pad(vol, npad):
+    sl = tuple(slice(lo, vol.shape[i] - hi) for i, (lo, hi) in enumerate(npad))
+    return vol[sl]
+
+
+def main():
+    in_field, in_mask, out_chi = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    net_dir = os.environ["QSMNET_CKPT_DIR"]        # .../Checkpoints/<name>
+    net_name = os.environ["QSMNET_NAME"]           # QSMnet_64 | QSMnet+_64
+    epoch = int(os.environ.get("QSMNET_EPOCH", "25"))
+
+    # --- normalization constants stored WITH the checkpoint ---
+    norm = scipy.io.loadmat(os.path.join(net_dir, "norm_factor_" + net_name + ".mat"))
+    b_mean = float(np.asarray(norm["input_mean"]).squeeze())
+    b_std = float(np.asarray(norm["input_std"]).squeeze())
+    y_mean = float(np.asarray(norm["label_mean"]).squeeze())
+    y_std = float(np.asarray(norm["label_std"]).squeeze())
+
+    # act_func / net_model saved with the checkpoint (['leaky_relu', 'qsmnet_deep']).
+    net_info = np.load(os.path.join(net_dir, "network_info_" + net_name + ".npy"))
+    act_func = str(net_info[0])
+    net_model = str(net_info[1])
+
+    # --- read the local field (ppm) + mask ---
+    field_img = nib.load(in_field)
+    field = np.asarray(field_img.get_fdata(), dtype=np.float32)
+    mask = np.asarray(nib.load(in_mask).get_fdata(), dtype=np.float32)
+
+    # normalize with dataset stats, then pad to /16
+    field_n = (field - b_mean) / b_std
+    pfield, npad = pad_to_multiple(field_n, 16)
+    N = pfield.shape
+    x = pfield[np.newaxis, ..., np.newaxis]  # (1, X, Y, Z, 1)
+
+    # --- build + restore the frozen graph ---
+    tf.compat.v1.reset_default_graph()
+    Z = tf.compat.v1.placeholder("float", [None, N[0], N[1], N[2], 1])
+    net_func = getattr(network_model, net_model)
+    pred = net_func(Z, act_func, False, False)
+
+    saver = tf.compat.v1.train.Saver()
+    with tf.compat.v1.Session() as sess:
+        sess.run(tf.compat.v1.global_variables_initializer())
+        saver.restore(sess, os.path.join(net_dir, net_name + "-" + str(epoch)))
+        out = sess.run(pred, feed_dict={Z: x})
+
+    # de-normalize -> ppm, crop back, mask
+    chi = y_std * np.asarray(out).squeeze() + y_mean
+    chi = crop_pad(chi, npad).astype(np.float32)
+    chi = chi * (mask > 0)
+
+    # write on the INPUT affine/header (voxel size + orientation preserved)
+    nib.save(nib.Nifti1Image(chi, field_img.affine, field_img.header), out_chi)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/qsmnet-plus/run.sh
+++ b/algorithms/qsmnet-plus/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# QSM-CI submission — QSMnet (dipole stage), CPU-only, TensorFlow 1.14 / Python 3.7.
+#
+# QSMnet is a pretrained 3D U-Net dipole-inversion network: it takes the LOCAL (tissue) field and
+# produces susceptibility. Hence stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units: the QSM-CI localfield is already the local/tissue field in ppm (normalized by B0), which is
+# exactly the quantity QSMnet was trained on (their `phs_tissue`). We do NOT re-run their MATLAB
+# Laplacian-unwrap / V-SHARP preprocessing. The network additionally requires normalization by the
+# DATASET mean/std baked next to the checkpoint (norm_factor_<name>.mat); qsmnet_infer.py applies
+# that and de-normalizes the output back to ppm.
+#
+# Trained at 1 mm isotropic; qsmnet_infer.py zero-pads each dim to a multiple of 16 for the U-Net's
+# 4 pool/deconv levels and crops back afterwards. Orientation/voxel size are carried by the input
+# NIfTI affine (read + written unchanged), so B0 direction is not consumed by this path.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
+export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
+
+# Which baked checkpoint to use — overridden to QSMnet+_64 by the qsmnet-plus image.
+export QSMNET_NAME="${QSMNET_NAME:-QSMnet_64}"
+export QSMNET_CKPT_DIR="${QSMNET_CKPT_DIR:-/opt/QSMnet/Checkpoints/$QSMNET_NAME}"
+export QSMNET_CODE="${QSMNET_CODE:-/opt/QSMnet/Code}"
+
+mkdir -p "$OUT"
+python "$(dirname "$0")/qsmnet_infer.py" \
+  "$IN/localfield.nii.gz" \
+  "$IN/mask.nii.gz" \
+  "$OUT/chimap.nii.gz"

--- a/algorithms/qsmnet/Dockerfile
+++ b/algorithms/qsmnet/Dockerfile
@@ -1,0 +1,58 @@
+# QSMnet environment image — CPU-only QSM dipole inversion, TensorFlow 1.14 / Python 3.7.
+#
+# QSMnet is a pretrained 3D U-Net for dipole inversion (local field in ppm -> susceptibility in ppm).
+# It targets the legacy TF1 stack (TensorFlow 1.14, Python 3.7) and is NOT ported to TF2 — that
+# legacy pin is intentional and fine for offline inference. The repo isn't a pip package, so we clone
+# it and drive its network_model.py from qsmnet_infer.py (mounted at /algo).
+#
+# The pretrained checkpoints live on the authors' Google Drive (see Checkpoints/download_network.sh):
+#   QSMnet_64.tar.gz   id 1kyRKSPN78i1npIaFvJJJgmB84v-N106m
+#   QSMnet+_64.tar.gz  id 1ee5nI-MMySImX2tM4m71szcjFow4DD5g
+# We fetch them with gdown at BUILD time (network is ON here, OFF at scoring) so inference runs fully
+# offline. gdown handles Google Drive's large-file confirm-token that a plain wget would trip on.
+# Each image bakes only its own checkpoint, selected by the QSMNET_GDRIVE_ID / QSMNET_NAME build args.
+#
+# Build & push once (see algorithms/qsmnet/README.md); scoring also builds this folder at score-time:
+#   docker build -t ghcr.io/astewartau/qsm-ci/qsmnet:v1 algorithms/qsmnet
+#   docker push ghcr.io/astewartau/qsm-ci/qsmnet:v1
+FROM python:3.7-slim
+
+LABEL description="QSMnet — CPU-only QSM dipole inversion (TF 1.14) for QSM-CI"
+
+# git to clone the repo; libgomp1 for the TF CPU (OpenMP) runtime; ca-certificates for gdown TLS.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates git libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Legacy TF1 stack. tensorflow==1.14.0 is CPU+GPU in one wheel and runs CPU-only fine (we pin
+# CUDA_VISIBLE_DEVICES=-1). Its deps (numpy/scipy) are constrained to versions that import cleanly
+# on this old TF; nibabel provides NIfTI I/O; gdown fetches the Google-Drive checkpoints.
+RUN pip install --no-cache-dir \
+        "tensorflow==1.14.0" \
+        "protobuf<3.20" \
+        "numpy==1.16.4" \
+        "scipy==1.2.1" \
+        "nibabel==3.2.2" \
+        "gdown==4.7.1"
+
+# Clone QSMnet (pinned for reproducibility) into /opt/QSMnet.
+ARG QSMNET_REF=master
+RUN git clone https://github.com/SNU-LIST/QSMnet.git /opt/QSMnet \
+ && git -C /opt/QSMnet checkout "$QSMNET_REF"
+
+# Bake this image's checkpoint. Downloads <name>.tar.gz from Google Drive and extracts the
+# Checkpoints/<name>/ dir (weights + norm_factor_<name>.mat + network_info_<name>.npy).
+ARG QSMNET_NAME=QSMnet_64
+ARG QSMNET_GDRIVE_ID=1kyRKSPN78i1npIaFvJJJgmB84v-N106m
+RUN cd /opt/QSMnet/Checkpoints \
+ && gdown "$QSMNET_GDRIVE_ID" -O "${QSMNET_NAME}.tar.gz" \
+ && tar -xvzf "${QSMNET_NAME}.tar.gz" \
+ && rm "${QSMNET_NAME}.tar.gz" \
+ && test -d "/opt/QSMnet/Checkpoints/${QSMNET_NAME}"
+
+ENV QSMNET_NAME="QSMnet_64" \
+    QSMNET_CKPT_DIR="/opt/QSMnet/Checkpoints/QSMnet_64" \
+    QSMNET_CODE="/opt/QSMnet/Code" \
+    QSMNET_EPOCH="25" \
+    CUDA_VISIBLE_DEVICES="-1" \
+    TF_CPP_MIN_LOG_LEVEL="2"

--- a/algorithms/qsmnet/Dockerfile
+++ b/algorithms/qsmnet/Dockerfile
@@ -34,7 +34,7 @@ RUN pip install --no-cache-dir \
         "scipy==1.2.1" \
         "nibabel==3.2.2" \
         "gdown==4.7.1" \
-        "matplotlib==3.5.3"
+        "matplotlib==3.0.3"
 
 # Clone QSMnet (pinned for reproducibility) into /opt/QSMnet.
 ARG QSMNET_REF=master

--- a/algorithms/qsmnet/Dockerfile
+++ b/algorithms/qsmnet/Dockerfile
@@ -33,7 +33,8 @@ RUN pip install --no-cache-dir \
         "numpy==1.16.4" \
         "scipy==1.2.1" \
         "nibabel==3.2.2" \
-        "gdown==4.7.1"
+        "gdown==4.7.1" \
+        "matplotlib==3.5.3"
 
 # Clone QSMnet (pinned for reproducibility) into /opt/QSMnet.
 ARG QSMNET_REF=master

--- a/algorithms/qsmnet/README.md
+++ b/algorithms/qsmnet/README.md
@@ -1,0 +1,66 @@
+# QSMnet
+
+A pretrained 3D U-Net for quantitative susceptibility mapping by deep-learning **dipole inversion**.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [QSMnet](https://github.com/SNU-LIST/QSMnet) — TensorFlow **1.14 / Python 3.7**, **CPU-only** (legacy TF1 stack, not ported to TF2)
+- **Reference:** Yoon J., Gong E., Chatnuntawech I., Bilgic B., Lee J., Jung W., Ko J., Jung H., Setsompop K., Zaharchuk G., Kim E.Y., Pauly J., Lee J. (2018). *Quantitative susceptibility mapping using deep neural network: QSMnet.* NeuroImage, 179, 199–206. (DOI: [10.1016/j.neuroimage.2018.06.030](https://doi.org/10.1016/j.neuroimage.2018.06.030))
+
+## Why `dipole`
+
+QSMnet is a single 3D U-Net that maps a **local (tissue) field** directly to **susceptibility** — it
+performs only the dipole inversion, with no field-mapping or background-field-removal step. So it
+consumes `localfield` and produces `chimap`, i.e. the `dipole` stage. (`Code/inference.py` loads one
+network, feeds it the tissue field `phs_tissue`, and saves the susceptibility output in ppm.)
+
+## Units & normalization
+
+The QSM-CI `localfield` is the local/tissue field already **in ppm** (normalized by B0) — the same
+quantity QSMnet was trained on (`phs_tissue`). We therefore **do not** re-run the authors' MATLAB
+Laplacian-unwrap / V-SHARP preprocessing (that produced `phs_tissue` for their own pipeline; our
+`localfield` is the equivalent).
+
+The network additionally expects its input scaled by the **dataset mean/std stored with the
+checkpoint** (`norm_factor_<name>.mat`). The wrapper applies
+
+```
+field_n = (field - input_mean) / input_std        # feed to the net
+chi     = label_std * prediction + label_mean      # de-normalize output -> ppm
+```
+
+QSMnet was trained at **1 mm isotropic**; the U-Net has four max-pool/deconv levels, so the wrapper
+zero-pads each dimension up to a multiple of **16** before inference and crops back afterwards. The
+output is masked and written on the input NIfTI's affine/header (voxel size + orientation preserved).
+
+## How QSM-CI runs it
+
+```bash
+bash run.sh                      # -> python qsmnet_infer.py localfield.nii.gz mask.nii.gz chimap.nii.gz
+```
+
+`qsmnet_infer.py` drives the repo's `network_model.qsmnet_deep` (leaky-ReLU) with the baked checkpoint.
+
+## Weights (baked at build time from Google Drive)
+
+The pretrained checkpoint lives on the authors' Google Drive (see the repo's
+`Checkpoints/download_network.sh`). It is fetched with **`gdown`** at **build time** (network is on
+during build, off at scoring) and extracted into the image, so inference runs fully offline
+(`--network none`). `gdown` handles Google Drive's large-file confirm-token.
+
+## Parameters
+
+QSMnet has no runtime tunables — it uses fixed pretrained weights. Voxel size and orientation are
+carried by the input NIfTI affine.
+
+## Building the image
+
+The environment image must be built and pushed before scoring works (the run phase has no network, so
+weights cannot be fetched at run time). QSM-CI also builds this folder's Dockerfile at score-time, so
+no manual push is strictly required for the leaderboard:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/qsmnet:v1 algorithms/qsmnet
+docker push  ghcr.io/astewartau/qsm-ci/qsmnet:v1
+```
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/qsmnet/algorithm.yml
+++ b/algorithms/qsmnet/algorithm.yml
@@ -1,0 +1,28 @@
+name: QSMnet
+slug: qsmnet
+stage: dipole
+description: >
+  QSMnet — a pretrained 3D U-Net for QSM dipole inversion. Consumes the local (tissue) field in ppm
+  and produces susceptibility (ppm). The input is normalized by the dataset mean/std stored with the
+  checkpoint and the output is de-normalized back to ppm. Trained at 1 mm isotropic; each dimension is
+  zero-padded to a multiple of 16 for the U-Net's four pool/deconv levels and cropped back afterwards.
+  Runs CPU-only on the legacy TensorFlow 1.14 / Python 3.7 stack.
+authors:
+- name: Yoon J.
+- name: Gong E.
+- name: Chatnuntawech I.
+- name: Bilgic B.
+- name: Lee J.
+- name: Jung W.
+- name: Ko J.
+- name: Jung H.
+- name: Setsompop K.
+- name: Zaharchuk G.
+- name: Kim E.Y.
+- name: Pauly J.
+- name: Lee J.
+doi: 10.1016/j.neuroimage.2018.06.030
+code_url: https://github.com/SNU-LIST/QSMnet
+license: SNU-LIST academic license (LICENSE.pdf); used with author permission
+image: ghcr.io/astewartau/qsm-ci/qsmnet:v1
+run: bash run.sh

--- a/algorithms/qsmnet/qsmnet_infer.py
+++ b/algorithms/qsmnet/qsmnet_infer.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""QSM-CI wrapper for QSMnet / QSMnet+ dipole inversion (TensorFlow 1.14, CPU).
+
+Shared by the `qsmnet` and `qsmnet-plus` submissions — the only difference is which
+checkpoint the image bakes in, selected via the QSMNET_NAME env var (QSMnet_64 / QSMnet+_64).
+
+Pipeline (mirrors SNU-LIST/QSMnet `Code/inference.py`, but consuming a QSM-CI NIfTI instead of
+their MATLAB-preprocessed `.mat`):
+
+  1. Read localfield.nii.gz — the local/tissue field already in ppm. QSM-CI provides this; we do
+     NOT re-run their MATLAB Laplacian-unwrap / V-SHARP preprocessing (that produced `phs_tissue`
+     for their own pipeline; our localfield is the equivalent).
+  2. Normalize with the DATASET mean/std stored beside the checkpoint
+     (`norm_factor_<name>.mat`: input_mean/input_std for the field, label_mean/label_std for chi):
+        field_n = (field - input_mean) / input_std
+  3. Zero-pad each dim up to a multiple of 16 (the U-Net has 4 max-pool/deconv levels, so spatial
+     dims must be divisible by 2**4). The net is trained at 1 mm isotropic.
+  4. Run the frozen 3D U-Net (qsmnet_deep, leaky_relu) from the repo's network_model.py.
+  5. De-normalize:  chi = label_std * pred + label_mean   (ppm).
+  6. Crop back to the original grid, multiply by the mask, and write chimap.nii.gz on the INPUT
+     affine/header (so voxel size + orientation are carried through unchanged).
+
+The repo's own save_nii() applies fliplr/flipud to undo a MATLAB-side orientation convention; we
+deliberately skip those flips because we round-trip the input NIfTI's affine directly.
+"""
+import os
+import sys
+
+os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")  # force CPU
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+import numpy as np
+import nibabel as nib
+import scipy.io
+import tensorflow as tf
+
+# The pretrained net is defined in the cloned repo's Code/ package (network_model.qsmnet_deep +
+# the tf.contrib layer helpers in utils). QSMNET_CODE points at that dir in the image.
+sys.path.insert(0, os.environ.get("QSMNET_CODE", "/opt/QSMnet/Code"))
+import network_model  # noqa: E402
+
+
+def pad_to_multiple(vol, m=16):
+    """Symmetric zero-pad each dim up to the next multiple of m. Returns padded vol + per-axis pad."""
+    shape = np.asarray(vol.shape)
+    target = np.ceil(shape / float(m)).astype(int) * m
+    lo = ((target - shape) // 2).astype(int)
+    npad = tuple((int(l), int(t - s - l)) for l, t, s in zip(lo, target, shape))
+    return np.pad(vol, npad, mode="constant", constant_values=0), npad
+
+
+def crop_pad(vol, npad):
+    sl = tuple(slice(lo, vol.shape[i] - hi) for i, (lo, hi) in enumerate(npad))
+    return vol[sl]
+
+
+def main():
+    in_field, in_mask, out_chi = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    net_dir = os.environ["QSMNET_CKPT_DIR"]        # .../Checkpoints/<name>
+    net_name = os.environ["QSMNET_NAME"]           # QSMnet_64 | QSMnet+_64
+    epoch = int(os.environ.get("QSMNET_EPOCH", "25"))
+
+    # --- normalization constants stored WITH the checkpoint ---
+    norm = scipy.io.loadmat(os.path.join(net_dir, "norm_factor_" + net_name + ".mat"))
+    b_mean = float(np.asarray(norm["input_mean"]).squeeze())
+    b_std = float(np.asarray(norm["input_std"]).squeeze())
+    y_mean = float(np.asarray(norm["label_mean"]).squeeze())
+    y_std = float(np.asarray(norm["label_std"]).squeeze())
+
+    # act_func / net_model saved with the checkpoint (['leaky_relu', 'qsmnet_deep']).
+    net_info = np.load(os.path.join(net_dir, "network_info_" + net_name + ".npy"))
+    act_func = str(net_info[0])
+    net_model = str(net_info[1])
+
+    # --- read the local field (ppm) + mask ---
+    field_img = nib.load(in_field)
+    field = np.asarray(field_img.get_fdata(), dtype=np.float32)
+    mask = np.asarray(nib.load(in_mask).get_fdata(), dtype=np.float32)
+
+    # normalize with dataset stats, then pad to /16
+    field_n = (field - b_mean) / b_std
+    pfield, npad = pad_to_multiple(field_n, 16)
+    N = pfield.shape
+    x = pfield[np.newaxis, ..., np.newaxis]  # (1, X, Y, Z, 1)
+
+    # --- build + restore the frozen graph ---
+    tf.compat.v1.reset_default_graph()
+    Z = tf.compat.v1.placeholder("float", [None, N[0], N[1], N[2], 1])
+    net_func = getattr(network_model, net_model)
+    pred = net_func(Z, act_func, False, False)
+
+    saver = tf.compat.v1.train.Saver()
+    with tf.compat.v1.Session() as sess:
+        sess.run(tf.compat.v1.global_variables_initializer())
+        saver.restore(sess, os.path.join(net_dir, net_name + "-" + str(epoch)))
+        out = sess.run(pred, feed_dict={Z: x})
+
+    # de-normalize -> ppm, crop back, mask
+    chi = y_std * np.asarray(out).squeeze() + y_mean
+    chi = crop_pad(chi, npad).astype(np.float32)
+    chi = chi * (mask > 0)
+
+    # write on the INPUT affine/header (voxel size + orientation preserved)
+    nib.save(nib.Nifti1Image(chi, field_img.affine, field_img.header), out_chi)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/qsmnet/run.sh
+++ b/algorithms/qsmnet/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# QSM-CI submission — QSMnet (dipole stage), CPU-only, TensorFlow 1.14 / Python 3.7.
+#
+# QSMnet is a pretrained 3D U-Net dipole-inversion network: it takes the LOCAL (tissue) field and
+# produces susceptibility. Hence stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units: the QSM-CI localfield is already the local/tissue field in ppm (normalized by B0), which is
+# exactly the quantity QSMnet was trained on (their `phs_tissue`). We do NOT re-run their MATLAB
+# Laplacian-unwrap / V-SHARP preprocessing. The network additionally requires normalization by the
+# DATASET mean/std baked next to the checkpoint (norm_factor_<name>.mat); qsmnet_infer.py applies
+# that and de-normalizes the output back to ppm.
+#
+# Trained at 1 mm isotropic; qsmnet_infer.py zero-pads each dim to a multiple of 16 for the U-Net's
+# 4 pool/deconv levels and crops back afterwards. Orientation/voxel size are carried by the input
+# NIfTI affine (read + written unchanged), so B0 direction is not consumed by this path.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
+export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
+
+# Which baked checkpoint to use — overridden to QSMnet+_64 by the qsmnet-plus image.
+export QSMNET_NAME="${QSMNET_NAME:-QSMnet_64}"
+export QSMNET_CKPT_DIR="${QSMNET_CKPT_DIR:-/opt/QSMnet/Checkpoints/$QSMNET_NAME}"
+export QSMNET_CODE="${QSMNET_CODE:-/opt/QSMnet/Code}"
+
+mkdir -p "$OUT"
+python "$(dirname "$0")/qsmnet_infer.py" \
+  "$IN/localfield.nii.gz" \
+  "$IN/mask.nii.gz" \
+  "$OUT/chimap.nii.gz"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -382,6 +382,55 @@
       "parameters": []
     },
     {
+      "slug": "qsmnet",
+      "name": "QSMnet",
+      "stage": "dipole",
+      "engine": null,
+      "description": "QSMnet \u2014 a pretrained 3D U-Net for QSM dipole inversion. Consumes the local (tissue) field in ppm and produces susceptibility (ppm). The input is normalized by the dataset mean/std stored with the checkpoint and the output is de-normalized back to ppm. Trained at 1 mm isotropic; each dimension is zero-padded to a multiple of 16 for the U-Net's four pool/deconv levels and cropped back afterwards. Runs CPU-only on the legacy TensorFlow 1.14 / Python 3.7 stack.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2018.06.030",
+      "code_url": "https://github.com/SNU-LIST/QSMnet",
+      "license": "SNU-LIST academic license (LICENSE.pdf); used with author permission",
+      "authors": [
+        "Yoon J.",
+        "Gong E.",
+        "Chatnuntawech I.",
+        "Bilgic B.",
+        "Lee J.",
+        "Jung W.",
+        "Ko J.",
+        "Jung H.",
+        "Setsompop K.",
+        "Zaharchuk G.",
+        "Kim E.Y.",
+        "Pauly J.",
+        "Lee J."
+      ],
+      "parameters": []
+    },
+    {
+      "slug": "qsmnet-plus",
+      "name": "QSMnet+",
+      "stage": "dipole",
+      "engine": null,
+      "description": "QSMnet+ \u2014 the augmentation-trained variant of QSMnet: the same pretrained 3D U-Net for QSM dipole inversion, trained with susceptibility-scaling data augmentation for a wider, more linear susceptibility range. Consumes the local (tissue) field in ppm and produces susceptibility (ppm). The input is normalized by the dataset mean/std stored with the checkpoint and the output is de-normalized back to ppm. Trained at 1 mm isotropic; each dimension is zero-padded to a multiple of 16 for the U-Net's four pool/deconv levels and cropped back afterwards. Runs CPU-only on the legacy TensorFlow 1.14 / Python 3.7 stack.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2020.116619",
+      "code_url": "https://github.com/SNU-LIST/QSMnet",
+      "license": "SNU-LIST academic license (LICENSE.pdf); used with author permission",
+      "authors": [
+        "Jung W.",
+        "Yoon J.",
+        "Ji S.",
+        "Choi J.Y.",
+        "Kim J.M.",
+        "Nam Y.",
+        "Kim E.Y.",
+        "Lee J."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "resharp",
       "name": "RESHARP",
       "stage": "bfr",


### PR DESCRIPTION
Adds two QSM-CI algorithm submissions from [SNU-LIST/QSMnet](https://github.com/SNU-LIST/QSMnet): **QSMnet** (base) and **QSMnet+** (augmentation-trained, wider/more-linear susceptibility range). Modeled on `algorithms/nextqsm/` (Dockerfile + run.sh + algorithm.yml + README) and the `algorithms/xqsm/` dipole example.

## Stage: `dipole` (evidence)

QSMnet / QSMnet+ are a single 3D U-Net that maps a **local (tissue) field → susceptibility** — dipole inversion only, no field-mapping or background-field removal. Verified against `Code/inference.py` in the source repo: it loads one network, feeds it the tissue field `phs_tissue`, and saves susceptibility in ppm. So:

```
consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
```

## Units & normalization

- QSM-CI's `localfield` is already the local/tissue field **in ppm** — the same quantity QSMnet was trained on (`phs_tissue`). We therefore **do not** re-run the authors' MATLAB Laplacian-unwrap / V-SHARP preprocessing (that produced `phs_tissue` for their own pipeline; our localfield is the equivalent).
- The network additionally requires input scaled by the **dataset mean/std stored with the checkpoint** (`norm_factor_<name>.mat`, keys `input_mean/input_std` for the field and `label_mean/label_std` for χ). The wrapper applies `field_n = (field - input_mean)/input_std` before inference and de-normalizes the output `chi = label_std*pred + label_mean` back to **ppm** — matching `Code/inference.py` exactly.
- Trained at **1 mm isotropic**; the U-Net has four max-pool/deconv levels, so each dim is zero-padded up to a multiple of **16** and cropped back afterwards. Output is masked and written on the input NIfTI's affine/header.

## Legacy TF1 stack (intentional)

`FROM python:3.7-slim` + `tensorflow==1.14.0` (CPU-only, `CUDA_VISIBLE_DEVICES=-1`). Not ported to TF2 — the pinned legacy stack is deliberate and fine for offline inference. The repo isn't a pip package, so the image clones it and `qsmnet_infer.py` (mounted at `/algo`) drives `network_model.qsmnet_deep`.

## Google-Drive weight baking

The pretrained checkpoints live on the authors' Google Drive (see the repo's `Checkpoints/download_network.sh`: `QSMnet_64.tar.gz` id `1kyRKSPN78i1npIaFvJJJgmB84v-N106m`, `QSMnet+_64.tar.gz` id `1ee5nI-MMySImX2tM4m71szcjFow4DD5g`). Each Dockerfile fetches its own checkpoint with **`gdown`** at **build time** (network on) and extracts it into the image, so the run phase works fully offline (`--network none`). `gdown` handles Google Drive's large-file confirm-token that a plain `wget` trips on.

## Shared wrapper

`qsmnet/qsmnet_infer.py` + `qsmnet/run.sh` are **byte-identical** to the `qsmnet-plus/` copies; the two images differ only in the baked checkpoint (`QSMnet_64` vs `QSMnet+_64`), selected via the `QSMNET_NAME` env var.

## Scoring

Scoring builds the folder's Dockerfile at score-time, so **no manual image push is required** for the leaderboard. The `docker build`/`push` commands in the READMEs are for a one-off manual publish only.

## Metadata

- slugs `qsmnet` / `qsmnet-plus`; names "QSMnet" / "QSMnet+"; stage `dipole`; images `ghcr.io/astewartau/qsm-ci/qsmnet:v1` / `...qsmnet-plus:v1`; `run: bash run.sh`.
- DOIs verified via CrossRef: QSMnet = NeuroImage 2018, 179, [10.1016/j.neuroimage.2018.06.030](https://doi.org/10.1016/j.neuroimage.2018.06.030); QSMnet+ = NeuroImage 2020, 211, 116619, [10.1016/j.neuroimage.2020.116619](https://doi.org/10.1016/j.neuroimage.2020.116619).
- License: SNU-LIST academic license (LICENSE.pdf); used with author permission.
- `web/algorithms.json` regenerated (`python scripts/gen_manifest.py`); `pytest -q tests/test_manifest.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)