### PR TITLE
Add MoDL-QSM submission (dipole stage)

### DIFF
--- a/algorithms/modl-qsm/Dockerfile
+++ b/algorithms/modl-qsm/Dockerfile
@@ -1,0 +1,37 @@
+# MoDL-QSM environment image — CPU-only inference on legacy TensorFlow 1.15.
+#
+# MoDL-QSM ships as source (github.com/Ruimin-Feng/MoDL-QSM) with the ~1.8 MB trained weights
+# (logs/last.h5) and the input-normalisation factors (NormFactor.mat) committed in-repo. We clone
+# the repo at BUILD time (network is ON) so everything — code + weights + NormFactor.mat — is baked
+# in and the run phase works fully offline (--network none).
+#
+# The method targets Python 3.6 + TensorFlow 1.15.0 + Keras 2.2.5 (README "Environmental
+# Requirements"). This legacy stack is pinned exactly; the code is NOT ported to TF2.
+#
+# Build & push once (see algorithms/modl-qsm/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/modl-qsm:v1 algorithms/modl-qsm
+#   docker push ghcr.io/astewartau/qsm-ci/modl-qsm:v1
+FROM python:3.6-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Legacy stack, pinned. TF 1.15 CPU wheel + Keras 2.2.5; numpy/h5py/protobuf pinned to versions that
+# still resolve against TF 1.15 on py36. nibabel for NIfTI I/O in run.sh's converter.
+RUN pip install --no-cache-dir \
+      "tensorflow==1.15.0" \
+      "keras==2.2.5" \
+      "numpy==1.18.5" \
+      "h5py==2.10.0" \
+      "protobuf==3.20.1" \
+      "scipy==1.4.1" \
+      "nibabel==3.0.2"
+
+# Bake the algorithm source (code + logs/last.h5 weights + NormFactor.mat) into the image at
+# /opt/MoDL-QSM. The run phase has no network, so this cannot be fetched at run time.
+RUN git clone --depth 1 https://github.com/Ruimin-Feng/MoDL-QSM /opt/MoDL-QSM
+ENV MODL_QSM_HOME="/opt/MoDL-QSM"
+
+# Force CPU + quiet TensorFlow logging at run time (the repo hardcodes CUDA device 0; override it).
+ENV CUDA_VISIBLE_DEVICES="-1" \
+    TF_CPP_MIN_LOG_LEVEL="2"

--- a/algorithms/modl-qsm/README.md
+++ b/algorithms/modl-qsm/README.md
@@ -1,0 +1,79 @@
+# MoDL-QSM
+
+Model-based deep learning for quantitative susceptibility mapping — a dipole-inversion network that
+unrolls a gradient-descent solver of the QSM forward model, alternating a learned CNN prior with
+data-consistency terms built from the dipole kernel.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [MoDL-QSM](https://github.com/Ruimin-Feng/MoDL-QSM) — legacy **TensorFlow 1.15 / Keras 2.2.5 / Python 3.6**, **CPU-only**
+- **Reference:** Feng R., Zhao J., Wang H., Yang B., Feng J., Shi Y., Zhang M., Liu C., Zhang Y., Zhuang J., Wei H. (2021). *MoDL-QSM: Model-based deep learning for quantitative susceptibility mapping.* NeuroImage, 240, 118376. (DOI: [10.1016/j.neuroimage.2021.118376](https://doi.org/10.1016/j.neuroimage.2021.118376); arXiv: [2101.08413](https://arxiv.org/abs/2101.08413))
+
+## Why `dipole`
+
+MoDL-QSM inverts the dipole convolution: it takes the **tissue (local) field** and produces
+**susceptibility**. Its `model_test` entry point (`test/test_tools.py`) consumes the tissue field
+`phi`, the brain mask, the voxel size, and the B0 direction, and returns the susceptibility map. The
+dipole kernel is generated **internally** from the B0 direction (`test_tools.dipole_kernel`) and
+enforced through data-consistency `A`/`AH` operators in the unrolled network (`model/MoDL_QSM.py`).
+So the method consumes `localfield` and produces `chimap` — the `dipole` stage.
+
+## Units
+
+The QSM-CI `localfield` is the tissue field already **in ppm** (normalized by B0). This is exactly
+MoDL-QSM's `phi` input: the repo's example `test_data.mat` `phi` arrays span ~±0.1–0.2 (ppm), not
+radians. The field is fed to the network **unchanged**, and the output susceptibility (in ppm) is
+written **unchanged** to `chimap.nii.gz`.
+
+## Input normalization — `NormFactor.mat`
+
+MoDL-QSM ships `NormFactor.mat`, the **train-set mean/std** (`CosTrnMean`, `CosTrnStd`) used to
+normalize the network's working variables. It **must** be applied or the output scale is wrong.
+Rather than normalizing the raw input in the runner, MoDL-QSM bakes these factors **into the Keras
+graph**: `define_generator()` normalizes each intermediate susceptibility estimate with
+`(x - CosTrnMean) / CosTrnStd` before the CNN prior and de-normalizes with `x * CosTrnStd + CosTrnMean`
+after (see `model/MoDL_QSM.py`). `model_test` loads `../NormFactor.mat` relative to the current
+directory, so `recon.py` runs from `$MODL_QSM_HOME/test` to guarantee the factors are found and
+applied.
+
+## Output — χ33
+
+The network emits **two channels**: χ33 (the STI susceptibility-tensor component along B0 — STI-
+flavored but comparable to scalar QSM) and the field induced by the χ13/χ23 terms. We keep channel 0
+(**χ33**) as the `chimap`.
+
+## How QSM-CI runs it
+
+```bash
+python recon.py /input /output
+```
+
+`recon.py` reads `localfield.nii.gz` + `mask.nii.gz`, takes the voxel size (NIfTI header) and B0
+direction (`$QSMCI_B0_DIR` / `params.json` `B0_dir`, default axial `0 0 1`), calls MoDL-QSM's
+`model_test` (which builds the dipole kernel and applies `NormFactor.mat`), and writes χ33 to
+`chimap.nii.gz` on the input grid, in ppm.
+
+## Parameters
+
+MoDL-QSM has no runtime tunables — it uses fixed pretrained weights (`logs/last.h5`, ~1.8 MB,
+committed in-repo). The only acquisition-derived inputs are the B0 direction and voxel size, used to
+build the dipole kernel.
+
+## Building the image
+
+The environment image must be built and pushed before scoring works (the run phase has no network,
+so the repo — code + weights + `NormFactor.mat` — cannot be fetched at run time; the Dockerfile
+`git clone`s it at build time):
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/modl-qsm:v1 algorithms/modl-qsm
+docker push  ghcr.io/astewartau/qsm-ci/modl-qsm:v1
+```
+
+QSM-CI builds this folder's `Dockerfile` at score time to produce the environment image; the mounted
+`run.sh` / `recon.py` are executed inside it.
+
+## License
+
+The MoDL-QSM repository declares no license. Used here with the authors' permission.
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/modl-qsm/algorithm.yml
+++ b/algorithms/modl-qsm/algorithm.yml
@@ -1,0 +1,26 @@
+name: MoDL-QSM
+slug: modl-qsm
+stage: dipole
+description: >
+  MoDL-QSM — model-based deep learning for quantitative susceptibility mapping. A dipole-inversion
+  network that unrolls a gradient-descent solver of the QSM forward model, alternating a learned
+  CNN prior with data-consistency terms built from the dipole kernel. Consumes the tissue (local)
+  field in ppm and produces susceptibility (the STI χ33 component, comparable to scalar QSM). Runs
+  CPU-only with legacy TensorFlow 1.15 / Keras 2.2.5.
+authors:
+- name: Feng R.
+- name: Zhao J.
+- name: Wang H.
+- name: Yang B.
+- name: Feng J.
+- name: Shi Y.
+- name: Zhang M.
+- name: Liu C.
+- name: Zhang Y.
+- name: Zhuang J.
+- name: Wei H.
+doi: 10.1016/j.neuroimage.2021.118376
+code_url: https://github.com/Ruimin-Feng/MoDL-QSM
+license: none declared; used with author permission
+image: ghcr.io/astewartau/qsm-ci/modl-qsm:v1
+run: bash run.sh

--- a/algorithms/modl-qsm/recon.py
+++ b/algorithms/modl-qsm/recon.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""MoDL-QSM dipole-inversion runner for QSM-CI (stage = dipole).
+
+Consumes  /input/localfield.nii.gz, /input/mask.nii.gz, /input/params.json
+Produces  /output/chimap.nii.gz  (susceptibility, ppm)
+
+MoDL-QSM (github.com/Ruimin-Feng/MoDL-QSM) is an unrolled model-based network. Its `model_test`
+entry point takes the tissue/local field, the brain mask, the voxel size, and the B0 direction; it
+builds the dipole kernel internally (test_tools.dipole_kernel from the B0 direction) and applies the
+train-set input normalisation via the shipped NormFactor.mat.
+
+Units. MoDL-QSM's `phi` input is the tissue field normalised to ppm (the repo's example test_data.mat
+`phi` arrays span ~±0.1-0.2, i.e. ppm — not radians). QSM-CI's localfield.nii.gz is already in ppm,
+so it is fed to the network unchanged. Likewise the output susceptibility is in ppm and written out
+unchanged.
+
+Normalisation (NormFactor.mat). MoDL-QSM does NOT normalise the raw input in this script — the
+train-set mean/std (CosTrnMean/CosTrnStd) are baked into the Keras graph by define_generator(), which
+normalises each intermediate susceptibility estimate before the CNN prior and de-normalises after
+(see model/MoDL_QSM.py: `(x-CosTrnMean)/CosTrnStd` ... `x*CosTrnStd+CosTrnMean`). Because model_test
+loads '../NormFactor.mat' relative to the CWD, we run from $MODL_QSM_HOME/test so the factors are
+found and applied — omitting this would leave the output scale wrong.
+
+Output. The network emits two channels: χ33 (STI-flavoured but comparable to scalar QSM) and the
+field induced by the χ13/χ23 terms. We keep channel 0 (χ33) as the chimap.
+"""
+import json
+import os
+import sys
+
+import nibabel as nib
+import numpy as np
+from scipy.io import savemat
+
+IN = sys.argv[1] if len(sys.argv) > 1 else "/input"
+OUT = sys.argv[2] if len(sys.argv) > 2 else "/output"
+
+MODL_HOME = os.environ.get("MODL_QSM_HOME", "/opt/MoDL-QSM")
+TEST_DIR = os.path.join(MODL_HOME, "test")
+
+# model_test() loads '../NormFactor.mat' and imports model.MoDL_QSM via a relative sys.path hack in
+# test_tools.py, so the CWD must be the repo's test/ dir for both to resolve.
+os.chdir(TEST_DIR)
+sys.path.insert(0, TEST_DIR)
+sys.path.insert(0, MODL_HOME)
+
+from test_tools import model_test  # noqa: E402  (import after chdir/sys.path setup)
+
+# --- Load QSM-CI inputs -------------------------------------------------------------------------
+localfield_nii = nib.load(os.path.join(IN, "localfield.nii.gz"))
+mask_nii = nib.load(os.path.join(IN, "mask.nii.gz"))
+
+phi = np.asarray(localfield_nii.dataobj, dtype=np.float64)          # tissue/local field, ppm
+mask = (np.asarray(mask_nii.dataobj) > 0).astype(np.float32)        # binary brain mask
+
+# Voxel size (mm) and B0 direction (unit vector) from params.json / env vars.
+params = {}
+ppath = os.path.join(IN, "params.json")
+if os.path.exists(ppath):
+    with open(ppath) as fh:
+        params = json.load(fh)
+
+
+def _vec(env_name, key, default):
+    env = os.environ.get(env_name)
+    if env:
+        return [float(v) for v in env.split()]
+    if key in params and params[key] is not None:
+        return [float(v) for v in params[key]]
+    return list(default)
+
+
+voxel_size = _vec("QSMCI_VOXEL_SIZE", "voxel_size", [1.0, 1.0, 1.0])
+b0_dir = _vec("QSMCI_B0_DIR", "B0_dir", [0.0, 0.0, 1.0])
+
+# Prefer the affine-derived voxel size when params omits it / disagrees, matching the NIfTI grid.
+hdr_zooms = [float(z) for z in localfield_nii.header.get_zooms()[:3]]
+if hdr_zooms and all(z > 0 for z in hdr_zooms):
+    voxel_size = hdr_zooms
+
+print("MoDL-QSM: phi", phi.shape, "voxel_size", voxel_size, "B0_dir", b0_dir, flush=True)
+
+# --- Run the model ------------------------------------------------------------------------------
+# model_dir is the committed weights; is_full_size=True runs the whole volume in one pass (the
+# repo's default). model_test builds the dipole kernel from b0_dir and applies NormFactor.mat.
+model_dir = os.path.join("..", "logs", "last.h5")
+Y = model_test(model_dir, phi, mask, voxel_size, b0_dir, True)
+Y = np.asarray(Y)
+
+# Y is (X, Y, Z, 2): channel 0 = χ33 susceptibility (ppm), channel 1 = χ13/χ23-induced field.
+chi = Y[..., 0] if Y.ndim == 4 else Y
+
+# model_test may crop odd dimensions to even; pad χ back to the input grid so the affine matches.
+if chi.shape != phi.shape:
+    pad = [(0, phi.shape[i] - chi.shape[i]) for i in range(3)]
+    chi = np.pad(chi, pad, mode="constant")
+
+chi = (chi * mask).astype(np.float32)
+
+os.makedirs(OUT, exist_ok=True)
+out_path = os.path.join(OUT, "chimap.nii.gz")
+# Preserve the input grid/affine (all 3D artifacts share mask.nii.gz's geometry).
+nib.Nifti1Image(chi, mask_nii.affine, mask_nii.header).to_filename(out_path)
+print("MoDL-QSM: wrote", out_path, chi.shape, "ppm", flush=True)

--- a/algorithms/modl-qsm/run.sh
+++ b/algorithms/modl-qsm/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# QSM-CI submission — MoDL-QSM (dipole stage), CPU-only.
+#
+# MoDL-QSM is a model-based unrolled dipole-inversion network. Stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units. The QSM-CI localfield is the tissue field already in ppm (normalized by B0), which is
+# exactly MoDL-QSM's `phi` input (the repo's example test data `phi` spans ~±0.1-0.2 ppm, not
+# radians). It is fed to the network unchanged, and the output susceptibility (χ33, ppm) is written
+# unchanged.
+#
+# NormFactor.mat. The train-set input normalization (CosTrnMean/CosTrnStd) is baked into the Keras
+# graph by define_generator() — it normalizes each intermediate susceptibility estimate and
+# de-normalizes after the CNN prior. recon.py runs from $MODL_QSM_HOME/test so model_test can load
+# '../NormFactor.mat'; skipping it would leave the output scale wrong.
+#
+# The B0 direction (for the internally-generated dipole kernel) and voxel size are passed through
+# from params.json / env vars:
+#   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm)
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+# Force CPU-only TensorFlow (the repo hardcodes CUDA device 0; also set in the image).
+export CUDA_VISIBLE_DEVICES="-1"
+export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
+export MODL_QSM_HOME="${MODL_QSM_HOME:-/opt/MoDL-QSM}"
+
+# recon.py loads localfield + mask, feeds the field (ppm) to model_test — which builds the dipole
+# kernel from the B0 direction and applies NormFactor.mat — then writes χ33 to chimap.nii.gz (ppm).
+python "$(dirname "$0")/recon.py" "$IN" "$OUT"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -305,6 +305,31 @@
       ]
     },
     {
+      "slug": "modl-qsm",
+      "name": "MoDL-QSM",
+      "stage": "dipole",
+      "engine": null,
+      "description": "MoDL-QSM \u2014 model-based deep learning for quantitative susceptibility mapping. A dipole-inversion network that unrolls a gradient-descent solver of the QSM forward model, alternating a learned CNN prior with data-consistency terms built from the dipole kernel. Consumes the tissue (local) field in ppm and produces susceptibility (the STI \u03c733 component, comparable to scalar QSM). Runs CPU-only with legacy TensorFlow 1.15 / Keras 2.2.5.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2021.118376",
+      "code_url": "https://github.com/Ruimin-Feng/MoDL-QSM",
+      "license": "none declared; used with author permission",
+      "authors": [
+        "Feng R.",
+        "Zhao J.",
+        "Wang H.",
+        "Yang B.",
+        "Feng J.",
+        "Shi Y.",
+        "Zhang M.",
+        "Liu C.",
+        "Zhang Y.",
+        "Zhuang J.",
+        "Wei H."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "nextqsm",
       "name": "NeXtQSM",
       "stage": "bfr+dipole",


### PR DESCRIPTION
Adds **MoDL-QSM** as a QSM-CI submission under `algorithms/modl-qsm/`.

MoDL-QSM (Feng R., Zhao J., Wang H., Yang B., Feng J., Shi Y., Zhang M., Liu C., Zhang Y., Zhuang J., Wei H. — *MoDL-QSM: Model-based deep learning for quantitative susceptibility mapping*, NeuroImage 240 (2021) 118376, [doi:10.1016/j.neuroimage.2021.118376](https://doi.org/10.1016/j.neuroimage.2021.118376), arXiv:2101.08413) is a model-based unrolled dipole-inversion network. Repo: https://github.com/Ruimin-Feng/MoDL-QSM.

## Stage: `dipole` — evidence

MoDL-QSM inverts the dipole convolution: it takes the **tissue/local field** and returns **susceptibility**. Its `model_test` entry point (`test/test_tools.py`) consumes the field `phi`, the mask, the voxel size, and the B0 direction, and returns the susceptibility map. The dipole kernel is generated **internally** from the B0 direction (`test_tools.dipole_kernel`) and enforced through data-consistency `A`/`AH` operators in the unrolled network (`model/MoDL_QSM.py`). So it consumes `localfield` and produces `chimap` → the `dipole` stage (consumes `localfield`, `mask`, `params`; produces `chimap`).

## NormFactor normalization + units

**Units.** The QSM-CI `localfield` is the tissue field already **in ppm** (normalized by B0), which is exactly MoDL-QSM's `phi` input — the repo's example `test_data.mat` `phi` arrays span ~±0.1–0.2 (ppm, not radians). The field is fed to the network **unchanged**, and the output susceptibility (ppm) is written **unchanged** to `chimap.nii.gz` on the input grid.

**NormFactor.mat.** MoDL-QSM ships `NormFactor.mat` — the train-set mean/std (`CosTrnMean`, `CosTrnStd`). It **must** be applied or the output scale is wrong. Rather than normalizing the raw input, MoDL-QSM bakes these factors **into the Keras graph**: `define_generator()` normalizes each intermediate susceptibility estimate with `(x - CosTrnMean)/CosTrnStd` before the CNN prior and de-normalizes with `x*CosTrnStd + CosTrnMean` after. `model_test` loads `../NormFactor.mat` relative to the CWD, so `recon.py` runs from `$MODL_QSM_HOME/test` to guarantee the factors resolve and are applied.

**Output.** The network emits two channels — χ33 (STI susceptibility-tensor component along B0; STI-flavored but comparable to scalar QSM) and the χ13/χ23-induced field. We keep channel 0 (**χ33**) as the `chimap`.

## Environment

Legacy stack pinned in the image: `FROM python:3.6-slim` + `tensorflow==1.15.0 keras==2.2.5` (Python 3.6). The code is **not** ported to TF2. CPU-only (`CUDA_VISIBLE_DEVICES=-1`; the repo hardcodes CUDA device 0). The `Dockerfile` `git clone`s the upstream repo at build time (network ON) so code + weights (`logs/last.h5`, ~1.8 MB, committed in-repo) + `NormFactor.mat` are baked in and the run phase works fully offline (`--network none`).

**Scoring builds this folder's `Dockerfile` at score time** to produce the environment image; the mounted `run.sh` / `recon.py` are then executed inside it.

## Files

- `algorithms/modl-qsm/algorithm.yml` — slug `modl-qsm`, stage `dipole`, image `ghcr.io/astewartau/qsm-ci/modl-qsm:v1`, run `bash run.sh`
- `algorithms/modl-qsm/Dockerfile` — pinned legacy stack + git-clone of the upstream repo
- `algorithms/modl-qsm/run.sh` + `recon.py` — localfield (ppm) → χ33 chimap (ppm), CPU-forced
- `algorithms/modl-qsm/README.md`
- `web/algorithms.json` — regenerated; `pytest -q tests/test_manifest.py` passes

License: the MoDL-QSM repo declares no license; used here with the authors' permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)