### PR TITLE
Add BFRnet (deep-learning background field removal) as a bfr submission

### DIFF
--- a/algorithms/matlab-bfrnet/BUILD.md
+++ b/algorithms/matlab-bfrnet/BUILD.md
@@ -1,0 +1,64 @@
+# Building matlab-bfrnet (compiled MATLAB deep-learning net → MATLAB Runtime)
+
+Compile `recon.m` on a machine with **MATLAB + MATLAB Compiler + Deep Learning Toolbox** (R2026a).
+Same MCR-deployment pattern as `../matlab-sti-iharperella/BUILD.md` (bundled NIfTI toolbox, OS
+gzip, no JVM), **but this is a deep-learning method**, so two extra requirements:
+
+1. **Deep Learning Toolbox is required *at compile time*.** `recon.m` calls `image3dInputLayer`,
+   `layerGraph`, `replaceLayer`, `assembleNetwork`, and `predict`, and the bundled `BFRnet.mat`
+   deserialises to a trained `DAGNetwork`. MATLAB Compiler *can* deploy DL networks onto the
+   license-free MATLAB Runtime, but only if the Deep Learning Toolbox is present on the build
+   machine when you run `mcc` (it packages the required runtime libraries into the CTF archive).
+   The Runtime itself needs no toolbox license — but the **build box does**.
+2. **The trained weights are fetched from the authors' Dropbox — NOT committed** (they're large and
+   not ours to redistribute). See step 1 below.
+
+Stage: `bfr` — consumes `totalfield` (ppm) + `mask` + `params`; produces `localfield` (ppm).
+BFRnet predicts the **background** field; `recon.m` returns `local = (totalfield − background)·mask`.
+
+## Units — clean scalar mapping, no TE/B0
+BFRnet operates entirely in **ppm**: input total field (ppm) → predicted background field (ppm) →
+local field (ppm). The network never sees TE, B0, or B0_dir, so no Hz↔ppm conversion is needed (the
+QSM-CI `totalfield`/`localfield` artifacts are already ppm). `params.json` is read only for
+completeness; voxel size rides on the NIfTI header.
+
+## 1. Fetch build-time deps (not committed)
+```bash
+# NIfTI toolbox (same as the STI submission) — gitignored via algorithms/*/nifti/
+cp -r /path/to/NIfTI_20140122   algorithms/matlab-bfrnet/nifti
+
+# BFRnet trained network from the authors' Dropbox ("data & checkpoints" link in the repo README:
+#   https://github.com/sunhongfu/BFRnet  ->  https://www.dropbox.com/sh/q678oapc65evrfa/...
+# The demo uses BFRnet_L2_64PS_24BS_45Epo_NewHCmix.mat, which contains a `net` variable.
+# Rename to BFRnet.mat (recon.m loads S.net from BFRnet.mat) and drop it in the folder.
+cp /path/to/BFRnet_L2_64PS_24BS_45Epo_NewHCmix.mat  algorithms/matlab-bfrnet/BFRnet.mat
+```
+`BFRnet.mat` is gitignored (large binary weights, redistributed only with author permission). If the
+Dropbox link ever dies, the same network is mirrored under `sunhongfu/deepMRI/BFRnet`.
+
+## 2. Compile
+```bash
+cd algorithms/matlab-bfrnet
+matlab -batch "addpath('shims'); addpath('nifti'); \
+  mcc('-m','recon.m','-a','nifti','-a','shims','-a','BFRnet.mat','-o','recon','-d','.')"
+```
+`-a BFRnet.mat` bundles the trained network into the CTF; `recon.m` finds it at run time via
+`ctfroot`. `-a nifti` bundles the NIfTI I/O. `-a shims` bundles the `padarray` replacement (the
+Runtime has no Image Processing Toolbox — same shim as the STI submission, `shims/` IS committed
+because it's ours). mcc auto-includes the Deep Learning Toolbox runtime because `recon.m`'s DL calls
+are on the traced path.
+
+## 3. Bake the MCR image and push
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/matlab-bfrnet:v1 .   # FROM matlab-runtime:r2026a + COPY recon
+docker push  ghcr.io/astewartau/qsm-ci/matlab-bfrnet:v1
+```
+Then make the GHCR package public. The `Dockerfile` is gitignored (`algorithms/matlab-*/Dockerfile`)
+so CI pulls the prebuilt image rather than rebuilding a licensed mcc binary it cannot reproduce.
+
+## Notes
+- BFRnet's 3 pooling levels require input dims divisible by 8; `recon.m` zero-pads ('post') to the
+  next multiple of 8 and crops the prediction back — matching the repo's `ZeroPadding(tfs, 8)` step.
+- Inference is CPU (`'ExecutionEnvironment','cpu'`) so it runs on any Runtime host; ~16 GB RAM is
+  recommended for a whole-brain volume (per the upstream demo). Switch to `'auto'`/`'gpu'` if the
+  evaluation host has a supported GPU.

--- a/algorithms/matlab-bfrnet/README.md
+++ b/algorithms/matlab-bfrnet/README.md
@@ -1,0 +1,31 @@
+# BFRnet — deep-learning background field removal (QSM-CI `bfr`)
+
+BFRnet is a 3D deep convolutional (Octave-convolution) network that removes the background field for
+QSM. It is trained to cope with brains containing **significant pathological susceptibility sources**
+(haemorrhage, calcification) where conventional BFR (V-SHARP, PDF, …) struggles.
+
+- **Stage:** `bfr` — consumes `totalfield` (ppm), `mask`, `params`; produces `localfield` (ppm).
+- **How it maps:** the network predicts the **background** field from the (masked) total field; the
+  local tissue field is `totalfield − background`, masked. Everything is in ppm, so there is no
+  Hz↔ppm conversion and the net never uses TE/B0/B0_dir.
+- **Framework:** MATLAB R2019a+ with the **Deep Learning Toolbox**. The trained network is a MATLAB
+  DAG network `.mat`. For QSM-CI it is compiled with the MATLAB Compiler and run on the license-free
+  MATLAB Runtime (r2026a).
+
+## Files
+- `recon.m` — QSM-CI wrapper: loads `totalfield.nii.gz`, rebuilds the net input layer at the volume
+  size, predicts the background field, writes `localfield.nii.gz`.
+- `run.sh` — invokes the compiled `recon` binary on the MATLAB Runtime.
+- `Dockerfile` — MCR image that bakes the compiled binary (gitignored; see BUILD.md).
+- `BUILD.md` — local compile + weights-fetch steps a maintainer must run (this method needs a
+  licensed MATLAB + Deep Learning Toolbox at compile time; it cannot be a plain Dockerfile).
+
+## Weights
+The trained network is **not committed**. Fetch it from the authors' Dropbox ("data & checkpoints"
+link in the [BFRnet README](https://github.com/sunhongfu/BFRnet)), rename to `BFRnet.mat`, and bundle
+it at compile time with `mcc -a` — see [BUILD.md](BUILD.md).
+
+## Citation
+Zhu X, Gao Y, Liu F, Crozier S, Sun H. *BFRnet: A deep learning-based MR background field removal
+method for QSM of the brain containing significant pathological susceptibility sources.* Zeitschrift
+für Medizinische Physik, 2022. doi:[10.1016/j.zemedi.2022.08.001](https://doi.org/10.1016/j.zemedi.2022.08.001)

--- a/algorithms/matlab-bfrnet/algorithm.yml
+++ b/algorithms/matlab-bfrnet/algorithm.yml
@@ -1,0 +1,20 @@
+name: BFRnet
+slug: matlab-bfrnet
+stage: bfr
+description: Deep-learning background field removal (BFRnet), a 3D Octave-convolution DAG network
+  trained to predict the background field of the brain — including brains with significant
+  pathological susceptibility sources (haemorrhage, calcification). Consumes the total field (ppm)
+  and predicts the background field; the local tissue field is total − background, masked. The
+  MATLAB Deep Learning Toolbox network is compiled with the MATLAB Compiler and run on the
+  license-free MATLAB Runtime.
+authors:
+- name: Xuanyu Zhu, Yang Gao, Feng Liu, Stuart Crozier, Hongfu Sun
+  affiliation: University of Queensland
+doi: 10.1016/j.zemedi.2022.08.001
+code_url: https://github.com/sunhongfu/BFRnet
+license: Used with author permission
+image: ghcr.io/astewartau/qsm-ci/matlab-bfrnet:v1
+run: bash run.sh
+matlab:
+  entry: recon.m
+  runtime: r2026a

--- a/algorithms/matlab-bfrnet/recon.m
+++ b/algorithms/matlab-bfrnet/recon.m
@@ -1,0 +1,75 @@
+function recon(inp, out)
+% QSM-CI `bfr` stage in MATLAB — BFRnet deep-learning background field removal.
+% Reads <inp>/totalfield.nii.gz (ppm, 3D) + mask + params, writes <out>/localfield.nii.gz (ppm).
+%
+% BFRnet is a 3D Octave-convolution DAG network (MATLAB Deep Learning Toolbox) that predicts the
+% BACKGROUND field from the total field; the local tissue field is total − background, masked.
+% Everything is in ppm — the network never sees TE/B0/B0_dir, so params.json is read only for
+% completeness (voxel_size is carried by the NIfTI header, not needed by the net). See BUILD.md.
+%
+% The trained network `BFRnet.mat` (variable `net`) is bundled at compile time with `mcc -a` and
+% is NOT committed to git (fetched from the authors' Dropbox — see BUILD.md). Bundled NIfTI toolbox
+% + a `padarray` IPT shim (the Runtime has no Image Processing Toolbox) + OS gunzip/gzip (no JVM).
+% Optional <inp>/config.json is accepted but BFRnet has no tunables.
+
+    % --- load inputs -----------------------------------------------------------------------------
+    nii  = read_niigz(fullfile(inp, 'totalfield.nii.gz'));
+    tfs  = double(nii.img);
+    Mask = double(getfield(read_niigz(fullfile(inp, 'mask.nii.gz')), 'img')) > 0.5;
+    if ndims(tfs) > 3, tfs = tfs(:,:,:,1); end
+    tfs  = tfs .* Mask;                                   % net was trained on masked total field
+
+    % --- locate the bundled network --------------------------------------------------------------
+    % mcc places `-a`-bundled data files next to the deployed binary; ctfroot resolves that dir at
+    % run time. Fall back to the source dir for uncompiled (interpreted) testing.
+    netfile = locate_net();
+    S   = load(netfile);                                 % `net` = a trained DAGNetwork/dlnetwork
+    net = S.net;
+
+    % --- pad to a multiple of 8 (BFRnet's 3 pooling levels need dims divisible by 8) --------------
+    sz0 = size(tfs);
+    pad = mod(8 - mod(sz0, 8), 8);                        % voxels to add per axis (0 if already ok)
+    tfp = padarray(tfs, pad, 0, 'post');
+
+    % --- rebuild the input layer at this image size and predict the background field -------------
+    imSize   = size(tfp);
+    newInput = image3dInputLayer(imSize, 'Name', 'ImageInputLayer', 'Normalization', 'none');
+    lg       = replaceLayer(layerGraph(net), 'ImageInputLayer', newInput);
+    L1Net    = assembleNetwork(lg);
+
+    bkg = predict(L1Net, tfp, 'ExecutionEnvironment', 'cpu');   % background field, ppm
+    bkg = double(bkg);
+    bkg = bkg(1:sz0(1), 1:sz0(2), 1:sz0(3));             % crop the post-pad back off
+
+    local = (tfs - bkg) .* Mask;                          % local tissue field, ppm
+
+    % --- write output ----------------------------------------------------------------------------
+    nii.img = single(local);
+    nii.hdr.dime.datatype = 16;  nii.hdr.dime.bitpix = 32;
+    nii.hdr.dime.dim(1) = 3;  nii.hdr.dime.dim(5) = 1;
+    write_niigz(nii, fullfile(out, 'localfield.nii.gz'));
+end
+
+function f = locate_net()
+    cands = {fullfile(ctfroot, 'BFRnet.mat'), ...
+             fullfile(fileparts(mfilename('fullpath')), 'BFRnet.mat'), ...
+             'BFRnet.mat'};
+    for i = 1:numel(cands)
+        if exist(cands{i}, 'file'), f = cands{i}; return; end
+    end
+    error('recon:netMissing', 'BFRnet.mat not found (bundle it with mcc -a; see BUILD.md).');
+end
+
+function nii = read_niigz(f)
+    t = [tempname '.nii'];
+    system(sprintf('gunzip -c ''%s'' > ''%s''', f, t));
+    nii = load_untouch_nii(t);
+    delete(t);
+end
+
+function write_niigz(nii, f)
+    t = [tempname '.nii'];
+    save_untouch_nii(nii, t);
+    system(sprintf('gzip -c ''%s'' > ''%s''', t, f));
+    delete(t);
+end

--- a/algorithms/matlab-bfrnet/run.sh
+++ b/algorithms/matlab-bfrnet/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary is either baked into the image at /opt/qsm-ci/recon (recommended) or committed
+# alongside this script and mounted at /algo. No network needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-bfrnet/shims/padarray.m
+++ b/algorithms/matlab-bfrnet/shims/padarray.m
@@ -1,0 +1,30 @@
+function B = padarray(A, padsize, varargin)
+% Minimal zero-padding replacement for the Image Processing Toolbox padarray,
+% so recon.m compiles/runs on the MATLAB Runtime (no IPT). Supports the forms used here:
+%   padarray(A, p)              padarray(A, p, dir)
+%   padarray(A, p, val, dir)    (val numeric; dir 'pre'|'post'|'both')
+% recon.m uses padarray(tfs, pad, 0, 'post') to reach a multiple of 8.
+% Only constant-value padding is implemented ('circular'/'replicate'/'symmetric'
+% are not used here).
+    padval = 0; direction = 'both';
+    for k = 1:numel(varargin)
+        v = varargin{k};
+        if ischar(v) || (isstring(v) && isscalar(v))
+            direction = char(v);
+        else
+            padval = v;
+        end
+    end
+    padsize = double(padsize(:)');
+    nd = max(ndims(A), numel(padsize));
+    padsize(end+1:nd) = 0;
+    sz = size(A); sz(end+1:nd) = 1;
+    switch lower(direction)
+        case 'pre',  pre = padsize;         post = zeros(1, nd);
+        case 'post', pre = zeros(1, nd);    post = padsize;
+        otherwise,   pre = padsize;         post = padsize;   % 'both'
+    end
+    B = repmat(cast(padval, 'like', A), sz + pre + post);
+    idx = arrayfun(@(d) (pre(d) + 1):(pre(d) + sz(d)), 1:nd, 'UniformOutput', false);
+    B(idx{:}) = A;
+end

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -146,6 +146,21 @@
       ]
     },
     {
+      "slug": "matlab-bfrnet",
+      "name": "BFRnet",
+      "stage": "bfr",
+      "engine": null,
+      "description": "Deep-learning background field removal (BFRnet), a 3D Octave-convolution DAG network trained to predict the background field of the brain \u2014 including brains with significant pathological susceptibility sources (haemorrhage, calcification). Consumes the total field (ppm) and predicts the background field; the local tissue field is total \u2212 background, masked. The MATLAB Deep Learning Toolbox network is compiled with the MATLAB Compiler and run on the license-free MATLAB Runtime.",
+      "citation": null,
+      "doi": "10.1016/j.zemedi.2022.08.001",
+      "code_url": "https://github.com/sunhongfu/BFRnet",
+      "license": "Used with author permission",
+      "authors": [
+        "Xuanyu Zhu, Yang Gao, Feng Liu, Stuart Crozier, Hongfu Sun"
+      ],
+      "parameters": []
+    },
+    {
       "slug": "matlab-medi",
       "name": "MEDI (MATLAB)",
       "stage": "bfr+dipole",


### PR DESCRIPTION
## Feasibility assessment (lead)

BFRnet is a **MATLAB Deep Learning Toolbox** method (not PyTorch), so it follows the compiled-MATLAB → MATLAB Runtime pattern of `matlab-sti-iharperella`, not the Dockerfile-based Python submissions. Verdict: **feasible**, pending a maintainer running the local licensed compile + weights fetch.

**1. Are the Dropbox weights still alive?** — **Yes.** The README "data & checkpoints" link (`dropbox.com/sh/q678oapc65evrfa/...`) 302-redirects to a live modern shared folder (`scl/fo/...`, HTTP 200), not a dead-link page. The demo consumes `BFRnet_L2_64PS_24BS_45Epo_NewHCmix.mat` (a `net` variable). The same trained network is also mirrored under `sunhongfu/deepMRI/BFRnet` as a fallback.

**2. Does compiling need the Deep Learning Toolbox?** — **Yes, at compile time only.** `recon.m` calls `image3dInputLayer`, `layerGraph`, `replaceLayer`, `assembleNetwork`, `predict`, and the `.mat` deserialises to a trained `DAGNetwork`. MATLAB Compiler *can* deploy DL networks onto the license-free Runtime, but the **build machine must have the Deep Learning Toolbox** present when `mcc` runs (it packages the DL runtime libs into the CTF). The Runtime host needs no toolbox license. This is the one hard prerequisite — a maintainer with a MATLAB + Compiler + Deep Learning Toolbox license must do the compile locally; CI cannot reproduce it (hence the gitignored Dockerfile + PULL image, exactly like the STI methods).

**3. Is a clean scalar `bfr` mapping possible?** — **Yes.** BFRnet operates entirely in **ppm**: it takes the (masked) total field and predicts the **background** field; local field = `totalfield − background`, masked. The network never sees TE/B0/B0_dir, so there is no Hz↔ppm conversion — QSM-CI's `totalfield`/`localfield` artifacts are already ppm. Maps directly onto stage `bfr` (consumes totalfield+mask+params → produces localfield). Note: `bfr` produces **localfield**, not chimap — this submission produces `localfield.nii.gz`, correct for the stage.

## What a maintainer must run locally (BUILD.md)

This method cannot be a plain Dockerfile — it needs a **licensed MATLAB + MATLAB Compiler + Deep Learning Toolbox** to compile:

1. Fetch build deps (not committed): the NIfTI toolbox → `algorithms/matlab-bfrnet/nifti/`, and the trained net from the authors' Dropbox → rename to `algorithms/matlab-bfrnet/BFRnet.mat`.
2. Compile: `mcc('-m','recon.m','-a','nifti','-a','shims','-a','BFRnet.mat','-o','recon','-d','.')` — bundles the net, NIfTI I/O, and the `padarray` IPT shim (the Runtime has no Image Processing Toolbox).
3. `docker build`/`push` the MCR image `ghcr.io/astewartau/qsm-ci/matlab-bfrnet:v1` and make the GHCR package public.

Full steps in `algorithms/matlab-bfrnet/BUILD.md`.

## What's in this PR

- `algorithm.yml` — slug `matlab-bfrnet`, name **BFRnet**, stage `bfr`, `matlab:{entry: recon.m, runtime: r2026a}`, image `ghcr.io/astewartau/qsm-ci/matlab-bfrnet:v1`.
- `recon.m` — reads `totalfield.nii.gz`+mask+params, loads the bundled DAG net (via `ctfroot`), zero-pads to a multiple of 8 (BFRnet's pooling requirement; matches upstream `ZeroPadding(tfs,8)`), rebuilds `image3dInputLayer` at the volume size, `predict`s the background field on CPU, writes `localfield.nii.gz` (ppm). Reuses the STI NIfTI gunzip/gzip I/O and the committed `padarray` shim.
- `run.sh`, `README.md`, `BUILD.md`, and a gitignored `Dockerfile`.

**Folder naming:** named `matlab-bfrnet` (not `bfrnet`) so the Dockerfile is covered by the existing `.gitignore: algorithms/matlab-*/Dockerfile` rule — a plain `bfrnet` would NOT match `matlab-*`, so this is the clean option and keeps it consistent with the other compiled-MATLAB submissions (no `.gitignore` edit needed).

## Verification done

- Dropbox liveness + DOI/authors confirmed against source (CrossRef: `10.1016/j.zemedi.2022.08.001`, Z Med Phys 2022, Zhu/Gao/Liu/Crozier/Sun). Note: the upstream repo's own README bibtex ("arXiv 2022") and `app.py` (which mis-cites a different NeuroImage paper + wrong author) are inaccurate — the algorithm.yml uses the authoritative CrossRef record.
- `recon.m` and the `padarray` shim parse cleanly under octave; `padarray(...,'post')` post-pad logic verified.
- `pytest -q tests/test_manifest.py` passes; `web/algorithms.json` regenerated (28 algorithms).

Draft because a maintainer must still run the local licensed compile + Dropbox weights fetch + GHCR push before this can score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)