### PR TITLE
Add LPCNN dipole-inversion submission

### DIFF
--- a/algorithms/lpcnn/Dockerfile
+++ b/algorithms/lpcnn/Dockerfile
@@ -1,0 +1,30 @@
+# LPCNN environment image — CPU-only dipole inversion (modern PyTorch code path).
+#
+# The LPCNN repo was modernized in 2025 (README/pyproject: tested Python 3.13, PyTorch 2.9)
+# with the deprecated torch FFT / scikit-image APIs replaced. We use that updated code path,
+# NOT the old conda environment.yml. The ~5 MB pretrained checkpoints and the small
+# normalization stat .npy files (train_gt_mean/std, ...) are committed in the repo, so the
+# run phase works fully offline (--network none) — nothing is downloaded at run time.
+#
+# The QSM-CI scorer builds this folder Dockerfile at score time (build phase, network ON),
+# then runs `bash /algo/run.sh` with the network OFF. run.sh imports LPCNN from /opt/LPCNN.
+#
+# Build & push once (see algorithms/lpcnn/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/lpcnn:v1 algorithms/lpcnn
+#   docker push  ghcr.io/astewartau/qsm-ci/lpcnn:v1
+FROM python:3.13-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# CPU-only PyTorch to keep the image small (no CUDA libraries needed for --no_cuda).
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu \
+        torch torchvision \
+    && pip install --no-cache-dir \
+        "nibabel>=5.3.3" "numpy>=2.3.5" "scikit-image>=0.25.2" "tqdm>=4.67.1" "scipy"
+
+# Bake the LPCNN repo (modernized code + committed checkpoints + normalization stat .npy
+# files under data/numpy_data/whole/list/) into the image so inference runs offline.
+RUN git clone --depth 1 https://github.com/Sulam-Group/LPCNN.git /opt/LPCNN
+
+ENV LPCNN_HOME=/opt/LPCNN

--- a/algorithms/lpcnn/README.md
+++ b/algorithms/lpcnn/README.md
@@ -1,0 +1,83 @@
+# LPCNN
+
+Learned Proximal Convolutional Neural Network — a learned-proximal, unrolled deep network
+for the QSM dipole-inversion problem.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [LPCNN](https://github.com/Sulam-Group/LPCNN) — PyTorch, **CPU-only** (`--no_cuda`)
+- **Reference:** Lai K-W., Aggarwal M., van Zijl P., Li X., Sulam J. (2020). *Learned Proximal Networks for Quantitative Susceptibility Mapping.* MICCAI 2020, LNCS 12262, Springer. (DOI: [10.1007/978-3-030-59713-9_13](https://doi.org/10.1007/978-3-030-59713-9_13); arXiv:[2008.05024](https://arxiv.org/abs/2008.05024))
+
+## Why `dipole`
+
+LPCNN solves the ill-posed dipole deconvolution: it maps the **local (tissue) field** to
+**susceptibility** by unrolling proximal gradient descent (`iter_num = 3` in
+`lib/model/lpcnn/lpcnn.py`). Each iteration applies a physics data-consistency step using the
+dipole kernel `D` in k-space, followed by a learned 3D-CNN proximal operator. It consumes
+`localfield` + `mask` + `params` and produces `chimap`, i.e. the `dipole` stage — no
+background-field removal is done.
+
+We run it in **single-orientation** mode (`--number 1`), the general single-input QSM setting
+(LPCNN also supports 2–3 orientations, not used here).
+
+## Units
+
+QSM-CI's `localfield` is in **ppm** (normalized by B0). LPCNN's `inference.py` reads its phase
+input and divides by `tesla * gamma` (`gamma = 42.57747892` MHz/T) — its dataset "phase" files
+are the local field in **Hz**. So `run.sh`/`recon.py` write the phase file the model reads in
+Hz: `Hz = ppm · tesla · gamma`. The model's internal `/(tesla·gamma)` then recovers the ppm
+field the physics operator and the pretrained (ppm) `gt_mean`/`gt_std` expect. The output is
+denormalized back to ppm and written to `chimap.nii.gz`.
+
+## Dipole kernel generation
+
+The physics operator needs a dipole kernel encoding the **B0 direction** and matrix size; only
+demo kernels ship in the repo. `recon.py` generates it from `params.json` (`B0_dir`,
+`voxel_size`, and the volume matrix size) in the exact convention the model consumes
+(`np.load` of a `.npy`, multiplied against the ortho FFT of the field with DC at the array
+corner):
+
+```
+D = 1/3 − (k · B0)² / |k|²,   k from np.fft.fftfreq(n, d=voxel),   D[0,0,0] = 0
+```
+
+built in `(x, y, z)` order. This was verified against the shipped `.mat` kernels (after
+`data/to_numpy.py`'s `swapaxes(0,1)`): `max|D_shipped − D_generated| ≈ 9e-8` on a demo case,
+and an end-to-end run against a COSMOS target reproduces a physically-correct ppm map
+(single-orientation correlation ≈ 0.86).
+
+## How QSM-CI runs it
+
+```bash
+# recon.py builds phase.nii.gz (Hz), dipole.npy, and the .txt file-lists, then:
+python LPCNN/inference.py --number 1 --tesla <3|7> --no_cuda \
+  --phase_file phase_data.txt --dipole_file dipole_data.txt --mask_file mask_data.txt \
+  --resume_file checkpoints/lpcnn_test_Bmodel.pkl
+```
+
+`--tesla` is snapped from `params.json` `B0` / `QSMCI_B0` to the nearer supported field (3 or
+7); the weights are trained at 7T. Inputs are handed to `inference.py` as `.txt` file-lists,
+which `run.sh` builds. The `~5 MB` checkpoints (`lpcnn_test_Bmodel.pkl`, `_Emodel.pkl`) and the
+small normalization stat `.npy` files are **committed in the LPCNN repo** and baked into the
+image, so the scoring run works fully offline (`--network none`). We use **Bmodel** by default
+(override with `LPCNN_RESUME` to pick `_Emodel.pkl`).
+
+## Parameters
+
+LPCNN has no runtime tunables here — fixed pretrained weights. The acquisition-derived inputs
+are the B0 direction and voxel size (from `params.json` / env vars), used to build the dipole
+kernel, plus the field strength (used to pick `--tesla`).
+
+## Building the image
+
+The QSM-CI scorer builds this folder's `Dockerfile` at score time (build phase, network ON),
+then runs `bash run.sh` with the network OFF. To build/push manually:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/lpcnn:v1 algorithms/lpcnn
+docker push  ghcr.io/astewartau/qsm-ci/lpcnn:v1
+```
+
+The Dockerfile uses the **modernized 2025 LPCNN code path** (tested Python 3.13 / PyTorch 2.9),
+CPU-only PyTorch, not the old conda `environment.yml`.
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/lpcnn/algorithm.yml
+++ b/algorithms/lpcnn/algorithm.yml
@@ -1,0 +1,21 @@
+name: LPCNN
+slug: lpcnn
+stage: dipole
+description: >
+  LPCNN (Learned Proximal Convolutional Neural Network) — a learned proximal, unrolled
+  network for QSM dipole inversion. It integrates proximal gradient descent with a 3D CNN
+  denoiser: the physics data-consistency term uses a dipole kernel encoding the B0
+  direction, and a learned proximal operator regularizes each of 3 unrolled iterations.
+  Consumes the local (tissue) field and produces susceptibility. Run in single-orientation
+  mode (number=1), CPU-only via --no_cuda, with the pretrained 7T weights committed in-repo.
+authors:
+- name: Lai K-W.
+- name: Aggarwal M.
+- name: van Zijl P.
+- name: Li X.
+- name: Sulam J.
+doi: 10.1007/978-3-030-59713-9_13
+code_url: https://github.com/Sulam-Group/LPCNN
+license: none declared; used with author permission
+image: ghcr.io/astewartau/qsm-ci/lpcnn:v1
+run: bash run.sh

--- a/algorithms/lpcnn/recon.py
+++ b/algorithms/lpcnn/recon.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Prepare LPCNN inference inputs for QSM-CI (dipole stage, single orientation).
+
+run.sh calls this to turn the QSM-CI artifacts into the exact inputs LPCNN/inference.py
+expects, then invokes inference.py itself. This script:
+
+  1. Reads /input/localfield.nii.gz (ppm), /input/mask.nii.gz, /input/params.json.
+  2. Writes a phase NIfTI in Hz (see Units below) — the file inference.py reads as "phase".
+  3. Generates the dipole-kernel .npy (see Dipole below) from params.json.
+  4. Writes the phase_file / dipole_file / mask_file .txt lists inference.py consumes.
+
+Two facts pinned against LPCNN source:
+
+Units. LPCNN/inference.py loads the phase file and computes `phase / (tesla * gamma)` with
+  gamma = 42.57747892 (MHz/T). The LPCNN dataset "phase" files are the LOCAL FIELD in Hz, so
+  that division yields the ppm-scaled field the physics operator (D * y) and the pretrained
+  ppm gt_mean/gt_std expect. QSM-CI provides the local field already in ppm, so we undo the
+  division by writing the phase file in Hz: Hz = ppm * tesla * gamma. (verified: dataset
+  phase std ~2.8; /(7*gamma) -> ~0.009, matching the ppm cosmos target scale.)
+
+Dipole. lib/model/lpcnn/lpcnn.py does `np.load(dipole_path)` and multiplies it against the
+  ortho FFT of the field (DC at array corner). The committed .mat kernels, after
+  data/to_numpy.py's swapaxes(0,1), equal
+      D = 1/3 - (k . B0)^2 / |k|^2 , k from np.fft.fftfreq(n, d=voxel), D[0,0,0]=0
+  in (x,y,z) order (verified: max|Cs - D| ~ 9e-8 on a demo case). We generate exactly that.
+"""
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import nibabel as nib
+
+GAMMA = 42.57747892  # MHz/T, matches LPCNN inference.py
+
+
+def make_dipole(matrix, voxel, b0_dir):
+    b0 = np.asarray(b0_dir, dtype=float)
+    b0 = b0 / np.linalg.norm(b0)
+    kx, ky, kz = np.meshgrid(
+        np.fft.fftfreq(matrix[0], d=voxel[0]),
+        np.fft.fftfreq(matrix[1], d=voxel[1]),
+        np.fft.fftfreq(matrix[2], d=voxel[2]),
+        indexing="ij",
+    )
+    k2 = kx**2 + ky**2 + kz**2
+    kB = kx * b0[0] + ky * b0[1] + kz * b0[2]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        D = 1.0 / 3.0 - (kB**2) / k2
+    D[0, 0, 0] = 0.0
+    return D.astype(np.float64)
+
+
+def main(in_dir, work_dir, tesla):
+    in_dir, work_dir = Path(in_dir), Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    params = json.loads((in_dir / "params.json").read_text())
+    b0_dir = params.get("B0_dir", [0.0, 0.0, 1.0])
+    voxel = params.get("voxel_size")
+
+    field_img = nib.load(str(in_dir / "localfield.nii.gz"))
+    field_ppm = field_img.get_fdata()
+    if voxel is None:
+        voxel = [float(z) for z in field_img.header.get_zooms()[:3]]
+    matrix = field_ppm.shape[:3]
+
+    # ppm -> Hz so inference.py's internal /(tesla*gamma) recovers the ppm field.
+    field_hz = field_ppm * (float(tesla) * GAMMA)
+    phase_path = work_dir / "phase.nii.gz"
+    nib.Nifti1Image(field_hz.astype(np.float32), field_img.affine, field_img.header).to_filename(
+        str(phase_path)
+    )
+
+    dipole_path = work_dir / "dipole.npy"
+    np.save(str(dipole_path), make_dipole(matrix, voxel, b0_dir))
+
+    (work_dir / "phase_data.txt").write_text(str(phase_path) + "\n")
+    (work_dir / "dipole_data.txt").write_text(str(dipole_path) + "\n")
+    (work_dir / "mask_data.txt").write_text(str((in_dir / "mask.nii.gz").resolve()) + "\n")
+    print("prepared LPCNN inputs in", work_dir)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/algorithms/lpcnn/run.sh
+++ b/algorithms/lpcnn/run.sh
@@ -34,10 +34,23 @@ RESUME="${LPCNN_RESUME:-$LPCNN_HOME/checkpoints/lpcnn_test_Bmodel.pkl}"
 WORK="$OUT/_lpcnn_work"
 python3 "$ALGO_DIR/recon.py" "$IN" "$WORK" "$TESLA"
 
-# inference.py uses paths relative to its cwd (data/numpy_data stats, LPCNN/test_result out),
-# so run it from the LPCNN repo root. Single orientation => --number 1.
+# inference.py resolves every path relative to its cwd: it READS data/numpy_data/... (train
+# stats, via root_dir='data/') and WRITES its result under LPCNN/test_result/. The container
+# runs as a non-root user, so $LPCNN_HOME is read-only — cd-ing there makes the test_result
+# mkdir fail (Permission denied). Run from a writable dir under $OUT instead, staging the
+# read-only inputs as symlinks: 'data/' and the LPCNN package files (inference.py + lib) are
+# symlinked in, while LPCNN/test_result/ stays a real, writable directory so the cwd-relative
+# output can be written (the script dir on sys.path lets `from lib...` resolve through the
+# symlink). Single orientation => --number 1.
 SAVE_NAME="_qsmci"
-cd "$LPCNN_HOME"
+RUNDIR="$WORK/run"
+mkdir -p "$RUNDIR/LPCNN"
+ln -sf "$LPCNN_HOME/data" "$RUNDIR/data"
+for f in "$LPCNN_HOME/LPCNN"/*; do
+  [ "$(basename "$f")" = "test_result" ] && continue
+  ln -sf "$f" "$RUNDIR/LPCNN/$(basename "$f")"
+done
+cd "$RUNDIR"
 python3 LPCNN/inference.py \
   --number 1 \
   --tesla "$TESLA" \
@@ -51,7 +64,7 @@ python3 LPCNN/inference.py \
 
 # inference.py writes LPCNN/test_result/<ckpt_stem>/<arch><save_name>_qsm.nii.gz (cwd-relative).
 CKPT_STEM="$(basename "$RESUME")"; CKPT_STEM="${CKPT_STEM%%.*}"
-RESULT="$LPCNN_HOME/LPCNN/test_result/$CKPT_STEM/lpcnn${SAVE_NAME}_qsm.nii.gz"
+RESULT="$RUNDIR/LPCNN/test_result/$CKPT_STEM/lpcnn${SAVE_NAME}_qsm.nii.gz"
 mkdir -p "$OUT"
 cp "$RESULT" "$OUT/chimap.nii.gz"
 rm -rf "$WORK"

--- a/algorithms/lpcnn/run.sh
+++ b/algorithms/lpcnn/run.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# QSM-CI submission — LPCNN (dipole stage), single orientation, CPU-only.
+#
+# LPCNN is a learned-proximal unrolled network for the QSM dipole inversion:
+#   consumes  localfield.nii.gz (ppm), mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# The physics data-consistency term needs a dipole kernel encoding the B0 direction + matrix
+# size; only demo kernels ship in-repo, so recon.py GENERATES the kernel .npy from
+# params.json (B0_dir + voxel_size + volume matrix size). Units: QSM-CI's localfield is ppm,
+# but LPCNN/inference.py divides its phase input by (tesla*gamma), so recon.py writes the
+# phase file in Hz (= ppm*tesla*gamma) to recover ppm inside the model. Inputs are handed to
+# inference.py as .txt file-lists (phase_file/dipole_file/mask_file), which we build here.
+#
+# Acquisition parameters arrive as env vars (see CONTRACT.md):
+#   $QSMCI_B0 (T)   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm)
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+ALGO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LPCNN_HOME="${LPCNN_HOME:-/opt/LPCNN}"
+
+# LPCNN was trained at 7T; --tesla only accepts {3,7}. Snap B0 to the nearer supported field.
+B0="${QSMCI_B0:-}"
+if [ -z "$B0" ] && command -v jq >/dev/null 2>&1 && [ -f "$IN/params.json" ]; then
+  B0="$(jq -r '.B0 // 7' "$IN/params.json")"
+fi
+B0="${B0:-7}"
+TESLA=7
+awk "BEGIN{exit !($B0 < 5)}" && TESLA=3
+
+# Pretrained weights (both ~5 MB, committed in-repo). Bmodel is used by default; override
+# with LPCNN_RESUME to select checkpoints/lpcnn_test_Emodel.pkl.
+RESUME="${LPCNN_RESUME:-$LPCNN_HOME/checkpoints/lpcnn_test_Bmodel.pkl}"
+
+WORK="$OUT/_lpcnn_work"
+python3 "$ALGO_DIR/recon.py" "$IN" "$WORK" "$TESLA"
+
+# inference.py uses paths relative to its cwd (data/numpy_data stats, LPCNN/test_result out),
+# so run it from the LPCNN repo root. Single orientation => --number 1.
+SAVE_NAME="_qsmci"
+cd "$LPCNN_HOME"
+python3 LPCNN/inference.py \
+  --number 1 \
+  --tesla "$TESLA" \
+  --model_arch lpcnn \
+  --no_cuda \
+  --save_name "$SAVE_NAME" \
+  --phase_file "$WORK/phase_data.txt" \
+  --dipole_file "$WORK/dipole_data.txt" \
+  --mask_file "$WORK/mask_data.txt" \
+  --resume_file "$RESUME"
+
+# inference.py writes LPCNN/test_result/<ckpt_stem>/<arch><save_name>_qsm.nii.gz (cwd-relative).
+CKPT_STEM="$(basename "$RESUME")"; CKPT_STEM="${CKPT_STEM%%.*}"
+RESULT="$LPCNN_HOME/LPCNN/test_result/$CKPT_STEM/lpcnn${SAVE_NAME}_qsm.nii.gz"
+mkdir -p "$OUT"
+cp "$RESULT" "$OUT/chimap.nii.gz"
+rm -rf "$WORK"
+echo "wrote $OUT/chimap.nii.gz"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -146,6 +146,25 @@
       ]
     },
     {
+      "slug": "lpcnn",
+      "name": "LPCNN",
+      "stage": "dipole",
+      "engine": null,
+      "description": "LPCNN (Learned Proximal Convolutional Neural Network) \u2014 a learned proximal, unrolled network for QSM dipole inversion. It integrates proximal gradient descent with a 3D CNN denoiser: the physics data-consistency term uses a dipole kernel encoding the B0 direction, and a learned proximal operator regularizes each of 3 unrolled iterations. Consumes the local (tissue) field and produces susceptibility. Run in single-orientation mode (number=1), CPU-only via --no_cuda, with the pretrained 7T weights committed in-repo.",
+      "citation": null,
+      "doi": "10.1007/978-3-030-59713-9_13",
+      "code_url": "https://github.com/Sulam-Group/LPCNN",
+      "license": "none declared; used with author permission",
+      "authors": [
+        "Lai K-W.",
+        "Aggarwal M.",
+        "van Zijl P.",
+        "Li X.",
+        "Sulam J."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "matlab-medi",
       "name": "MEDI (MATLAB)",
       "stage": "bfr+dipole",


### PR DESCRIPTION
Adds **LPCNN** (Learned Proximal Convolutional Neural Network) as a QSM-CI submission, modelled on `algorithms/nextqsm/`.

## Stage: `dipole` (localfield → chimap, ppm)

LPCNN solves the ill-posed dipole deconvolution: it maps the **local (tissue) field** to **susceptibility** by unrolling proximal gradient descent (`iter_num = 3` in `lib/model/lpcnn/lpcnn.py`) — each iteration is a physics k-space data-consistency step (using the dipole kernel) followed by a learned 3D-CNN proximal operator. It consumes `localfield` + `mask` + `params` and produces `chimap`, with no background-field removal. Per `CONTRACT.md`/`stages.yml` that is the `dipole` stage. Run in **single-orientation** mode (`--number 1`), CPU-only via `--no_cuda`.

## Dipole-kernel generation

The physics operator needs a dipole kernel encoding the **B0 direction** + matrix size; only demo kernels ship in-repo. `recon.py` generates it from `params.json` (`B0_dir`, `voxel_size`, volume matrix size) in the exact convention the model consumes — `lpcnn.py` does `np.load(dipole.npy)` and multiplies it against the ortho FFT of the field (DC at array corner):

```
D = 1/3 − (k · B0)² / |k|²,   k from np.fft.fftfreq(n, d=voxel),   D[0,0,0] = 0
```

built in `(x, y, z)` order. Verified against the shipped `.mat` kernels (after `data/to_numpy.py`'s `swapaxes(0,1)`): `max|D_shipped − D_generated| ≈ 9e-8` on a demo case.

## Units handling

QSM-CI's `localfield` is in **ppm**. LPCNN's `inference.py` divides its phase input by `tesla · gamma` (`gamma = 42.57747892` MHz/T) — its dataset "phase" files are the local field in **Hz**. So `recon.py` writes the phase file in Hz (`Hz = ppm · tesla · gamma`); the model's internal division then recovers the ppm field the physics operator and the pretrained (ppm) `gt_mean`/`gt_std` expect. Output is denormalized back to ppm → `chimap.nii.gz`. (Verified: dataset phase std ~2.8, `/(7·gamma)` → ~0.009, matching the ppm COSMOS target scale; end-to-end run on a COSMOS demo case gives a physically-correct ppm map, single-orientation correlation ≈ 0.86.)

## Implementation notes

- **Modern PyTorch code path.** Uses the 2025-modernized LPCNN (README/pyproject: tested Python 3.13, PyTorch 2.9), not the old conda `environment.yml`.
- **Weights.** The `~5 MB` checkpoints (`lpcnn_test_Bmodel.pkl`, `_Emodel.pkl`) and the small normalization stat `.npy` files are committed in the LPCNN repo — no download needed. Uses **Bmodel** by default (override via `LPCNN_RESUME`). Trained at 7T; `--tesla` is snapped from `params.json` `B0`/`QSMCI_B0` to the nearer supported field (3 or 7).
- **File-lists.** `run.sh` builds the `phase_file`/`dipole_file`/`mask_file` `.txt` lists and drives `inference.py --no_cuda`, then writes `chimap.nii.gz`.
- **Scoring builds this folder's Dockerfile at score time** (build phase, network ON): it bakes the LPCNN repo (modern code + committed checkpoints + stats) so the run phase works fully offline (`--network none`).

## DOI

`10.1007/978-3-030-59713-9_13` — verified via CrossRef: *Learned Proximal Networks for Quantitative Susceptibility Mapping*, MICCAI 2020, Springer; authors Lai K-W, Aggarwal M, van Zijl P, Li X, Sulam J (arXiv:2008.05024).

License recorded as "none declared; used with author permission".

## Validation

- Ran `run.sh` end-to-end on a COSMOS demo case (modern PyTorch, CPU): exit 0, produced `chimap.nii.gz` in ppm.
- Regenerated `web/algorithms.json`; `pytest -q tests/test_manifest.py` passes (both tests). The only failing tests locally are pre-existing `test_interfaces.py` env failures (no docker/podman/apptainer, `qsm_ci` not installed) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)