### PR TITLE
Add QSMGAN dipole submission

### DIFF
--- a/algorithms/qsmgan/Dockerfile
+++ b/algorithms/qsmgan/Dockerfile
@@ -1,0 +1,46 @@
+# QSMGAN environment image — CPU-only, patch-based inference (no GPU).
+#
+# QSMGAN (Chen et al., NeuroImage 2020) is a 3D U-Net generator refined by a WGAN-GP.
+# The published code targets "PyTorch >= 0.4"; the released checkpoints are the legacy
+# (pre-1.6, tar/pickle) torch.save format. The state_dict is only standard
+# Conv3d/BatchNorm3d/ConvTranspose3d layers, so a legacy torch loads and runs it as-is
+# — we do NOT rewrite the model, only vendor its UNet3D definition in recon.py.
+#
+# Pinning: Python 3.7 + the legacy CPU wheel torch==1.1.0 from the PyTorch download
+# index. torch 1.1.0 (May 2019) is contemporaneous with the QSMGAN release (checkpoints
+# dated 2019) and satisfies the code's "PyTorch >= 0.4" requirement. We do NOT use the
+# 0.4.1 wheel: its prebuilt cu92 binary was compiled WITHOUT NumPy support, so
+# torch.from_numpy() raises at runtime. 1.1.0 is the lowest legacy torch that both loads
+# the pre-1.6 checkpoint AND has working NumPy interop.
+#
+# Weights (~30 MB total) are committed in the working fork and unzipped at BUILD time
+# (network is on only during build); the run phase is offline (--network none).
+#
+# Build & push once (see algorithms/qsmgan/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/qsmgan:v1 algorithms/qsmgan
+#   docker push  ghcr.io/astewartau/qsm-ci/qsmgan:v1
+FROM python:3.7-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Legacy PyTorch (CPU). torch 0.4.1 is the version the QSMGAN code was written for and
+# is published as a cp37 CPU wheel on the PyTorch index. numpy/nibabel are pinned to
+# versions that still support py3.7 and the old torch ABI.
+RUN pip install --no-cache-dir "numpy<1.20" \
+    && pip install --no-cache-dir \
+        torch==1.1.0 -f https://download.pytorch.org/whl/torch_stable.html \
+    && pip install --no-cache-dir "nibabel==3.2.2" "scipy<1.6"
+
+# Fetch the WGAN-refined generator weights from the working fork and unzip. The
+# official LupoLab-UCSF/QSMGAN repo ships README only; the fork below carries the
+# code + committed checkpoints (UNet3D_i64o48.zip, WGAN_i64o48.zip). We use the
+# WGAN generator (the checkpoint the upstream NIFTI inference script loads).
+RUN git clone --depth 1 https://github.com/mmorri10/QSMGAN-LupoLab /tmp/qsmgan \
+    && mkdir -p /opt/qsmgan \
+    && unzip -q /tmp/qsmgan/WGAN_i64o48.zip -d /opt/qsmgan \
+    && unzip -q /tmp/qsmgan/UNet3D_i64o48.zip -d /opt/qsmgan \
+    && rm -rf /tmp/qsmgan
+
+ENV CUDA_VISIBLE_DEVICES="-1" \
+    QSMGAN_WEIGHTS="/opt/qsmgan/WGAN_i64o48"

--- a/algorithms/qsmgan/Dockerfile
+++ b/algorithms/qsmgan/Dockerfile
@@ -36,11 +36,16 @@ RUN pip install --no-cache-dir "numpy<1.20" \
 # official LupoLab-UCSF/QSMGAN repo ships README only; the fork below carries the
 # code + committed checkpoints (UNet3D_i64o48.zip, WGAN_i64o48.zip). We use the
 # WGAN generator (the checkpoint the upstream NIFTI inference script loads).
+# The committed .zip preserves the checkpoints' original 0660 root:root perms; the
+# scorer runs the container as a non-root user (docker run --user <uid>:<gid>), which
+# then can't read config.json / net_best.pt (recon.py -> PermissionError). chmod the
+# tree world-readable so inference works regardless of the run uid.
 RUN git clone --depth 1 https://github.com/mmorri10/QSMGAN-LupoLab /tmp/qsmgan \
     && mkdir -p /opt/qsmgan \
     && unzip -q /tmp/qsmgan/WGAN_i64o48.zip -d /opt/qsmgan \
     && unzip -q /tmp/qsmgan/UNet3D_i64o48.zip -d /opt/qsmgan \
-    && rm -rf /tmp/qsmgan
+    && rm -rf /tmp/qsmgan \
+    && chmod -R a+rX /opt/qsmgan
 
 ENV CUDA_VISIBLE_DEVICES="-1" \
     QSMGAN_WEIGHTS="/opt/qsmgan/WGAN_i64o48"

--- a/algorithms/qsmgan/README.md
+++ b/algorithms/qsmgan/README.md
@@ -1,0 +1,83 @@
+# QSMGAN
+
+Efficient and accurate QSM dipole inversion by a 3D U-Net generator refined with a
+Wasserstein GAN (WGAN-GP) and an increased receptive field.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [QSMGAN](https://github.com/mmorri10/QSMGAN-LupoLab) — PyTorch (legacy), **CPU-only**
+- **Reference:** Chen Y., Jakary A., Avadiappan S., Hess C.P., Lupo J.M. (2020). *QSMGAN: Improved Quantitative Susceptibility Mapping using 3D Generative Adversarial Networks with increased receptive field.* NeuroImage, 207, 116389. (DOI: [10.1016/j.neuroimage.2019.116389](https://doi.org/10.1016/j.neuroimage.2019.116389))
+
+## Why `dipole`
+
+QSMGAN learns the dipole inversion only. Upstream, the network is fed the
+background-removed **local field** (their pipeline runs SEPIA for background field
+removal first) and outputs susceptibility. It does not do field mapping or background
+removal itself, so it maps exactly onto the QSM-CI `dipole` stage: consumes
+`localfield.nii.gz`, `mask.nii.gz`, `params.json`; produces `chimap.nii.gz`.
+
+The architecture is a 3D U-Net **generator** (`UNet3D`, 4 pool layers, LeakyReLU,
+BatchNorm, tanh output head) trained first with an L1 objective and then refined
+adversarially by a WGAN-GP discriminator. We load the WGAN-refined generator
+(`WGAN_i64o48/net_best.pt`) — the checkpoint the upstream NIFTI inference script uses.
+
+## Source: official repo has no code
+
+The official repository [LupoLab-UCSF/QSMGAN](https://github.com/LupoLab-UCSF/QSMGAN)
+is **README only** — no code and no weights. This submission uses the working fork
+[mmorri10/QSMGAN-LupoLab](https://github.com/mmorri10/QSMGAN-LupoLab), which carries the
+PyTorch code and the committed checkpoints (`UNet3D_i64o48.zip`, `WGAN_i64o48.zip`).
+Both repos are MIT-licensed (the fork's LICENSE is © 2021 Melanie A. Morrison).
+
+## Units
+
+QSMGAN expects the SEPIA **local field in ppm**. QSM-CI's `localfield.nii.gz` is already
+a background-removed local field in ppm on the mask grid, which is exactly that — no
+rescaling of the input units is applied. The network's own internal normalization
+(`input_scale = 100`; output head `tanh`, `output_scale = 10`, so
+`chi = arctanh(net_out) / 10`) is reproduced verbatim in `recon.py` from the upstream
+config. Output is in ppm on the input grid.
+
+## Patch-based inference and stitching
+
+Inference is patch-based with an **increased receptive field**: a 64³ input patch is
+mapped to a 48³ output patch (a center receptive-field crop) — the "i64o48" scheme.
+`recon.py` tiles the volume by non-overlapping 48³ **output** patches; each output
+patch's 64³ **input** patch is the same center with an 8-voxel context margin per side,
+zero-padded at the volume edges. Output patches are placed back and clipped to the
+volume bounds, so arbitrary volume shapes (not just multiples of 48) are handled. The
+result is masked by `mask.nii.gz`.
+
+Unlike the upstream `QsmPatchDataHD`, we deliberately **skip** its hard-coded
+`[1, 1, 1/0.8]` resolution zoom (that is specific to one 0.8 mm HD scanner); QSM-CI
+data is already on the mask grid, so the output stays on the input grid.
+
+## Legacy PyTorch pinning
+
+The published code targets "PyTorch >= 0.4" and the released checkpoints are the legacy
+(pre-1.6, tar/pickle) `torch.save` format. The image pins **`torch==1.1.0`** (CPU) on
+**Python 3.7** — contemporaneous with the 2019 release and the lowest legacy torch that
+both loads the checkpoint and has working NumPy interop. (The `torch==0.4.1` prebuilt
+wheel was compiled *without* NumPy support, so `torch.from_numpy()` raises at runtime;
+1.1.0 is used instead.) The `UNet3D` generator is **not** rewritten — its definition is
+vendored verbatim into `recon.py` and the state_dict is loaded as-is.
+
+## Parameters
+
+QSMGAN has no runtime tunables — it uses fixed pretrained weights. The B0 direction is
+not needed (the network learned the dipole implicitly for axial acquisition).
+
+## Building the image
+
+The environment image must be built and pushed before scoring works (the run phase has
+no network, so weights cannot be fetched at run time). The ~30 MB checkpoints are cloned
+from the fork and unzipped at **build** time:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/qsmgan:v1 algorithms/qsmgan
+docker push  ghcr.io/astewartau/qsm-ci/qsmgan:v1
+```
+
+QSM-CI builds this folder's `Dockerfile` at score time to produce the environment; your
+`run.sh` + `recon.py` are then mounted read-only at `/algo` and run offline.
+
+_Citations/DOIs are auto-generated best-effort references and should be verified._

--- a/algorithms/qsmgan/algorithm.yml
+++ b/algorithms/qsmgan/algorithm.yml
@@ -1,0 +1,20 @@
+name: QSMGAN
+slug: qsmgan
+stage: dipole
+description: >
+  QSMGAN — dipole inversion by a 3D U-Net generator refined with a WGAN-GP and an
+  increased receptive field. Consumes the background-removed local field (ppm) and
+  produces susceptibility. Patch-based inference: 64^3 input patches are mapped to
+  48^3 receptive-field-cropped output patches (i64o48) and stitched. Runs CPU-only on
+  legacy PyTorch with the published WGAN-refined generator weights.
+authors:
+- name: Chen Y.
+- name: Jakary A.
+- name: Avadiappan S.
+- name: Hess C.P.
+- name: Lupo J.M.
+doi: 10.1016/j.neuroimage.2019.116389
+code_url: https://github.com/mmorri10/QSMGAN-LupoLab
+license: MIT
+image: ghcr.io/astewartau/qsm-ci/qsmgan:v1
+run: bash run.sh

--- a/algorithms/qsmgan/recon.py
+++ b/algorithms/qsmgan/recon.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""QSMGAN dipole inversion for QSM-CI (CPU-only, patch-based inference).
+
+QSMGAN is a 3D U-Net generator refined by a WGAN-GP that maps a background-removed
+LOCAL field (in ppm) directly to susceptibility (chimap, ppm). This is the `dipole`
+stage: consumes localfield + mask (+ params), produces chimap.
+
+The generator (UNet3D) is defined here verbatim from the upstream fork
+(mmorri10/QSMGAN-LupoLab, models/unet3d.py) so inference does not depend on the
+fork's package layout. We load the WGAN-refined generator weights
+(WGAN_i64o48/net_best.pt, the checkpoint the upstream NIFTI inference script uses)
+and reproduce the upstream patch pipeline (utils/data.py QsmPatchDataHD +
+predict.py QsmPredict.run_net):
+
+  * input patch  64^3, output (receptive-field crop) 48^3  ->  i64o48
+  * input_scale  = 100   (localfield ppm is multiplied by this before the net)
+  * output_scale = 10, output_transform = tanh -> inverse is arctanh
+        chi_patch = arctanh(net_out) / output_scale
+  * the volume is tiled by 48^3 OUTPUT patches; each 64^3 input patch is the same
+    centre with an 8-voxel context margin; out-of-bounds voxels are zero-padded.
+
+Deviations from upstream, deliberate and documented:
+  * NO 0.8 mm resolution zoom. QsmPatchDataHD hard-codes a [1,1,1/0.8] zoom for one
+    specific HD scanner; QSM-CI localfield is already on the mask grid, so we skip it
+    and keep the output on the input grid.
+  * The output is masked by mask.nii.gz (QSMGAN outputs ~0 outside the brain anyway).
+"""
+import json
+import os
+import sys
+
+import numpy as np
+import nibabel as nib
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+# --------------------------------------------------------------------------- model
+# Verbatim from mmorri10/QSMGAN-LupoLab code_pytorch_v3/models/unet3d.py.
+def center_crop_3d(x, crop_shape):
+    assert len(crop_shape) == 3
+    w1, w2, w3 = x.shape[2:]
+    c1, c2, c3 = crop_shape
+    assert w1 >= c1 and w2 >= c2 and w2 >= c3
+    s1, s2, s3 = w1 // 2 - c1 // 2, w1 // 2 - c2 // 2, w3 // 2 - c3 // 2
+    e1, e2, e3 = s1 + c1, s2 + c2, s3 + c3
+    return x[..., s1:e1, s2:e2, s3:e3]
+
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_chans, out_chans, drop_prob, non_lin='ReLU', norm='none'):
+        super().__init__()
+        self.in_chans, self.out_chans = in_chans, out_chans
+        self.drop_prob, self.non_lin, self.norm = drop_prob, non_lin, norm
+        layers = []
+        for _ in range(2):
+            layers.append(nn.Conv3d(in_chans if not layers else out_chans, out_chans,
+                                    kernel_size=3, padding=1))
+            if norm == 'BatchNorm':
+                layers.append(nn.BatchNorm3d(out_chans))
+            elif norm == 'InstanceNorm':
+                layers.append(nn.InstanceNorm3d(out_chans))
+            elif norm == 'LayerNorm':
+                layers.append(nn.LayerNorm(out_chans))
+            if non_lin == 'ReLU':
+                layers.append(nn.ReLU())
+            elif non_lin == 'LReLU':
+                layers.append(nn.LeakyReLU(0.1))
+        self.layers = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.layers(x)
+
+
+class UNet3D(nn.Module):
+    def __init__(self, in_chans, out_chans, out_shape, chans, num_pool_layers,
+                 drop_prob, non_lin='ReLU', norm=None, tanh=False):
+        super().__init__()
+        self.out_shape = out_shape
+        self.down_sample_layers = nn.ModuleList(
+            [ConvBlock(in_chans, chans, drop_prob, non_lin, norm)])
+        ch = chans
+        for _ in range(num_pool_layers - 1):
+            self.down_sample_layers += [ConvBlock(ch, ch * 2, drop_prob, non_lin, norm)]
+            ch *= 2
+        self.conv = ConvBlock(ch, ch, drop_prob, non_lin, norm)
+
+        self.up_sample_layers = nn.ModuleList()
+        for _ in range(num_pool_layers - 1):
+            self.up_sample_layers += [ConvBlock(ch * 2, ch // 2, drop_prob, non_lin, norm)]
+            ch //= 2
+        self.up_sample_layers += [ConvBlock(ch * 2, ch, drop_prob, non_lin, norm)]
+
+        ch = chans * 2 ** (num_pool_layers - 1)
+        self.conv_transpose_layers = nn.ModuleList()
+        for _ in range(num_pool_layers):
+            self.conv_transpose_layers += [nn.ConvTranspose3d(ch, ch, kernel_size=2, stride=2)]
+            ch //= 2
+        ch *= 2
+        conv2 = [nn.Conv3d(ch, out_chans, kernel_size=1),
+                 nn.Conv3d(out_chans, out_chans, kernel_size=1)]
+        if tanh:
+            conv2.append(nn.Tanh())
+        self.conv2 = nn.Sequential(*conv2)
+
+    def forward(self, x):
+        stack = []
+        out = x
+        for layer in self.down_sample_layers:
+            out = layer(out)
+            stack.append(out)
+            out = F.avg_pool3d(out, kernel_size=2)
+        out = self.conv(out)
+        for convtrans, layer in zip(self.conv_transpose_layers, self.up_sample_layers):
+            out = convtrans(out)
+            out = torch.cat([out, stack.pop()], dim=1)
+            out = layer(out)
+        out = self.conv2(out)
+        out = center_crop_3d(out, self.out_shape)
+        return out
+
+
+# ----------------------------------------------------------------------- inference
+def get_patch(vol, center, patch):
+    """Zero-padded patch of size `patch` centred at `center` (upstream _get_patch)."""
+    def coords(c, p, m):
+        L, R = c - p // 2, c + p // 2
+        ml, mr = max(L, 0), min(m, R)
+        pl = 0 if L >= 0 else -L
+        pr = p if R <= m else p - (R - m)
+        return ml, mr, pl, pr
+    out = np.zeros(patch, dtype=np.float32)
+    ml1, mr1, pl1, pr1 = coords(center[0], patch[0], vol.shape[0])
+    ml2, mr2, pl2, pr2 = coords(center[1], patch[1], vol.shape[1])
+    ml3, mr3, pl3, pr3 = coords(center[2], patch[2], vol.shape[2])
+    out[pl1:pr1, pl2:pr2, pl3:pr3] = vol[ml1:mr1, ml2:mr2, ml3:mr3]
+    return out
+
+
+def main():
+    in_dir = sys.argv[1] if len(sys.argv) > 1 else '/input'
+    out_dir = sys.argv[2] if len(sys.argv) > 2 else '/output'
+    weights_dir = os.environ.get('QSMGAN_WEIGHTS', '/opt/qsmgan/WGAN_i64o48')
+
+    torch.set_num_threads(max(1, os.cpu_count() or 1))
+    device = torch.device('cpu')
+
+    with open(os.path.join(weights_dir, 'config.json')) as f:
+        cfg = json.load(f)
+    ips = tuple(cfg['dset_args']['input_patch_size'])    # (64,64,64)
+    ops = tuple(cfg['dset_args']['output_patch_size'])   # (48,48,48)
+    input_scale = cfg['dset_args']['input_scale']        # 100
+    output_scale = cfg['dset_args']['output_scale']      # 10
+    tanh_out = cfg['dset_args']['output_transform'] == 'tanh'
+
+    net = UNet3D(**cfg['netG_args']).to(device)
+    ckpt = torch.load(os.path.join(weights_dir, 'net_best.pt'), map_location=device)
+    net.load_state_dict(ckpt['netG'])
+    net.eval()
+
+    lf_nii = nib.load(os.path.join(in_dir, 'localfield.nii.gz'))
+    localfield = np.asarray(lf_nii.dataobj, dtype=np.float32)
+    localfield = np.nan_to_num(localfield)
+    mask = np.asarray(nib.load(os.path.join(in_dir, 'mask.nii.gz')).dataobj)
+    mask = (mask > 0).astype(np.float32)
+
+    X, Y, Z = localfield.shape
+    predict = np.zeros((X, Y, Z), dtype=np.float32)
+
+    # Tile the volume by OUTPUT (48^3) patches (upstream _calc_centers, sample 'other').
+    ox, oy, oz = (ops[0] // 2, ops[1] // 2, ops[2] // 2)
+    inv = np.arctanh if tanh_out else (lambda v: v)
+    with torch.no_grad():
+        for cx in range(ox, X + ox + 1, ops[0]):
+            for cy in range(oy, Y + oy + 1, ops[1]):
+                for cz in range(oz, Z + oz + 1, ops[2]):
+                    inp = get_patch(localfield, (cx, cy, cz), ips) * input_scale
+                    t = torch.from_numpy(inp).unsqueeze(0).unsqueeze(0).float().to(device)
+                    out = net(t).cpu().squeeze().numpy()
+                    if tanh_out:
+                        out = np.clip(out, -0.999999, 0.999999)
+                    patch = (inv(out) / output_scale).astype(np.float32)
+                    # place the 48^3 output patch, clipped to the volume bounds
+                    x0, y0, z0 = cx - ops[0] // 2, cy - ops[1] // 2, cz - ops[2] // 2
+                    xe = min(x0 + ops[0], X); ye = min(y0 + ops[1], Y); ze = min(z0 + ops[2], Z)
+                    px, py, pz = xe - x0, ye - y0, ze - z0
+                    if px <= 0 or py <= 0 or pz <= 0:
+                        continue
+                    predict[x0:xe, y0:ye, z0:ze] = patch[:px, :py, :pz]
+
+    predict = (predict * mask)
+    predict = np.nan_to_num(predict).astype(np.float32)
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_nii = nib.Nifti1Image(predict, lf_nii.affine, lf_nii.header)
+    nib.save(out_nii, os.path.join(out_dir, 'chimap.nii.gz'))
+    print(f'QSMGAN: wrote chimap.nii.gz shape={predict.shape} '
+          f'range=[{predict.min():.4f},{predict.max():.4f}]')
+
+
+if __name__ == '__main__':
+    main()

--- a/algorithms/qsmgan/run.sh
+++ b/algorithms/qsmgan/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# QSM-CI submission — QSMGAN (dipole stage), CPU-only.
+#
+# QSMGAN is a 3D U-Net generator refined by a WGAN-GP. It maps a background-removed
+# LOCAL field (in ppm) straight to susceptibility. Hence stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units: QSMGAN's upstream pipeline feeds it the SEPIA local field (background-removed,
+# ppm). QSM-CI's localfield.nii.gz is already that: a local field in ppm on the mask
+# grid. No rescaling of the input is applied here (the model's own input_scale=100 and
+# output_scale=10 / arctanh handling live in recon.py, matching the upstream config).
+#
+# Inference is patch-based: 64^3 input -> 48^3 receptive-field-cropped output (i64o48).
+# recon.py tiles the volume by 48^3 output patches and stitches them; see recon.py.
+#
+# Force CPU: no GPU at score time, and the legacy torch build runs CPU-only fine.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+export CUDA_VISIBLE_DEVICES="-1"
+export QSMGAN_WEIGHTS="${QSMGAN_WEIGHTS:-/opt/qsmgan/WGAN_i64o48}"
+
+# Code is mounted at /algo (see CONTRACT.md); weights are baked into the image.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+python "$SCRIPT_DIR/recon.py" "$IN" "$OUT"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -560,6 +560,25 @@
       "parameters": []
     },
     {
+      "slug": "qsmgan",
+      "name": "QSMGAN",
+      "stage": "dipole",
+      "engine": null,
+      "description": "QSMGAN \u2014 dipole inversion by a 3D U-Net generator refined with a WGAN-GP and an increased receptive field. Consumes the background-removed local field (ppm) and produces susceptibility. Patch-based inference: 64^3 input patches are mapped to 48^3 receptive-field-cropped output patches (i64o48) and stitched. Runs CPU-only on legacy PyTorch with the published WGAN-refined generator weights.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2019.116389",
+      "code_url": "https://github.com/mmorri10/QSMGAN-LupoLab",
+      "license": "MIT",
+      "authors": [
+        "Chen Y.",
+        "Jakary A.",
+        "Avadiappan S.",
+        "Hess C.P.",
+        "Lupo J.M."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "qsmnet",
       "name": "QSMnet",
       "stage": "dipole",
@@ -605,25 +624,6 @@
         "Nam Y.",
         "Kim E.Y.",
         "Lee J."
-      ],
-      "parameters": []
-    },
-    {
-      "slug": "qsmgan",
-      "name": "QSMGAN",
-      "stage": "dipole",
-      "engine": null,
-      "description": "QSMGAN \u2014 dipole inversion by a 3D U-Net generator refined with a WGAN-GP and an increased receptive field. Consumes the background-removed local field (ppm) and produces susceptibility. Patch-based inference: 64^3 input patches are mapped to 48^3 receptive-field-cropped output patches (i64o48) and stitched. Runs CPU-only on legacy PyTorch with the published WGAN-refined generator weights.",
-      "citation": null,
-      "doi": "10.1016/j.neuroimage.2019.116389",
-      "code_url": "https://github.com/mmorri10/QSMGAN-LupoLab",
-      "license": "MIT",
-      "authors": [
-        "Chen Y.",
-        "Jakary A.",
-        "Avadiappan S.",
-        "Hess C.P.",
-        "Lupo J.M."
       ],
       "parameters": []
     },

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -382,6 +382,25 @@
       "parameters": []
     },
     {
+      "slug": "qsmgan",
+      "name": "QSMGAN",
+      "stage": "dipole",
+      "engine": null,
+      "description": "QSMGAN \u2014 dipole inversion by a 3D U-Net generator refined with a WGAN-GP and an increased receptive field. Consumes the background-removed local field (ppm) and produces susceptibility. Patch-based inference: 64^3 input patches are mapped to 48^3 receptive-field-cropped output patches (i64o48) and stitched. Runs CPU-only on legacy PyTorch with the published WGAN-refined generator weights.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2019.116389",
+      "code_url": "https://github.com/mmorri10/QSMGAN-LupoLab",
+      "license": "MIT",
+      "authors": [
+        "Chen Y.",
+        "Jakary A.",
+        "Avadiappan S.",
+        "Hess C.P.",
+        "Lupo J.M."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "resharp",
       "name": "RESHARP",
       "stage": "bfr",


### PR DESCRIPTION
## QSMGAN — `dipole` stage

Adds **QSMGAN** (Chen et al., *NeuroImage* 2020) as a QSM-CI submission, modeled on `algorithms/nextqsm/`.

### Stage + evidence
- **Stage: `dipole`** — consumes `localfield.nii.gz`, `mask.nii.gz`, `params.json`; produces `chimap.nii.gz` (ppm).
- QSMGAN learns the **dipole inversion only**. Upstream, the network is fed the SEPIA background-removed **local field** and outputs susceptibility; it does no field mapping or background removal itself. The architecture is a 3D U-Net **generator** (`UNet3D`) trained with L1 then refined adversarially by a **WGAN-GP** discriminator. We load the WGAN-refined generator (`WGAN_i64o48/net_best.pt`) — the checkpoint the upstream NIFTI inference script uses. This maps exactly onto the `dipole` stage (localfield → chimap), verified against `CONTRACT.md`/`stages.yml`.

### Source (official repo has no code)
The official [LupoLab-UCSF/QSMGAN](https://github.com/LupoLab-UCSF/QSMGAN) is **README-only** — no code, no weights. This submission uses the working fork [mmorri10/QSMGAN-LupoLab](https://github.com/mmorri10/QSMGAN-LupoLab), which carries the PyTorch code and the committed checkpoints (`UNet3D_i64o48.zip`, `WGAN_i64o48.zip`). Both are **MIT** (fork LICENSE © 2021 Melanie A. Morrison). DOI **10.1016/j.neuroimage.2019.116389** verified via CrossRef (NeuroImage 207, 116389; authors Chen Y., Jakary A., Avadiappan S., Hess C.P., Lupo J.M.).

### Legacy PyTorch pinning
The published code targets "PyTorch >= 0.4" and the released checkpoints are the legacy (pre-1.6, tar/pickle) `torch.save` format. The image pins **`torch==1.1.0` (CPU) on Python 3.7** — contemporaneous with the 2019 release and the lowest legacy torch that both loads the checkpoint and has working NumPy interop.

**Not a blocker:** the older `torch==0.4.1` cp37 wheel *does* install, but its prebuilt cu92 binary was compiled **without NumPy support**, so `torch.from_numpy()` raises at runtime. I verified this in-container, then dropped to `1.1.0`, which loads the checkpoint and runs the model cleanly. The `UNet3D` generator is **not** rewritten — its definition is vendored verbatim into `recon.py` and the state_dict is loaded as-is.

### Patch handling + units
- **Patch-based (i64o48):** 64³ input patch → 48³ receptive-field-cropped output patch. `recon.py` tiles the volume by non-overlapping 48³ **output** patches; each output patch's 64³ **input** patch is the same center with an 8-voxel context margin per side, zero-padded at edges. Output patches are placed back and clipped to volume bounds, so arbitrary shapes (not just multiples of 48) are handled. Reproduces the upstream `input_scale=100` and `chi = arctanh(net_out)/10` (tanh output head) verbatim. **Deliberately skips** upstream's hard-coded `[1,1,1/0.8]` HD-scanner zoom (QSM-CI data is already on the mask grid).
- **Units:** QSMGAN expects the SEPIA local field in **ppm**; QSM-CI's `localfield.nii.gz` is exactly that (background-removed local field in ppm on the mask grid). No input rescaling. Output is ppm on the input grid, masked by `mask.nii.gz`. CPU forced via `CUDA_VISIBLE_DEVICES=-1`.

### Verification
- Built `algorithms/qsmgan/Dockerfile` and ran the run phase **offline** (`--network none`) on synthetic input → finite, correctly-stitched, mask-respecting `chimap.nii.gz` on a non-48-multiple volume (90×100×60), affine preserved.
- `web/algorithms.json` regenerated; `pytest -q tests/test_manifest.py` passes (2 passed).

### Scoring note
Weights (~30 MB) are cloned from the fork and unzipped at **build** time (network on); the run phase is offline. **Scoring builds this folder's `Dockerfile` at score-time** to produce the environment image, then mounts `run.sh`/`recon.py` read-only at `/algo`. The `image:` tag `ghcr.io/astewartau/qsm-ci/qsmgan:v1` in `algorithm.yml` still needs a one-time build+push if the platform expects a prebuilt image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)