### PR TITLE
fix: correct citation metadata (DOIs, authors, journals)

### DIFF
--- a/algorithms/harperella/algorithm.yml
+++ b/algorithms/harperella/algorithm.yml
@@ -4,8 +4,14 @@ stage: unwrap+bfr
 engine: QSMxT / QSM.rs
 description: >
   Integrated phase unwrapping + background field removal, operating on wrapped phase.
-citation: Li et al., NeuroImage 2014
-doi: 10.1016/j.neuroimage.2014.08.029
+citation: Li et al., NMR Biomed 2014
+authors:
+- name: Wei Li
+- name: Alexandru V. Avram
+- name: Bing Wu
+- name: Xue Xiao
+- name: Chunlei Liu
+doi: 10.1002/nbm.3056
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.7.0

--- a/algorithms/iharperella/algorithm.yml
+++ b/algorithms/iharperella/algorithm.yml
@@ -4,8 +4,14 @@ stage: unwrap+bfr
 engine: QSMxT / QSM.rs
 description: >
   Improved HARPERELLA: iterative integrated unwrapping + background removal on wrapped phase.
-citation: Li et al., NeuroImage 2014
-doi: 10.1016/j.neuroimage.2014.08.029
+citation: Li et al., NMR Biomed 2014
+authors:
+- name: Wei Li
+- name: Alexandru V. Avram
+- name: Bing Wu
+- name: Xue Xiao
+- name: Chunlei Liu
+doi: 10.1002/nbm.3056
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.7.0

--- a/algorithms/ilsqr/algorithm.yml
+++ b/algorithms/ilsqr/algorithm.yml
@@ -4,8 +4,18 @@ stage: dipole
 engine: QSMxT / QSM.rs
 description: >
   Iterative LSQR inversion with streaking-artifact reduction.
-citation: Li et al., NMR Biomed 2015
-doi: null
+citation: Li et al., NeuroImage 2015
+authors:
+- name: Wei Li
+- name: Nian Wang
+- name: Fang Yu
+- name: Hui Han
+- name: Wei Cao
+- name: Rebecca Romero
+- name: Bundhit Tantiwongkosi
+- name: Timothy Q. Duong
+- name: Chunlei Liu
+doi: 10.1016/j.neuroimage.2014.12.043
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/ismv/algorithm.yml
+++ b/algorithms/ismv/algorithm.yml
@@ -4,8 +4,14 @@ stage: bfr
 engine: QSMxT / QSM.rs
 description: >
   Iterative Spherical Mean Value background field removal.
-citation: Wen et al., 2014
-doi: null
+citation: Wen et al., Magn Reson Med 2014
+authors:
+- name: Yan Wen
+- name: Dong Zhou
+- name: Tian Liu
+- name: Pascal Spincemaille
+- name: Yi Wang
+doi: 10.1002/mrm.24998
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/matlab-medi/algorithm.yml
+++ b/algorithms/matlab-medi/algorithm.yml
@@ -5,9 +5,19 @@ description: Morphology Enabled Dipole Inversion (Cornell MEDI toolbox), compile
   MATLAB and run on the license-free MATLAB Runtime. Takes the total field, removes the
   background field with PDF, then solves the L1 morphology-regularized dipole inversion.
 authors:
-- name: QSM-CI
-  affiliation: Neurodesk
-doi: 10.1002/mrm.26946
+- name: Jing Liu
+- name: Tian Liu
+- name: Ludovic de Rochefort
+- name: James Ledoux
+- name: Ildar Khalidov
+- name: Weiwei Chen
+- name: A. John Tsiouris
+- name: Cynthia Wisnieff
+- name: Pascal Spincemaille
+- name: Martin R. Prince
+- name: Yi Wang
+doi: 10.1016/j.neuroimage.2011.08.082
+citation: Liu et al., NeuroImage 2012
 license: See Cornell MEDI toolbox license
 image: ghcr.io/astewartau/qsm-ci/matlab-medi:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-iharperella/algorithm.yml
+++ b/algorithms/matlab-sti-iharperella/algorithm.yml
@@ -5,9 +5,13 @@ description: Integrated phase unwrapping + background field removal (iHARPERELLA
   compiled from MATLAB and run on the license-free MATLAB Runtime. Operates on wrapped multi-echo
   phase and yields the local tissue field (echoes combined with optimal TE^2 weights).
 authors:
-- name: Wei Li and Chunlei Liu
-  affiliation: UC Berkeley
-doi: 10.1016/j.neuroimage.2014.08.029
+- name: Wei Li
+- name: Alexandru V. Avram
+- name: Bing Wu
+- name: Xue Xiao
+- name: Chunlei Liu
+doi: 10.1002/nbm.3056
+citation: Li et al., NMR Biomed 2014
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-iharperella:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-ilsqr/algorithm.yml
+++ b/algorithms/matlab-sti-ilsqr/algorithm.yml
@@ -5,9 +5,17 @@ description: Iterative LSQR dipole inversion from STI Suite v3 (the reference iL
   compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the local field and solves
   for susceptibility with streaking-artifact reduction.
 authors:
-- name: Wei Li and Chunlei Liu
-  affiliation: UC Berkeley
-doi: 10.1002/nbm.3056
+- name: Wei Li
+- name: Nian Wang
+- name: Fang Yu
+- name: Hui Han
+- name: Wei Cao
+- name: Rebecca Romero
+- name: Bundhit Tantiwongkosi
+- name: Timothy Q. Duong
+- name: Chunlei Liu
+doi: 10.1016/j.neuroimage.2014.12.043
+citation: Li et al., NeuroImage 2015
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-ilsqr:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-vsharp/algorithm.yml
+++ b/algorithms/matlab-sti-vsharp/algorithm.yml
@@ -5,9 +5,12 @@ description: V-SHARP background field removal from STI Suite v3 (spatially-varyi
   compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field and removes
   the background field to yield the local tissue field.
 authors:
-- name: Hongjiang Wei and Chunlei Liu
-  affiliation: UC Berkeley
-doi: 10.1002/nbm.3056
+- name: Bing Wu
+- name: Wei Li
+- name: Arnaud Guidon
+- name: Chunlei Liu
+doi: 10.1002/mrm.23000
+citation: Wu et al., Magn Reson Med 2012
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-vsharp:v1
 run: bash run.sh

--- a/algorithms/matlab-tkd/algorithm.yml
+++ b/algorithms/matlab-tkd/algorithm.yml
@@ -5,9 +5,14 @@ description: Thresholded k-space division dipole inversion implemented in MATLAB
   run on the license-free MATLAB Runtime. Reference `dipole`-stage submission demonstrating
   the MATLAB path.
 authors:
-- name: QSM-CI
-  affiliation: Neurodesk
-doi: 10.1002/mrm.22187
+- name: Karin Shmueli
+- name: Jacco A. de Zwart
+- name: Peter van Gelderen
+- name: Tie-Qiang Li
+- name: Stephen J. Dodd
+- name: Jeff H. Duyn
+doi: 10.1002/mrm.22135
+citation: Shmueli et al., Magn Reson Med 2009
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/matlab-tkd:v1
 run: bash run.sh

--- a/algorithms/medi/algorithm.yml
+++ b/algorithms/medi/algorithm.yml
@@ -4,8 +4,20 @@ stage: dipole
 engine: QSMxT / QSM.rs
 description: >
   Morphology Enabled Dipole Inversion: magnitude-guided edge regularization.
-citation: Liu et al., 2012
-doi: null
+citation: Liu et al., NeuroImage 2012
+authors:
+- name: Jing Liu
+- name: Tian Liu
+- name: Ludovic de Rochefort
+- name: James Ledoux
+- name: Ildar Khalidov
+- name: Weiwei Chen
+- name: A. John Tsiouris
+- name: Cynthia Wisnieff
+- name: Pascal Spincemaille
+- name: Martin R. Prince
+- name: Yi Wang
+doi: 10.1016/j.neuroimage.2011.08.082
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/qsmart/algorithm.yml
+++ b/algorithms/qsmart/algorithm.yml
@@ -6,8 +6,21 @@ description: >
   QSMART: vessel-aware two-stage reconstruction. Consumes the total field and produces
   susceptibility, doing its own spatially-dependent background field removal and vasculature-aware
   regularization (Frangi vessel detection + SDF).
-citation: Yaghmaie et al., NMR Biomed 2021
-doi: 10.1002/nbm.4442
+citation: Yaghmaie et al., NeuroImage 2021
+authors:
+- name: Negin Yaghmaie
+- name: Warda T. Syeda
+- name: Chengchuan Wu
+- name: Yicheng Zhang
+- name: Tracy D. Zhang
+- name: Emma L. Burrows
+- name: Amy Brodtmann
+- name: Bradford A. Moffat
+- name: David K. Wright
+- name: Rebecca Glarin
+- name: Scott Kolbe
+- name: Leigh A. Johnston
+doi: 10.1016/j.neuroimage.2020.117701
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/rts/algorithm.yml
+++ b/algorithms/rts/algorithm.yml
@@ -5,7 +5,11 @@ engine: QSMxT / QSM.rs
 description: >
   Rapid Two-Step QSM: streaking-artifact reduction via a fast ADMM split.
 citation: Kames et al., NeuroImage 2018
-doi: 10.1016/j.neuroimage.2018.07.043
+authors:
+- name: Christian Kames
+- name: Vanessa Wiggermann
+- name: Alexander Rauscher
+doi: 10.1016/j.neuroimage.2017.11.018
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/tkd/algorithm.yml
+++ b/algorithms/tkd/algorithm.yml
@@ -5,7 +5,14 @@ engine: QSMxT / QSM.rs
 description: >
   Thresholded K-space Division: direct inversion with the dipole kernel thresholded.
 citation: Shmueli et al., Magn Reson Med 2009
-doi: null
+authors:
+- name: Karin Shmueli
+- name: Jacco A. de Zwart
+- name: Peter van Gelderen
+- name: Tie-Qiang Li
+- name: Stephen J. Dodd
+- name: Jeff H. Duyn
+doi: 10.1002/mrm.22135
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/vsharp/algorithm.yml
+++ b/algorithms/vsharp/algorithm.yml
@@ -5,7 +5,12 @@ engine: QSMxT / QSM.rs
 description: >
   Variable-radius SHARP: SMV deconvolution with a spatially varying kernel radius.
 citation: Wu et al., Magn Reson Med 2012
-doi: null
+authors:
+- name: Bing Wu
+- name: Wei Li
+- name: Arnaud Guidon
+- name: Chunlei Liu
+doi: 10.1002/mrm.23000
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -6,11 +6,17 @@
       "stage": "unwrap+bfr",
       "engine": "QSMxT / QSM.rs",
       "description": "Integrated phase unwrapping + background field removal, operating on wrapped phase.",
-      "citation": "Li et al., NeuroImage 2014",
-      "doi": "10.1016/j.neuroimage.2014.08.029",
+      "citation": "Li et al., NMR Biomed 2014",
+      "doi": "10.1002/nbm.3056",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Wei Li",
+        "Alexandru V. Avram",
+        "Bing Wu",
+        "Xue Xiao",
+        "Chunlei Liu"
+      ],
       "parameters": [
         {
           "name": "radius",
@@ -35,11 +41,17 @@
       "stage": "unwrap+bfr",
       "engine": "QSMxT / QSM.rs",
       "description": "Improved HARPERELLA: iterative integrated unwrapping + background removal on wrapped phase.",
-      "citation": "Li et al., NeuroImage 2014",
-      "doi": "10.1016/j.neuroimage.2014.08.029",
+      "citation": "Li et al., NMR Biomed 2014",
+      "doi": "10.1002/nbm.3056",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Wei Li",
+        "Alexandru V. Avram",
+        "Bing Wu",
+        "Xue Xiao",
+        "Chunlei Liu"
+      ],
       "parameters": [
         {
           "name": "radius",
@@ -64,11 +76,21 @@
       "stage": "dipole",
       "engine": "QSMxT / QSM.rs",
       "description": "Iterative LSQR inversion with streaking-artifact reduction.",
-      "citation": "Li et al., NMR Biomed 2015",
-      "doi": null,
+      "citation": "Li et al., NeuroImage 2015",
+      "doi": "10.1016/j.neuroimage.2014.12.043",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Wei Li",
+        "Nian Wang",
+        "Fang Yu",
+        "Hui Han",
+        "Wei Cao",
+        "Rebecca Romero",
+        "Bundhit Tantiwongkosi",
+        "Timothy Q. Duong",
+        "Chunlei Liu"
+      ],
       "parameters": [
         {
           "name": "tol",
@@ -88,11 +110,17 @@
       "stage": "bfr",
       "engine": "QSMxT / QSM.rs",
       "description": "Iterative Spherical Mean Value background field removal.",
-      "citation": "Wen et al., 2014",
-      "doi": null,
+      "citation": "Wen et al., Magn Reson Med 2014",
+      "doi": "10.1002/mrm.24998",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Yan Wen",
+        "Dong Zhou",
+        "Tian Liu",
+        "Pascal Spincemaille",
+        "Yi Wang"
+      ],
       "parameters": [
         {
           "name": "tol",
@@ -151,12 +179,22 @@
       "stage": "bfr+dipole",
       "engine": null,
       "description": "Morphology Enabled Dipole Inversion (Cornell MEDI toolbox), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field, removes the background field with PDF, then solves the L1 morphology-regularized dipole inversion.",
-      "citation": null,
-      "doi": "10.1002/mrm.26946",
+      "citation": "Liu et al., NeuroImage 2012",
+      "doi": "10.1016/j.neuroimage.2011.08.082",
       "code_url": null,
       "license": "See Cornell MEDI toolbox license",
       "authors": [
-        "QSM-CI"
+        "Jing Liu",
+        "Tian Liu",
+        "Ludovic de Rochefort",
+        "James Ledoux",
+        "Ildar Khalidov",
+        "Weiwei Chen",
+        "A. John Tsiouris",
+        "Cynthia Wisnieff",
+        "Pascal Spincemaille",
+        "Martin R. Prince",
+        "Yi Wang"
       ],
       "parameters": [
         {
@@ -187,12 +225,16 @@
       "stage": "unwrap+bfr",
       "engine": null,
       "description": "Integrated phase unwrapping + background field removal (iHARPERELLA) from STI Suite v3, compiled from MATLAB and run on the license-free MATLAB Runtime. Operates on wrapped multi-echo phase and yields the local tissue field (echoes combined with optimal TE^2 weights).",
-      "citation": null,
-      "doi": "10.1016/j.neuroimage.2014.08.029",
+      "citation": "Li et al., NMR Biomed 2014",
+      "doi": "10.1002/nbm.3056",
       "code_url": null,
       "license": "See STI Suite license",
       "authors": [
-        "Wei Li and Chunlei Liu"
+        "Wei Li",
+        "Alexandru V. Avram",
+        "Bing Wu",
+        "Xue Xiao",
+        "Chunlei Liu"
       ],
       "parameters": [
         {
@@ -213,12 +255,20 @@
       "stage": "dipole",
       "engine": null,
       "description": "Iterative LSQR dipole inversion from STI Suite v3 (the reference iLSQR implementation), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the local field and solves for susceptibility with streaking-artifact reduction.",
-      "citation": null,
-      "doi": "10.1002/nbm.3056",
+      "citation": "Li et al., NeuroImage 2015",
+      "doi": "10.1016/j.neuroimage.2014.12.043",
       "code_url": null,
       "license": "See STI Suite license",
       "authors": [
-        "Wei Li and Chunlei Liu"
+        "Wei Li",
+        "Nian Wang",
+        "Fang Yu",
+        "Hui Han",
+        "Wei Cao",
+        "Rebecca Romero",
+        "Bundhit Tantiwongkosi",
+        "Timothy Q. Duong",
+        "Chunlei Liu"
       ],
       "parameters": [
         {
@@ -255,12 +305,15 @@
       "stage": "bfr",
       "engine": null,
       "description": "V-SHARP background field removal from STI Suite v3 (spatially-varying SMV deconvolution), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field and removes the background field to yield the local tissue field.",
-      "citation": null,
-      "doi": "10.1002/nbm.3056",
+      "citation": "Wu et al., Magn Reson Med 2012",
+      "doi": "10.1002/mrm.23000",
       "code_url": null,
       "license": "See STI Suite license",
       "authors": [
-        "Hongjiang Wei and Chunlei Liu"
+        "Bing Wu",
+        "Wei Li",
+        "Arnaud Guidon",
+        "Chunlei Liu"
       ],
       "parameters": [
         {
@@ -276,12 +329,17 @@
       "stage": "dipole",
       "engine": null,
       "description": "Thresholded k-space division dipole inversion implemented in MATLAB and run on the license-free MATLAB Runtime. Reference `dipole`-stage submission demonstrating the MATLAB path.",
-      "citation": null,
-      "doi": "10.1002/mrm.22187",
+      "citation": "Shmueli et al., Magn Reson Med 2009",
+      "doi": "10.1002/mrm.22135",
       "code_url": null,
       "license": "MIT",
       "authors": [
-        "QSM-CI"
+        "Karin Shmueli",
+        "Jacco A. de Zwart",
+        "Peter van Gelderen",
+        "Tie-Qiang Li",
+        "Stephen J. Dodd",
+        "Jeff H. Duyn"
       ],
       "parameters": []
     },
@@ -291,11 +349,23 @@
       "stage": "dipole",
       "engine": "QSMxT / QSM.rs",
       "description": "Morphology Enabled Dipole Inversion: magnitude-guided edge regularization.",
-      "citation": "Liu et al., 2012",
-      "doi": null,
+      "citation": "Liu et al., NeuroImage 2012",
+      "doi": "10.1016/j.neuroimage.2011.08.082",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Jing Liu",
+        "Tian Liu",
+        "Ludovic de Rochefort",
+        "James Ledoux",
+        "Ildar Khalidov",
+        "Weiwei Chen",
+        "A. John Tsiouris",
+        "Cynthia Wisnieff",
+        "Pascal Spincemaille",
+        "Martin R. Prince",
+        "Yi Wang"
+      ],
       "parameters": [
         {
           "name": "lambda",
@@ -374,11 +444,24 @@
       "stage": "bfr+dipole",
       "engine": "QSMxT / QSM.rs",
       "description": "QSMART: vessel-aware two-stage reconstruction. Consumes the total field and produces susceptibility, doing its own spatially-dependent background field removal and vasculature-aware regularization (Frangi vessel detection + SDF).",
-      "citation": "Yaghmaie et al., NMR Biomed 2021",
-      "doi": "10.1002/nbm.4442",
+      "citation": "Yaghmaie et al., NeuroImage 2021",
+      "doi": "10.1016/j.neuroimage.2020.117701",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Negin Yaghmaie",
+        "Warda T. Syeda",
+        "Chengchuan Wu",
+        "Yicheng Zhang",
+        "Tracy D. Zhang",
+        "Emma L. Burrows",
+        "Amy Brodtmann",
+        "Bradford A. Moffat",
+        "David K. Wright",
+        "Rebecca Glarin",
+        "Scott Kolbe",
+        "Leigh A. Johnston"
+      ],
       "parameters": []
     },
     {
@@ -427,10 +510,14 @@
       "engine": "QSMxT / QSM.rs",
       "description": "Rapid Two-Step QSM: streaking-artifact reduction via a fast ADMM split.",
       "citation": "Kames et al., NeuroImage 2018",
-      "doi": "10.1016/j.neuroimage.2018.07.043",
+      "doi": "10.1016/j.neuroimage.2017.11.018",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Christian Kames",
+        "Vanessa Wiggermann",
+        "Alexander Rauscher"
+      ],
       "parameters": [
         {
           "name": "delta",
@@ -528,10 +615,17 @@
       "engine": "QSMxT / QSM.rs",
       "description": "Thresholded K-space Division: direct inversion with the dipole kernel thresholded.",
       "citation": "Shmueli et al., Magn Reson Med 2009",
-      "doi": null,
+      "doi": "10.1002/mrm.22135",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Karin Shmueli",
+        "Jacco A. de Zwart",
+        "Peter van Gelderen",
+        "Tie-Qiang Li",
+        "Stephen J. Dodd",
+        "Jeff H. Duyn"
+      ],
       "parameters": [
         {
           "name": "threshold",
@@ -595,10 +689,15 @@
       "engine": "QSMxT / QSM.rs",
       "description": "Variable-radius SHARP: SMV deconvolution with a spatially varying kernel radius.",
       "citation": "Wu et al., Magn Reson Med 2012",
-      "doi": null,
+      "doi": "10.1002/mrm.23000",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Bing Wu",
+        "Wei Li",
+        "Arnaud Guidon",
+        "Chunlei Liu"
+      ],
       "parameters": [
         {
           "name": "threshold",


### PR DESCRIPTION
An audit (verified against CrossRef) found several DOIs pointing at **unrelated papers** and copy-paste errors:

- harperella / iharperella / matlab-sti-iharperella → pointed at an **fMRI language-mapping** paper; corrected to 10.1002/nbm.3056 (Li et al., HARPERELLA).
- matlab-sti-ilsqr, matlab-sti-vsharp → had the **HARPERELLA DOI** copy-pasted; corrected to the iLSQR / V-SHARP papers.
- qsmart → an **MR elastography** paper; rts → a **GAN** paper; matlab-tkd → a Bayesian-regularization paper. All corrected.
- Filled canonical DOIs + author lists for the null-DOI engine methods (ilsqr, tkd, vsharp, medi, ismv) and switched matlab-medi to the base-MEDI paper matching its description.

Each fix updates `doi`, `citation`, and the full `authors` list from CrossRef.

🤖 Generated with [Claude Code](https://claude.com/claude-code)