### PR TITLE
pipeline: run submissions via the qsm-ci CLI (one run path, no CI builds)

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -55,7 +55,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install scorer deps
-        run: pip install -r eval/requirements.txt
+        # `.` installs the qsm-ci CLI onto PATH — pipeline.py --runner docker delegates each run to
+        # `qsm-ci run …` (one run path, no CI-side container builds).
+        run: pip install -r eval/requirements.txt .
 
       - name: Cache OSF dataset zip
         uses: actions/cache@v4

--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -76,7 +76,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install scorer deps
-        run: pip install -r eval/requirements.txt huggingface_hub
+        # `.` installs the qsm-ci CLI onto PATH — pipeline.py --runner docker delegates each run to
+        # `qsm-ci run …` (one run path, no CI-side container builds).
+        run: pip install -r eval/requirements.txt huggingface_hub .
 
       - name: Cache OSF dataset zip
         uses: actions/cache@v4

--- a/qsm_ci/runner.py
+++ b/qsm_ci/runner.py
@@ -361,18 +361,25 @@ def check_docker() -> bool:  # kept for back-compat
 
 
 def _build_oci(algo: dict, engine: str, log) -> str:
-    """docker/podman: build a Dockerfile if present, else pull image:. Returns the image ref."""
-    if (algo["dir"] / "Dockerfile").exists():
-        tag = f"qsm-ci-local/{algo['slug']}:latest"
-        log(f"⚙ building image from Dockerfile → {tag}")
-        subprocess.run([engine, "build", "-q", "-t", tag, str(algo["dir"])], check=True)
-        return tag
-    tag = algo["image"]
+    """docker/podman: PULL the submission's prebuilt image: and return its ref — never build.
+
+    CI must not build containers. Every submission publishes a prebuilt ``image:``; a folder
+    Dockerfile is only the build recipe (used out-of-band to produce that image), never built here.
+    Pull the tag; if the pull fails (offline / registry hiccup) fall back to a locally cached copy;
+    if neither is available, stop with a clear message telling the author to build and push first."""
+    tag = algo.get("image")
     if not tag:
-        raise SystemExit("algorithm.yml has no image: and no Dockerfile to build")
-    if subprocess.run([engine, "image", "inspect", tag], capture_output=True).returncode != 0:
-        log(f"↓ pulling {tag}")
-        subprocess.run([engine, "pull", tag], check=True)
+        raise SystemExit(
+            "algorithm.yml has no image:. Publish a prebuilt image (build and push it first) and set "
+            "image: to its reference — the runner pulls images, it does not build containers.")
+    log(f"↓ pulling {tag}")
+    if subprocess.run([engine, "pull", tag], capture_output=True).returncode != 0:
+        # Offline / registry hiccup — fall back to a locally cached copy if one exists.
+        if subprocess.run([engine, "image", "inspect", tag], capture_output=True).returncode != 0:
+            raise SystemExit(
+                f"could not pull {tag} and no local copy is cached. Build and push the image first; "
+                "the runner does not build containers (a folder Dockerfile is only the build recipe).")
+        log(f"  (pull failed — using locally cached {tag})")
     return tag
 
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -2,8 +2,10 @@
 """QSM-CI pipeline runner — isolated + composed evaluation.
 
 Discovers stage submissions under algorithms/, runs them on a dataset, scores each produced
-artifact with qsm-eval, and writes results/ entries. Runs submissions directly via their run.sh
-(no Docker) so it works locally; the CI workflows mirror this with containers.
+artifact with qsm-eval, and writes results/ entries. The `local` runner runs submissions directly
+via their run.sh (no Docker) so it works locally; the `docker` runner (CI) delegates each run to the
+installed `qsm-ci run` CLI, which pulls the prebuilt image, mounts run.sh, and injects QSMCI_* env
+vars — one run path shared with the CLI, so the two harnesses can't drift.
 
 Modes (see stages.yml):
   isolated  — feed each stage/span its GROUND-TRUTH consumed artifacts; score its outputs vs GT.
@@ -107,33 +109,22 @@ def prepare_input(consumes: list[str], sources: dict[str, Path], dest: Path) -> 
         shutil.copy(src, dest / ARTIFACT_FILE[art])
 
 
-_built: dict[str, str] = {}
+def _cli_run_argv(algo: dict, input_dir: Path, output_dir: Path) -> list[str]:
+    """Build the `qsm-ci run …` argv that reproduces this submission's isolated docker run.
 
-
-def build_env(algo: dict) -> str:
-    """Resolve the submission's ENVIRONMENT image (build/setup phase — network allowed).
-
-    - If the folder has a Dockerfile, build it (a base image + any toolbox downloads). The code is
-      NOT baked in; it is mounted at run time.
-    - Otherwise use `image:` (a ready base, e.g. a MATLAB Runtime container), pulling if not local.
-    Returns the image tag to run offline.
-    """
-    if algo["slug"] in _built:
-        return _built[algo["slug"]]
-    if (algo["dir"] / "Dockerfile").exists():
-        tag = f"qsm-ci-env/{algo['slug']}:latest"
-        subprocess.run(["docker", "build", "-q", "-t", tag, str(algo["dir"])], check=True)
-    else:
-        tag = algo["image"]
-        # Always pull: submissions push updated builds to the SAME tag (e.g. matlab-*:v1), so a
-        # stale copy cached from a prior run would otherwise be used silently (docker image inspect
-        # succeeds and skips the pull). `docker pull` is cheap when the digest already matches.
-        if subprocess.run(["docker", "pull", tag], capture_output=True).returncode != 0:
-            # Offline / registry hiccup — fall back to a locally cached image if one exists.
-            if subprocess.run(["docker", "image", "inspect", tag], capture_output=True).returncode != 0:
-                raise RuntimeError(f"cannot pull or find image {tag}")
-    _built[algo["slug"]] = tag
-    return tag
+    Each consumed artifact becomes a `--<artifact> <input_dir>/<file>` flag (magnitude is optional —
+    only passed when present); the produced artifact is written with `-o <output_dir>/<file>`. The
+    CLI owns image resolution, mounting run.sh, and injecting the QSMCI_* acquisition env vars — so
+    the scorer no longer duplicates (and drifts from) that logic."""
+    produced = algo["produces"][0]
+    argv = ["qsm-ci", "run", str(algo["dir"])]
+    for art in algo["consumes"]:
+        f = input_dir / ARTIFACT_FILE[art]
+        if art == "magnitude" and not f.exists():
+            continue  # optional — only some methods use it
+        argv += [f"--{art}", str(f)]
+    argv += ["-o", str(output_dir / ARTIFACT_FILE[produced]), "--runner", "docker"]
+    return argv
 
 
 def run_algo(algo: dict, input_dir: Path, output_dir: Path, runner: str = "local") -> float:
@@ -142,15 +133,11 @@ def run_algo(algo: dict, input_dir: Path, output_dir: Path, runner: str = "local
     output_dir.mkdir(parents=True)
     t0 = time.time()
     if runner == "docker":
-        import os
-        # Run phase: no network, read-only input, the submission's CODE mounted at /algo (not baked).
-        subprocess.run([
-            "docker", "run", "--rm", "--network", "none",
-            "--user", f"{os.getuid()}:{os.getgid()}",
-            "-v", f"{algo['dir']}:/algo:ro",
-            "-v", f"{input_dir}:/input:ro", "-v", f"{output_dir}:/output",
-            algo["image"], "bash", "/algo/run.sh",
-        ], check=True)
+        # Delegate to the installed `qsm-ci` CLI (a console script) rather than reimplementing the
+        # container run here. The CLI resolves the folder, pulls the prebuilt image, mounts run.sh
+        # read-only, and injects the QSMCI_* env vars (TE/B0/…) — the very env vars this scorer used
+        # to omit, which DNF'd submissions that read acquisition params through them.
+        subprocess.run(_cli_run_argv(algo, input_dir, output_dir), check=True)
     else:
         subprocess.run(["bash", str(algo["dir"] / "run.sh"), str(input_dir), str(output_dir)],
                        check=True)
@@ -260,23 +247,9 @@ def main() -> None:
     runs: list[dict] = []
     args.work.mkdir(parents=True, exist_ok=True)
 
-    # Build/setup phase (network allowed): resolve each submission's environment image. Code is
-    # mounted at run time, not baked. A submission whose env can't be built is excluded (DNF).
-    if args.runner == "docker":
-        ok = []
-        iso_only = args.focus or args.only  # in pure isolated mode, only this slug needs building
-        for a in algos:
-            if iso_only and a["slug"] != iso_only and args.mode == "isolated":
-                ok.append(a)
-                continue
-            try:
-                a["image"] = build_env(a)
-                ok.append(a)
-            except Exception as e:
-                print(f"  build     {a['slug']:<16} env FAILED ({e}) — excluded")
-                runs.append(dnf(f"{a['slug']}-iso", a["slug"], a["slug"], a["stage"], "isolated", args.track))
-        algos = ok
-
+    # Image resolution (pull, network allowed) is owned by the `qsm-ci` CLI now — each run_algo call
+    # in docker mode shells out to `qsm-ci run …`, which pulls the submission's prebuilt image. A
+    # submission whose image can't be pulled DNFs at run time (per-run, doesn't sink the batch).
     iso_target = args.focus or args.only  # isolated runs only this slug when set
 
     # -------- isolated (independent runs -> parallel) --------

--- a/scripts/pr_comment.sh
+++ b/scripts/pr_comment.sh
@@ -16,8 +16,10 @@ if not runs:
     print(f"### QSM-CI · {slug}\n\n**DNF** — no valid output was produced.")
     raise SystemExit
 r = runs[0]
+rt = r.get("runtime_s")
+rt_str = f"{rt:.1f}s" if isinstance(rt, (int, float)) else "n/a"
 lines = [f"### QSM-CI · `{slug}` · stage `{r.get('stage')}` · isolated",
-         f"Scored artifact: `{r.get('artifact')}` ({r.get('kind')}), runtime {r.get('runtime_s'):.1f}s\n",
+         f"Scored artifact: `{r.get('artifact')}` ({r.get('kind')}), runtime {rt_str}\n",
          "| metric | value |", "|---|---|"]
 for k, v in (r.get("metrics") or {}).items():
     lines.append(f"| {k} | {'—' if v is None else round(v, 4)} |")


### PR DESCRIPTION
## Why

The scorer (`scripts/pipeline.py`) ran each submission through its **own** container code that duplicated — and drifted from — the `qsm-ci run` CLI. The CLI injects acquisition parameters as `QSMCI_*` env vars (`QSMCI_TE`/`QSMCI_TE0`/`QSMCI_B0`/`QSMCI_B0_DIR`/`QSMCI_VOXEL_SIZE`); the scorer did **not**. Any submission that reads TE/B0 through those env vars therefore worked under `qsm-ci run` but **DNF'd in scoring** with `no echo time(s) available`.

This unifies both harnesses onto a **single run path**: the scorer's docker runner now shells out to the installed `qsm-ci` CLI, so there is exactly one place that resolves the folder, pulls the image, mounts `run.sh`, and injects the env vars — they can no longer drift.

## Changes

- **`scripts/pipeline.py` `run_algo` (docker runner)** — delegate to the console script:
  `qsm-ci run <dir> --<artifact> <input>/<file> … -o <output>/<produced>.nii.gz --runner docker`.
  Artifact flags are built from `algo['consumes']` via `ARTIFACT_FILE`; `magnitude` is passed only when the file is present (optional). The `local` runner (direct `bash run.sh`) is unchanged. A non-zero `qsm-ci run` exit still DNFs that one submission without sinking the batch.
- Removed the now-dead setup-phase `build_env()` call and the `build_env` function — image resolution is owned by the CLI now.
- **`qsm_ci/runner.py` `_build_oci`** — made **pull-only**. CI must not build containers: every submission publishes a prebuilt `image:`. Pull it, fall back to a locally cached copy, else `SystemExit` telling the author to build and push first. A folder Dockerfile is only the build recipe, never built here.
- **`.github/workflows/score.yml` + `evaluate.yml`** — added `pip install .` so `qsm-ci` is on PATH when `pipeline.py` calls it.
- **`scripts/pr_comment.sh`** — tolerate a missing/`None` `runtime_s` (print `n/a`) instead of crashing on a DNF run.

## Supersedes #56

#56 made only the *scorer's* `build_env` pull-only. Since the single image path is now the CLI's `_build_oci`, this PR carries that pull-only guarantee in the right place. **#56 should be closed.**

## Verified locally

- Command construction: unit-tested `run_algo`/`_cli_run_argv` build the right argv (`qsm-ci run <dir> --localfield … --mask … --params … -o …/chimap.nii.gz --runner docker`), with `magnitude` correctly omitted when absent and included when present; `local` runner still runs `bash run.sh`.
- `_build_oci` pull-only: never invokes `build`; clean `SystemExit` when `image:` is missing or a pull fails with no cached copy; falls back to a cached copy when the pull fails.
- End-to-end (`python scripts/pipeline.py --dataset /tmp/fix --mode isolated --runner docker --only rts`): ran through `qsm-ci run`, **pulled** `qsmxt:v9.4.0` (no `docker build`), the container produced `chimap.nii.gz`, and it scored — **no "no echo time(s) available" error**.
- `pr_comment.sh` DNF path prints `runtime n/a` without crashing.
- `pytest tests/test_registry.py tests/test_runner_help.py` pass; the only failing tests (`test_interfaces.py`) fail identically on a clean tree due to missing `nipype`/`pydra` deps — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)