### PR TITLE
ci: fix qsm-ci install on the runner (setuptools-scm build error)

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -57,7 +57,10 @@ jobs:
       - name: Install scorer deps
         # `.` installs the qsm-ci CLI onto PATH — pipeline.py --runner docker delegates each run to
         # `qsm-ci run …` (one run path, no CI-side container builds).
-        run: pip install -r eval/requirements.txt .
+        run: |
+          pip install -r eval/requirements.txt
+          pip install --upgrade setuptools setuptools_scm wheel   # runner's build tools are too old for setuptools-scm
+          pip install --no-build-isolation .                       # build the CLI with the upgraded tools
 
       - name: Cache OSF dataset zip
         uses: actions/cache@v4

--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -78,7 +78,10 @@ jobs:
       - name: Install scorer deps
         # `.` installs the qsm-ci CLI onto PATH — pipeline.py --runner docker delegates each run to
         # `qsm-ci run …` (one run path, no CI-side container builds).
-        run: pip install -r eval/requirements.txt huggingface_hub .
+        run: |
+          pip install -r eval/requirements.txt huggingface_hub
+          pip install --upgrade setuptools setuptools_scm wheel   # runner's build tools are too old for setuptools-scm
+          pip install --no-build-isolation .                       # build the CLI with the upgraded tools
 
       - name: Cache OSF dataset zip
         uses: actions/cache@v4


### PR DESCRIPTION
#59's `pip install .` failed on the runner (`AttributeError: ignore_egg_info_in_manifest` — build-tool version mismatch), which broke all scoring. Upgrade the build tools + `--no-build-isolation`. Verified the install succeeds locally. 🤖 Generated with [Claude Code](https://claude.com/claude-code)