### PR TITLE
Fix run harnesses for 6 DL/TGV submissions (DNFs + sign/scale bugs)

### DIFF
--- a/algorithms/autoqsm/run.sh
+++ b/algorithms/autoqsm/run.sh
@@ -13,6 +13,13 @@
 # with values ~[-0.9, 0.5] ppm). The V-Net output (tanh) is susceptibility in ppm. No Hz/rad/ppm
 # rescaling is applied. predict.py handles NIfTI<->array and preserves the mask grid / affine.
 #
+# Field POLARITY: QSM-CI's field is simulated by qsm-forward with the dipole kernel
+# D = 1/3 - kz^2/k^2  (field = ifft(fft(chi) * D)). AutoQSM was trained on the OPPOSITE field
+# convention (the QSMnet-lineage D = kz^2/k^2 - 1/3), so feeding the QSM-CI field as-is makes the
+# V-Net emit -chi (isolated corr/xsim came out negative: xsim=-0.033, corr=-0.505). We therefore
+# NEGATE the input field to match the training polarity; the network then emits correctly-signed chi
+# (verified: isolated corr flips to +0.53). This is an input-convention fix, not an output negation.
+#
 # Acquisition parameters are injected as env vars (see CONTRACT.md); AutoQSM needs none of them (it
 # has no dipole-kernel orientation input — orientation is baked into the trained weights).
 set -euo pipefail
@@ -26,6 +33,18 @@ export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
 # baked in the image at $AUTOQSM_HOME (default /opt/AutoQSM).
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Negate the totalfield into a temp NIfTI so the baked predict.py / V-Net is untouched (input-only,
+# convention-matching fix). Uses the numpy/nibabel already in the image.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+python - "$IN/totalfield.nii.gz" "$WORK/totalfield.nii.gz" <<'PY'
+import sys, numpy as np, nibabel as nib
+nii = nib.load(sys.argv[1])
+neg = nib.Nifti1Image(-np.asarray(nii.get_fdata(), dtype=np.float32), nii.affine, nii.header)
+neg.set_data_dtype(np.float32)
+nib.save(neg, sys.argv[2])
+PY
+
 python "$HERE/predict.py" \
-  "$IN/totalfield.nii.gz" \
+  "$WORK/totalfield.nii.gz" \
   "$OUT/chimap.nii.gz"

--- a/algorithms/lpcnn/run.sh
+++ b/algorithms/lpcnn/run.sh
@@ -66,6 +66,13 @@ python3 LPCNN/inference.py \
 CKPT_STEM="$(basename "$RESUME")"; CKPT_STEM="${CKPT_STEM%%.*}"
 RESULT="$RUNDIR/LPCNN/test_result/$CKPT_STEM/lpcnn${SAVE_NAME}_qsm.nii.gz"
 mkdir -p "$OUT"
-cp "$RESULT" "$OUT/chimap.nii.gz"
+# inference.py's qsm_display saves a 4-D NIfTI (x,y,z,1); QSM-CI scoring indexes the recon
+# with a 3-D mask (a[mask]) and can't broadcast (x,y,z,1) against (x,y,z). Drop the trailing axis.
+python3 - "$RESULT" "$OUT/chimap.nii.gz" <<'PY'
+import sys, numpy as np, nibabel as nib
+img = nib.load(sys.argv[1])
+data = np.squeeze(np.asanyarray(img.dataobj))
+nib.Nifti1Image(data.astype(np.float32), img.affine, img.header).to_filename(sys.argv[2])
+PY
 rm -rf "$WORK"
 echo "wrote $OUT/chimap.nii.gz"

--- a/algorithms/qsmgan/run.sh
+++ b/algorithms/qsmgan/run.sh
@@ -10,6 +10,13 @@
 # grid. No rescaling of the input is applied here (the model's own input_scale=100 and
 # output_scale=10 / arctanh handling live in recon.py, matching the upstream config).
 #
+# Field POLARITY: QSM-CI's local field is simulated by qsm-forward with the dipole kernel
+# D = 1/3 - kz^2/k^2. QSMGAN was trained on the OPPOSITE field convention (QSMnet-lineage
+# D = kz^2/k^2 - 1/3), so feeding the QSM-CI field as-is makes the generator emit -chi
+# (isolated corr/xsim came out negative: xsim=-0.030, corr=-0.716). We NEGATE the input
+# local field to match the training polarity; the generator then emits correctly-signed chi
+# (verified: isolated corr flips to +0.74). This is an input-convention fix, not an output negation.
+#
 # Inference is patch-based: 64^3 input -> 48^3 receptive-field-cropped output (i64o48).
 # recon.py tiles the volume by 48^3 output patches and stitches them; see recon.py.
 #
@@ -23,4 +30,22 @@ export QSMGAN_WEIGHTS="${QSMGAN_WEIGHTS:-/opt/qsmgan/WGAN_i64o48}"
 # Code is mounted at /algo (see CONTRACT.md); weights are baked into the image.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-python "$SCRIPT_DIR/recon.py" "$IN" "$OUT"
+# Stage a temp input dir whose localfield is negated to match QSMGAN's training polarity; other
+# inputs (mask/params/magnitude) are symlinked through unchanged. recon.py reads <dir>/localfield
+# and <dir>/mask, so the baked inference code is untouched (input-only, convention-matching fix).
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+for f in "$IN"/*; do
+  b="$(basename "$f")"
+  [ "$b" = "localfield.nii.gz" ] && continue
+  ln -s "$f" "$WORK/$b"
+done
+python - "$IN/localfield.nii.gz" "$WORK/localfield.nii.gz" <<'PY'
+import sys, numpy as np, nibabel as nib
+nii = nib.load(sys.argv[1])
+neg = nib.Nifti1Image(-np.asarray(nii.get_fdata(), dtype=np.float32), nii.affine, nii.header)
+neg.set_data_dtype(np.float32)
+nib.save(neg, sys.argv[2])
+PY
+
+python "$SCRIPT_DIR/recon.py" "$WORK" "$OUT"

--- a/algorithms/qsmnet-plus/run.sh
+++ b/algorithms/qsmnet-plus/run.sh
@@ -16,6 +16,7 @@
 # NIfTI affine (read + written unchanged), so B0 direction is not consumed by this path.
 set -euo pipefail
 IN="${1:-/input}"; OUT="${2:-/output}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"             # resolve before we chdir below
 
 export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
 export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
@@ -26,7 +27,21 @@ export QSMNET_CKPT_DIR="${QSMNET_CKPT_DIR:-/opt/QSMnet/Checkpoints/$QSMNET_NAME}
 export QSMNET_CODE="${QSMNET_CODE:-/opt/QSMnet/Code}"
 
 mkdir -p "$OUT"
-python "$(dirname "$0")/qsmnet_infer.py" \
+
+# The cloned repo's training_params.py (imported transitively via network_model -> utils) runs an
+# UNCONDITIONAL os.makedirs('../Checkpoints/QSMnet_64/validation_result') at IMPORT time — a stray
+# training-only side effect. Under CI the container runs as a non-root --user with cwd=/, so that
+# relative path resolves to /Checkpoints (read-only) and the import dies before inference even
+# starts:  PermissionError: [Errno 13] Permission denied: '../Checkpoints'. We give it a writable
+# cwd instead — run from a scratch "Code" dir under /tmp and pre-create the sibling
+# Checkpoints/QSMnet_64/validation_result (the name training_params.py hardcodes, same for both
+# images) so the makedirs is a harmless no-op. The REAL weights are loaded by qsmnet_infer.py from
+# the absolute QSMNET_CKPT_DIR and are untouched by any of this.
+SCRATCH="$(mktemp -d)"
+mkdir -p "$SCRATCH/Code" "$SCRATCH/Checkpoints/QSMnet_64/validation_result"
+cd "$SCRATCH/Code"
+
+python "$SCRIPT_DIR/qsmnet_infer.py" \
   "$IN/localfield.nii.gz" \
   "$IN/mask.nii.gz" \
   "$OUT/chimap.nii.gz"

--- a/algorithms/qsmnet/run.sh
+++ b/algorithms/qsmnet/run.sh
@@ -16,6 +16,7 @@
 # NIfTI affine (read + written unchanged), so B0 direction is not consumed by this path.
 set -euo pipefail
 IN="${1:-/input}"; OUT="${2:-/output}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"             # resolve before we chdir below
 
 export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
 export TF_CPP_MIN_LOG_LEVEL="${TF_CPP_MIN_LOG_LEVEL:-2}"
@@ -26,7 +27,21 @@ export QSMNET_CKPT_DIR="${QSMNET_CKPT_DIR:-/opt/QSMnet/Checkpoints/$QSMNET_NAME}
 export QSMNET_CODE="${QSMNET_CODE:-/opt/QSMnet/Code}"
 
 mkdir -p "$OUT"
-python "$(dirname "$0")/qsmnet_infer.py" \
+
+# The cloned repo's training_params.py (imported transitively via network_model -> utils) runs an
+# UNCONDITIONAL os.makedirs('../Checkpoints/QSMnet_64/validation_result') at IMPORT time — a stray
+# training-only side effect. Under CI the container runs as a non-root --user with cwd=/, so that
+# relative path resolves to /Checkpoints (read-only) and the import dies before inference even
+# starts:  PermissionError: [Errno 13] Permission denied: '../Checkpoints'. We give it a writable
+# cwd instead — run from a scratch "Code" dir under /tmp and pre-create the sibling
+# Checkpoints/QSMnet_64/validation_result (the name training_params.py hardcodes, same for both
+# images) so the makedirs is a harmless no-op. The REAL weights are loaded by qsmnet_infer.py from
+# the absolute QSMNET_CKPT_DIR and are untouched by any of this.
+SCRATCH="$(mktemp -d)"
+mkdir -p "$SCRATCH/Code" "$SCRATCH/Checkpoints/QSMnet_64/validation_result"
+cd "$SCRATCH/Code"
+
+python "$SCRIPT_DIR/qsmnet_infer.py" \
   "$IN/localfield.nii.gz" \
   "$IN/mask.nii.gz" \
   "$OUT/chimap.nii.gz"

--- a/algorithms/tgv/run.sh
+++ b/algorithms/tgv/run.sh
@@ -15,4 +15,15 @@ if [ -f "$CFG" ]; then
   V=$(jq -r '.alpha1 // empty' "$CFG"); [ -n "$V" ] && SET="$SET --alpha1 $V"
   V=$(jq -r '.alpha0 // empty' "$CFG"); [ -n "$V" ] && SET="$SET --alpha0 $V"
 fi
-qsmxt invert tgv "$IN/totalfield.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/chimap.nii.gz" --b0-direction $B0 --field-strength "$(jq -r .B0 "$IN/params.json")" --echo-time "$(jq -r .TE[0] "$IN/params.json")" $SET
+# UNIT FIX (QSM-CI contract: totalfield is in ppm; QSMxT/QSM.rs `invert tgv` expects the field in
+# RADIANS). Internally tgv_qsm scales its result to ppm with  chi_ppm = chi_raw / (2*pi*gamma*TE*B0),
+# gamma = 42.5781 Hz/T (see QSM.rs src/inversion/tgv.rs). QSM.rs's own pipeline (run_tgv in
+# src/pipeline/inversion.rs) therefore feeds it phase in radians. Passing our ppm field with the real
+# TE/B0 makes TGV divide by 2*pi*gamma*TE*B0 (~7.5 here) a SECOND time -> output ~10x too small.
+#
+# Fix without touching the NIfTI (no python/fslmaths in the image): choose --echo-time/--field-strength
+# so the internal rad->ppm scale is exactly 1, i.e. 2*pi*gamma*TE*B0 = 1. Then a ppm field passes
+# straight through to a ppm chimap. This is algebraically identical to converting ppm->rad on input
+# with the real TE/B0 and letting TGV convert it back (the TE/B0 cancel).
+TGV_TE=$(awk 'BEGIN{ pi=atan2(0,-1); gamma=42.5781; printf "%.15g\n", 1.0/(2*pi*gamma) }')
+qsmxt invert tgv "$IN/totalfield.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/chimap.nii.gz" --b0-direction $B0 --field-strength 1 --echo-time "$TGV_TE" $SET


### PR DESCRIPTION
The full rescore on the real 7T scoring data surfaced six submissions that DNF'd or scored negative/mis-scaled. **All were wrapper bugs, not model problems** — every fix is in the mounted `run.sh`, so **no image rebuilds** are needed.

| Method | Before | After | Root cause / fix |
|---|---|---|---|
| **lpcnn** | DNF | **xsim 0.620** (r 0.895) | 4-D `(x,y,z,1)` output vs 3-D mask broadcast → squeeze trailing axis |
| **qsmnet** | DNF | **xsim 0.622** (r 0.88) | `training_params.py` `os.makedirs` at import fails under non-root CI user → writable scratch cwd |
| **qsmnet-plus** | DNF | **xsim 0.512** (r 0.86) | same as qsmnet (identical run.sh; variant via baked `QSMNET_NAME`) |
| **autoqsm** | xsim −0.033 (r −0.505) | **xsim 0.248** (r +0.53) | opposite dipole-kernel sign convention → negate input field |
| **qsmgan** | xsim −0.030 (r −0.716) | **xsim 0.245** (r +0.74) | same polarity mismatch → negate input field |
| **tgv** | xsim 0.046 | **xsim 0.325** | ppm field fed to rad-expecting tgv_qsm → double `2π·γ·TE·B0` division (~7.5–10× too small); cancel the internal scale |

Each fix verified locally through the exact CI path (`scripts/pipeline.py --mode isolated --runner docker --track sim`). `evaluate.yml` will independently re-verify each changed slug on the runner.

A full `score` rescore (`scope=all`) will follow the merge to recompute these + the now-public `matlab-bfrnet` + the composed matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)