### PR TITLE
ci: static submission lint + evaluate --fail-on-dnf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Scorer selfcheck + unit tests
         run: |
           python eval/qsm_eval.py --selfcheck
-          pytest -q eval/test_metrics.py tests/test_manifest.py tests/test_runner_help.py
+          pytest -q eval/test_metrics.py tests/test_manifest.py tests/test_runner_help.py tests/test_submissions.py
 
       - name: Scaffold check (qsm-ci new)
         run: |

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -74,13 +74,17 @@ jobs:
         run: scripts/fetch_dataset.sh "$TRACK" data/${TRACK}/scoring
 
       - name: Isolated evaluation (build env with network, run offline, mount code)
+        # --fail-on-dnf: a submission that can't run (missing/broken run.sh, crash, wrong output
+        # artifact) turns this check RED instead of merging green and silently scoring DNF on main.
         run: |
           python scripts/pipeline.py \
             --dataset data/${TRACK}/scoring \
-            --mode isolated --runner docker --only "${{ matrix.slug }}" --track "$TRACK"
+            --mode isolated --runner docker --only "${{ matrix.slug }}" --track "$TRACK" --fail-on-dnf
 
       - name: Comment metrics on PR
-        if: github.event_name == 'pull_request'
+        # always() so a DNF (which fails the eval step above) still posts its metrics/DNF comment —
+        # the job stays red, but the PR shows why.
+        if: ${{ always() && github.event_name == 'pull_request' }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -224,6 +224,10 @@ def main() -> None:
     ap.add_argument("--work", type=Path, default=ROOT / ".work")
     ap.add_argument("--emit-volumes", action="store_true",
                     help="write recon/truth/error NIfTIs per run under results/<id>/ for the web viewer")
+    ap.add_argument("--fail-on-dnf", action="store_true",
+                    help="exit non-zero if any run in scope DNF'd (a submission that couldn't run or "
+                         "produce a scorable artifact). Used by evaluate.yml so a broken run.sh / crash "
+                         "surfaces as a red check instead of a silently-swallowed DNF.")
     args = ap.parse_args()
 
     global EMIT_VOLUMES
@@ -401,6 +405,13 @@ def main() -> None:
 
     total = flush_index(runs)
     print(f"\nmerged {len(runs)} runs into results/index.json ({total} total)")
+
+    if args.fail_on_dnf:
+        dnfs = [r for r in runs if r.get("status") == "DNF"]
+        if dnfs:
+            print(f"\n::error::{len(dnfs)} run(s) DNF'd: "
+                  f"{', '.join(sorted({r['slug'] for r in dnfs}))}")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -1,0 +1,53 @@
+"""Submission well-formedness gate (fast, static — no container).
+
+A malformed submission — missing `run.sh`, a typo'd `run:` path, a missing required field, an
+unknown `stage` — otherwise merges green: evaluate.yml runs the container but swallows the
+resulting DNF, so the breakage only shows up as a DNF on the leaderboard *after* merge. This test
+fails the PR instead, in seconds, with a specific message. (Pullability of the image is gated
+separately by the image-access workflow; the runtime behaviour by evaluate.yml.)
+"""
+import shlex
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Valid stage names = the swappable stages + the named spans, straight from the registry.
+_STAGES_YML = yaml.safe_load((ROOT / "stages.yml").read_text())
+VALID_STAGES = set(_STAGES_YML.get("stages", {})) | set(_STAGES_YML.get("spans", {}))
+
+REQUIRED_FIELDS = ("name", "slug", "stage", "image", "run")
+_INTERPRETERS = {"bash", "sh", "python", "python3", "env"}
+
+
+def _submission_dirs():
+    for d in sorted((ROOT / "algorithms").glob("*/")):
+        if d.name.startswith("_"):          # _template etc. are not submissions
+            continue
+        if (d / "algorithm.yml").exists():
+            yield d
+
+
+@pytest.mark.parametrize("d", list(_submission_dirs()), ids=lambda d: d.name)
+def test_submission_is_wellformed(d):
+    meta = yaml.safe_load((d / "algorithm.yml").read_text())
+    assert isinstance(meta, dict), f"{d.name}: algorithm.yml is not a mapping"
+
+    for field in REQUIRED_FIELDS:
+        assert meta.get(field), f"{d.name}: algorithm.yml missing required field '{field}'"
+
+    assert meta["stage"] in VALID_STAGES, (
+        f"{d.name}: unknown stage {meta['stage']!r} (valid: {sorted(VALID_STAGES)})"
+    )
+
+    # The `run:` command must reference a script that actually exists in the submission dir
+    # (this is what catches a missing/renamed/typo'd run.sh — the exact class of merge-green,
+    # score-DNF bug this gate exists for).
+    tokens = shlex.split(str(meta["run"]))
+    candidates = [t for t in tokens if not t.startswith("-") and t not in _INTERPRETERS]
+    assert any((d / t).exists() for t in candidates), (
+        f"{d.name}: run {meta['run']!r} references no existing file in the submission dir "
+        f"(looked for {candidates})"
+    )


### PR DESCRIPTION
Follow-up to #63 (image-access). Closes the *entry-script* half of the same hole: a submission with a missing/typo'd `run.sh`, an unknown `stage`, or a missing required field currently **merges green** — `evaluate.yml` runs the container but swallows the DNF — and only surfaces as a DNF on the leaderboard after merge.

**Two parts:**
1. **Static lint** (`tests/test_submissions.py`, wired into the existing `cli` job — ubuntu, seconds, no container): for every real submission asserts `algorithm.yml` parses, has `name/slug/stage/image/run`, `stage` is a known stage/span (from `stages.yml`), and the `run:` command references a file that exists. **37/37 current submissions pass.** This is the required, cheap gate.
2. **`evaluate --fail-on-dnf`** (advisory): a submission that pulls but can't run (broken `run.sh`, crash, wrong output artifact) now turns the `evaluate` check **red** instead of green. Not a required check (keeps merges off the self-hosted-runner critical path), just loud + visible. The metrics comment still posts via `always()` so the PR shows why.

Intended branch protection: require `image-access` + `cli` (which now includes the lint). `evaluate` stays advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)