### PR TITLE
cli: fix misleading dipole --magnitude + nominal TE (no bare-run crash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Scorer selfcheck + unit tests
         run: |
           python eval/qsm_eval.py --selfcheck
-          pytest -q eval/test_metrics.py tests/test_manifest.py tests/test_runner_help.py tests/test_submissions.py
+          pytest -q eval/test_metrics.py tests/test_manifest.py tests/test_runner_help.py tests/test_submissions.py tests/test_stages_sync.py
 
       - name: Scaffold check (qsm-ci new)
         run: |

--- a/algorithms/medi/algorithm.yml
+++ b/algorithms/medi/algorithm.yml
@@ -22,6 +22,10 @@ code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0
 run: bash run.sh
+# MEDI uses magnitude for its morphological (edge) weighting — the plain dipole stage doesn't take
+# magnitude, so this method opts it in as an optional input (surfaced by `qsm-ci run medi`).
+optional_inputs:
+  - magnitude
 parameters:
   - name: lambda
     default: 1e-4

--- a/examples/workflow-engines/Snakefile
+++ b/examples/workflow-engines/Snakefile
@@ -32,10 +32,9 @@ rule dipole:
         localfield="localfield.nii.gz",
         mask="mask.nii.gz",
         params="params.json",
-        magnitude="magnitude.nii.gz",
     output:
         chimap="chimap.nii.gz",
     params:
         slug="rts",
     shell:
-        "qsm-ci run {params.slug} --localfield {input.localfield} --mask {input.mask} --params {input.params} --magnitude {input.magnitude} -o {output.chimap}"
+        "qsm-ci run {params.slug} --localfield {input.localfield} --mask {input.mask} --params {input.params} -o {output.chimap}"

--- a/examples/workflow-engines/pipeline.cwl
+++ b/examples/workflow-engines/pipeline.cwl
@@ -56,7 +56,6 @@ steps:
         localfield: { type: File, inputBinding: { prefix: --localfield, position: 2 } }
         mask: { type: File, inputBinding: { prefix: --mask, position: 2 } }
         params: { type: "File?", inputBinding: { prefix: --params, position: 2 } }
-        magnitude: { type: "File?", inputBinding: { prefix: --magnitude, position: 2 } }
         out: { type: string, default: chimap.nii.gz, inputBinding: { prefix: -o, position: 2 } }
       outputs:
         chimap: { type: File, outputBinding: { glob: chimap.nii.gz } }
@@ -64,5 +63,4 @@ steps:
       localfield: bfr/localfield
       mask: mask
       params: params
-      magnitude: magnitude
     out: [chimap]

--- a/examples/workflow-engines/pipeline.nf
+++ b/examples/workflow-engines/pipeline.nf
@@ -42,20 +42,19 @@ process dipole {
     path localfield
     path mask
     path params
-    path magnitude
 
     output:
     path 'chimap.nii.gz'
 
     script:
     """
-    qsm-ci run ${slug} --localfield ${localfield} --mask ${mask} --params ${params} --magnitude ${magnitude} -o chimap.nii.gz
+    qsm-ci run ${slug} --localfield ${localfield} --mask ${mask} --params ${params} -o chimap.nii.gz
     """
 }
 
 workflow {
     field_mapping_out = field_mapping('romeo-fieldmap', file(params.phase), file(params.magnitude), file(params.mask), file(params.params))
     bfr_out = bfr('vsharp', field_mapping_out, file(params.mask), file(params.params))
-    dipole_out = dipole('rts', bfr_out, file(params.mask), file(params.params), file(params.magnitude))
+    dipole_out = dipole('rts', bfr_out, file(params.mask), file(params.params))
     dipole_out.collectFile(name: 'chimap.nii.gz', storeDir: params.outdir ?: '.')
 }

--- a/qsm_ci/runner.py
+++ b/qsm_ci/runner.py
@@ -33,6 +33,18 @@ OPTIONAL_ARTIFACTS = {"magnitude"}
 STACKABLE_ARTIFACTS = {"phase", "magnitude"}
 
 
+def _consumes(algo: dict) -> list:
+    """Artifacts a method takes as input: its stage's consumes plus any optional extras the method
+    itself declares (`optional_inputs:` in algorithm.yml). The plain `dipole` stage takes only the
+    local field, but a few methods (e.g. MEDI) additionally use magnitude for data-consistency
+    weighting — they opt in so *their* help lists --magnitude without implying every dipole method
+    needs it. Extras must be known optional artifacts and are appended once, after the stage inputs."""
+    base = STAGES[algo["stage"]]["consumes"]
+    extra = [a for a in (algo.get("optional_inputs") or [])
+             if a in OPTIONAL_ARTIFACTS and a not in base]
+    return base + extra
+
+
 def _parse_manifest(algo_dir: Path) -> dict:
     spec = algo_dir / "algorithm.yml"
     if not spec.exists():
@@ -202,6 +214,17 @@ def _place_echoes(paths: list, dest: Path, log) -> None:
     log(f"  stacked {len(ordered)} echoes → {dest.name}")
 
 
+def _ensure_te(te: list, stage: str) -> list:
+    """BFR/dipole don't use TE physically — the field is already in ppm and the TE·B0 scaling that
+    some recon code applies cancels out — but that code still indexes TE(1). Supply a nominal
+    placeholder so an omitted --te writes TE=[1.0] rather than an empty list that blows up the
+    container (MATLAB: "Index exceeds array bounds"). Never fabricates TE for phase-consuming
+    stages (field-mapping / end-to-end) — those genuinely need a real echo time."""
+    if te or "phase" in STAGES[stage]["consumes"]:
+        return te
+    return [1.0]
+
+
 def _params_dict(args, stage: str) -> dict:
     """Assemble a params.json dict from --te/--field-strength/--b0-dir/--voxel-size (+ defaults).
 
@@ -217,6 +240,7 @@ def _params_dict(args, stage: str) -> dict:
         raise SystemExit(
             f"the {stage} stage needs echo times and field strength — pass "
             "--te SEC [SEC ...] and --field-strength TESLA, or give a --params file.")
+    te = _ensure_te(te, stage)  # BFR/dipole: nominal placeholder if omitted (cancels; never empty)
     if b0 is None:
         b0 = 3.0  # unused by BFR/dipole; a contract placeholder
     b0_dir = list(args.b0_dir) if args.b0_dir is not None else [0.0, 0.0, 1.0]
@@ -284,6 +308,7 @@ def _sidecar_to_params(path: Path, obj: dict, args, stage: str) -> dict:
         b0_dir = args.b0_dir
     if args.voxel_size is not None:
         voxel = args.voxel_size
+    te = _ensure_te(te, stage)  # BFR/dipole: nominal placeholder if the sidecar carried no TE
     return {"TE": [float(t) for t in te], "B0": float(b0),
             "B0_dir": [float(x) for x in b0_dir], "voxel_size": [float(v) for v in voxel]}
 
@@ -291,7 +316,7 @@ def _sidecar_to_params(path: Path, obj: dict, args, stage: str) -> dict:
 def _inputs_summary(slug: str, algo: dict) -> str:
     """Tell the user exactly which inputs a valid slug's stage needs, with an example."""
     stage = algo["stage"]
-    consumes = STAGES[stage]["consumes"]
+    consumes = _consumes(algo)
     produced = STAGES[stage]["produces"][0]
     needs_echo = "phase" in consumes
     lines = [f"{algo['name']}  —  {stage} stage   ({', '.join(consumes)} → {produced})", "",
@@ -523,7 +548,7 @@ def _manifest_epilog(algo: dict) -> "str | None":
 
 def _build_run_parser(slug: str, algo: dict) -> argparse.ArgumentParser:
     stage = algo["stage"]
-    consumes = STAGES[stage]["consumes"]
+    consumes = _consumes(algo)
     produced = STAGES[stage]["produces"][0]
     desc = f"{algo['name']} — {stage} stage  ({', '.join(consumes)} → {produced})"
     if algo.get("description"):
@@ -624,7 +649,7 @@ def run_command(argv, log=print) -> int:
     algo = _parse_manifest(algo_dir)
 
     # `qsm-ci run <slug>` with no input files (and not --help): tell them what to provide.
-    artifact_flags = {f"--{art}" for art in STAGES[algo["stage"]]["consumes"]}
+    artifact_flags = {f"--{art}" for art in _consumes(algo)}
     gave_input = any(a.split("=", 1)[0] in artifact_flags for a in argv)
     if not has_help and not gave_input:
         log(_inputs_summary(slug, algo))
@@ -642,7 +667,7 @@ def run_command(argv, log=print) -> int:
         return 1
 
     stage = algo["stage"]
-    consumes = STAGES[stage]["consumes"]
+    consumes = _consumes(algo)
     produced = STAGES[stage]["produces"][0]
 
     import tempfile

--- a/qsm_ci/stages.py
+++ b/qsm_ci/stages.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 STAGES = {
     "field-mapping": {"consumes": ["phase", "magnitude", "mask", "params"], "produces": ["totalfield"]},
     "bfr": {"consumes": ["totalfield", "mask", "params"], "produces": ["localfield"]},
-    "dipole": {"consumes": ["localfield", "mask", "params", "magnitude"], "produces": ["chimap"]},
+    "dipole": {"consumes": ["localfield", "mask", "params"], "produces": ["chimap"]},
     "unwrap+bfr": {"consumes": ["phase", "magnitude", "mask", "params"], "produces": ["localfield"]},
     "bfr+dipole": {"consumes": ["totalfield", "mask", "params", "magnitude"], "produces": ["chimap"]},
     "end-to-end": {"consumes": ["phase", "magnitude", "mask", "params"], "produces": ["chimap"]},

--- a/tests/test_stages_sync.py
+++ b/tests/test_stages_sync.py
@@ -1,0 +1,35 @@
+"""Drift guard: qsm_ci/stages.py must mirror the authoritative stages.yml.
+
+qsm_ci/stages.py is a hand-maintained plain-Python copy of stages.yml (so the installed CLI needs
+no YAML dependency and no repo checkout). When they disagree, the CLI advertises inputs the scorer
+doesn't provide — e.g. dipole once listed `magnitude` in stages.py but not stages.yml, so every
+dipole method's `qsm-ci run` help implied a magnitude file it never uses. This test fails the PR
+instead: update qsm_ci/stages.py to match stages.yml.
+"""
+from pathlib import Path
+
+import yaml
+
+import qsm_ci.stages as pystages
+
+ROOT = Path(__file__).resolve().parent.parent
+_YML = yaml.safe_load((ROOT / "stages.yml").read_text())
+
+
+def test_stages_match_yaml():
+    expected = {
+        name: {"consumes": spec["consumes"], "produces": spec["produces"]}
+        for name, spec in {**_YML["stages"], **_YML["spans"]}.items()
+    }
+    assert pystages.STAGES == expected, (
+        "qsm_ci/stages.py STAGES drifted from stages.yml (stages + spans) — update it to match."
+    )
+
+
+def test_artifact_files_match_yaml():
+    expected = {
+        name: spec["file"] for name, spec in _YML["artifacts"].items() if "file" in spec
+    }
+    assert pystages.ARTIFACT_FILE == expected, (
+        "qsm_ci/stages.py ARTIFACT_FILE drifted from stages.yml artifacts.*.file — update it."
+    )


### PR DESCRIPTION
Surfaced by running `qsm-ci run matlab-sti-ilsqr --localfield … --mask …` (no `--te`) on a laptop — it crashed, and the help implied a magnitude file the method never uses.

### 1. Empty-TE crash → nominal TE
BFR/dipole methods don't use TE physically (the field is already ppm; the TE·B0 scaling some recon code applies cancels), but that code still indexes `TE(1)`. With no `--te` the CLI wrote `TE=[]`, so the container died with `Index exceeds array bounds` (`matlab-sti-*/recon.m:13`). Now non-phase stages get a nominal `TE=[1.0]` instead of an empty list. Phase-consuming stages (field-mapping / end-to-end) still **require** a real `--te` (unchanged).

### 2. Misleading `--magnitude` → method-scoped optional inputs
`qsm_ci/stages.py` listed `magnitude` under the `dipole` stage; the scorer's `stages.yml` does **not**. So every dipole method's `run` help advertised `--magnitude [optional]` even though almost none use it. Fixed by aligning `stages.py` to `stages.yml` and adding a per-method `optional_inputs:` opt-in. Only **MEDI** (magnitude-weighted) declares it; the other 16 dipole methods drop `--magnitude`.

Before/after for `qsm-ci run matlab-sti-ilsqr`:
```
- (localfield, mask, params, magnitude → chimap)      - --magnitude PATH  [optional]
+ (localfield, mask, params → chimap)
```
`qsm-ci run medi` still shows `--magnitude`.

### 3. Drift guard
`tests/test_stages_sync.py` asserts `qsm_ci/stages.py` mirrors `stages.yml` (STAGES + ARTIFACT_FILE) — this drift is what caused #2, so lock it down.

CLI-only, ships in the next release. **No MATLAB recompiles** — the nominal TE means the fragile `TE(1)` index is never reached. Verified locally: help output correct, `TE=[1.0]` for dipole, field-mapping still raises without `--te`, full `cli` test set green (48 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)