### PR TITLE
scorer: fix --magnitude drift that DNF'd all dipole methods (regression from #66)

### DIFF
--- a/results/index.json
+++ b/results/index.json
@@ -2,32 +2,6 @@
   "generated": null,
   "runs": [
     {
-      "contract": "v2",
-      "name": "octave-tkd",
-      "track": "sim",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 3.0080835819244385,
-      "metrics": {
-        "nrmse": 37.03495324457923,
-        "nrmse_detrend": 39.72054204822565,
-        "nrmse_tissue": 45.453110404587015,
-        "nrmse_blood": 67.38459622014909,
-        "nrmse_dgm": 32.514883589654865,
-        "dgm_linearity": 0.15603774142287863,
-        "calc_moment_dev": 8.90408793091774,
-        "calc_streak": 0.026247346398780638,
-        "correlation": 0.9293695765576047,
-        "xsim": 0.7143791507206863
-      },
-      "status": "ok",
-      "id": "octave-tkd-iso",
-      "slug": "octave-tkd",
-      "mode": "isolated"
-    },
-    {
       "name": "harperella",
       "track": "sim",
       "stage": "unwrap+bfr",

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -51,7 +51,7 @@ def _pmap(items, fn):
 STAGES = {
     "field-mapping": {"consumes": ["phase", "magnitude", "mask", "params"], "produces": ["totalfield"]},
     "bfr": {"consumes": ["totalfield", "mask", "params"], "produces": ["localfield"]},
-    "dipole": {"consumes": ["localfield", "mask", "params", "magnitude"], "produces": ["chimap"]},
+    "dipole": {"consumes": ["localfield", "mask", "params"], "produces": ["chimap"]},
     "unwrap+bfr": {"consumes": ["phase", "magnitude", "mask", "params"], "produces": ["localfield"]},
     "bfr+dipole": {"consumes": ["totalfield", "mask", "params", "magnitude"], "produces": ["chimap"]},
     "end-to-end": {"consumes": ["phase", "magnitude", "mask", "params"], "produces": ["chimap"]},
@@ -90,9 +90,16 @@ def discover_algorithms() -> list[dict]:
         if not stage:
             continue
         s = stage.group(1)
+        # A method may declare optional extra inputs (algorithm.yml `optional_inputs:`) beyond its
+        # stage's baseline — e.g. MEDI (dipole) uses magnitude for edge weighting. Append them so the
+        # scorer mounts + passes exactly what `qsm-ci run` accepts (its _consumes does the same);
+        # otherwise it passes a flag the CLI rejects (--magnitude) and the run DNFs.
+        opt = re.search(r"^optional_inputs:\s*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n?)+)", text, re.M)
+        optional = re.findall(r"-[ \t]*(\S+)", opt.group(1)) if opt else []
+        consumes = STAGES[s]["consumes"] + [a for a in optional if a not in STAGES[s]["consumes"]]
         algos.append({
             "slug": d.name, "dir": d, "stage": s, "image": image.group(1) if image else None,
-            "consumes": STAGES[s]["consumes"], "produces": STAGES[s]["produces"],
+            "consumes": consumes, "produces": STAGES[s]["produces"],
         })
     return algos
 

--- a/tests/test_stages_sync.py
+++ b/tests/test_stages_sync.py
@@ -1,11 +1,13 @@
-"""Drift guard: qsm_ci/stages.py must mirror the authoritative stages.yml.
+"""Drift guard: the two hand-maintained plain-Python copies of the stage table — qsm_ci/stages.py
+(so the installed CLI needs no YAML dep) and scripts/pipeline.py (the standalone scorer) — must
+both mirror the authoritative stages.yml.
 
-qsm_ci/stages.py is a hand-maintained plain-Python copy of stages.yml (so the installed CLI needs
-no YAML dependency and no repo checkout). When they disagree, the CLI advertises inputs the scorer
-doesn't provide — e.g. dipole once listed `magnitude` in stages.py but not stages.yml, so every
-dipole method's `qsm-ci run` help implied a magnitude file it never uses. This test fails the PR
-instead: update qsm_ci/stages.py to match stages.yml.
+When they disagree, the scorer and the CLI mount/accept different inputs: e.g. pipeline.py once kept
+`magnitude` under `dipole` while qsm_ci dropped it, so the scorer passed `--magnitude` to a `qsm-ci
+run` that rejected it and every dipole method DNF'd. These tests fail the PR instead — update the
+drifted copy to match stages.yml.
 """
+import importlib.util
 from pathlib import Path
 
 import yaml
@@ -15,21 +17,38 @@ import qsm_ci.stages as pystages
 ROOT = Path(__file__).resolve().parent.parent
 _YML = yaml.safe_load((ROOT / "stages.yml").read_text())
 
+_EXPECTED_STAGES = {
+    name: {"consumes": spec["consumes"], "produces": spec["produces"]}
+    for name, spec in {**_YML["stages"], **_YML["spans"]}.items()
+}
+_EXPECTED_FILES = {name: spec["file"] for name, spec in _YML["artifacts"].items() if "file" in spec}
 
-def test_stages_match_yaml():
-    expected = {
-        name: {"consumes": spec["consumes"], "produces": spec["produces"]}
-        for name, spec in {**_YML["stages"], **_YML["spans"]}.items()
-    }
-    assert pystages.STAGES == expected, (
+
+def _load_pipeline():
+    spec = importlib.util.spec_from_file_location("pipeline", ROOT / "scripts" / "pipeline.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_cli_stages_match_yaml():
+    assert pystages.STAGES == _EXPECTED_STAGES, (
         "qsm_ci/stages.py STAGES drifted from stages.yml (stages + spans) — update it to match."
     )
 
 
-def test_artifact_files_match_yaml():
-    expected = {
-        name: spec["file"] for name, spec in _YML["artifacts"].items() if "file" in spec
-    }
-    assert pystages.ARTIFACT_FILE == expected, (
+def test_cli_artifact_files_match_yaml():
+    assert pystages.ARTIFACT_FILE == _EXPECTED_FILES, (
         "qsm_ci/stages.py ARTIFACT_FILE drifted from stages.yml artifacts.*.file — update it."
+    )
+
+
+def test_scorer_stages_match_yaml():
+    pipeline = _load_pipeline()
+    assert pipeline.STAGES == _EXPECTED_STAGES, (
+        "scripts/pipeline.py STAGES drifted from stages.yml — update it (this is what made every "
+        "dipole method DNF when the CLI and scorer disagreed on --magnitude)."
+    )
+    assert pipeline.ARTIFACT_FILE == _EXPECTED_FILES, (
+        "scripts/pipeline.py ARTIFACT_FILE drifted from stages.yml artifacts.*.file — update it."
     )


### PR DESCRIPTION
### The bug
#66 removed `magnitude` from the CLI's dipole stage (`qsm_ci/stages.py`) but **not** from `scripts/pipeline.py`'s separate STAGES copy. So the scorer still mounted magnitude and passed `--magnitude` to `qsm-ci run <dipole-method>`, which the post-#66 CLI rejects:

```
qsm-ci run .../lpcnn: error: unrecognized arguments: --magnitude   (exit 2 → DNF)
```

The last rescore therefore DNF'd **every dipole method** (lpcnn, qsmnet, qsmnet-plus isolated + all composed combos, including matlab-bfrnet × dipole) — which is why those have no scores on the site.

### The fix
- `pipeline.py`: drop magnitude from the `dipole` stage and honour a method's `optional_inputs:` (algorithm.yml), so **MEDI** still gets magnitude while the rest don't — matching the CLI's `_consumes` exactly. Verified: `matlab-sti-ilsqr/lpcnn/qsmnet` → `[localfield, mask, params]`; `medi` → `+magnitude`; `tgv` (bfr+dipole) → `+magnitude`.
- `test_stages_sync.py`: extend the drift guard to also assert **`scripts/pipeline.py`**'s STAGES mirror `stages.yml` (the third copy — the one that just drifted).
- `results/index.json`: prune the stale `octave-tkd` entry (no such submission; lingered because `flush_index` merges rather than replaces).

Merging this re-triggers a **full rescore** (pipeline.py is a scoring path), which repopulates all the dipole + matlab-bfrnet scores correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)