### PR TITLE
submissions: complete metadata (DOI/authors/code_url) + TGV Langkammer regularization

### DIFF
--- a/algorithms/laplacian-fieldmap/algorithm.yml
+++ b/algorithms/laplacian-fieldmap/algorithm.yml
@@ -7,6 +7,7 @@ authors:
 - name: QSM-CI
   affiliation: Neurodesk
 doi: null
+code_url: https://github.com/QSMxT/QSM-CI
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/py-ref:v1
 run: bash run.sh

--- a/algorithms/lbv/algorithm.yml
+++ b/algorithms/lbv/algorithm.yml
@@ -5,6 +5,11 @@ engine: QSMxT / QSM.rs
 description: >
   Laplacian Boundary Value: solves the Laplacian of the field with boundary conditions.
 citation: Zhou et al., NMR Biomed 2014
+authors:
+- name: Dong Zhou
+- name: Tian Liu
+- name: Pascal Spincemaille
+- name: Yi Wang
 doi: 10.1002/nbm.3064
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT

--- a/algorithms/matlab-medi/algorithm.yml
+++ b/algorithms/matlab-medi/algorithm.yml
@@ -18,6 +18,7 @@ authors:
 - name: Yi Wang
 doi: 10.1016/j.neuroimage.2011.08.082
 citation: Liu et al., NeuroImage 2012
+code_url: http://pre.weill.cornell.edu/mri/pages/qsm.html
 license: See Cornell MEDI toolbox license
 image: ghcr.io/astewartau/qsm-ci/matlab-medi:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-iharperella/algorithm.yml
+++ b/algorithms/matlab-sti-iharperella/algorithm.yml
@@ -12,6 +12,7 @@ authors:
 - name: Chunlei Liu
 doi: 10.1002/nbm.3056
 citation: Li et al., NMR Biomed 2014
+code_url: https://people.eecs.berkeley.edu/~chunlei.liu/software.html
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-iharperella:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-ilsqr/algorithm.yml
+++ b/algorithms/matlab-sti-ilsqr/algorithm.yml
@@ -16,6 +16,7 @@ authors:
 - name: Chunlei Liu
 doi: 10.1016/j.neuroimage.2014.12.043
 citation: Li et al., NeuroImage 2015
+code_url: https://people.eecs.berkeley.edu/~chunlei.liu/software.html
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-ilsqr:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-star/algorithm.yml
+++ b/algorithms/matlab-sti-star/algorithm.yml
@@ -8,6 +8,7 @@ authors:
 - name: Hongjiang Wei and Chunlei Liu
   affiliation: UC Berkeley
 doi: 10.1002/nbm.3383
+code_url: https://people.eecs.berkeley.edu/~chunlei.liu/software.html
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-star:v1
 run: bash run.sh

--- a/algorithms/matlab-sti-vsharp/algorithm.yml
+++ b/algorithms/matlab-sti-vsharp/algorithm.yml
@@ -11,6 +11,7 @@ authors:
 - name: Chunlei Liu
 doi: 10.1002/mrm.23000
 citation: Wu et al., Magn Reson Med 2012
+code_url: https://people.eecs.berkeley.edu/~chunlei.liu/software.html
 license: See STI Suite license
 image: ghcr.io/astewartau/qsm-ci/matlab-sti-vsharp:v1
 run: bash run.sh

--- a/algorithms/matlab-tkd/algorithm.yml
+++ b/algorithms/matlab-tkd/algorithm.yml
@@ -13,6 +13,7 @@ authors:
 - name: Jeff H. Duyn
 doi: 10.1002/mrm.22135
 citation: Shmueli et al., Magn Reson Med 2009
+code_url: https://github.com/QSMxT/QSM-CI
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/matlab-tkd:v1
 run: bash run.sh

--- a/algorithms/nltv/algorithm.yml
+++ b/algorithms/nltv/algorithm.yml
@@ -4,8 +4,12 @@ stage: dipole
 engine: QSMxT / QSM.rs
 description: >
   Nonlocal Total Variation regularized inversion.
-citation: —
-doi: null
+citation: Kames et al., NeuroImage 2018
+authors:
+- name: Christian Kames
+- name: Vanessa Wiggermann
+- name: Alexander Rauscher
+doi: 10.1016/j.neuroimage.2017.11.018
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/pdf/algorithm.yml
+++ b/algorithms/pdf/algorithm.yml
@@ -5,6 +5,14 @@ engine: QSMxT / QSM.rs
 description: >
   Projection onto Dipole Fields: models the background field as external dipoles.
 citation: Liu et al., NMR Biomed 2011
+authors:
+- name: Tian Liu
+- name: Ildar Khalidov
+- name: Ludovic de Rochefort
+- name: Pascal Spincemaille
+- name: Jing Liu
+- name: A. John Tsiouris
+- name: Yi Wang
 doi: 10.1002/nbm.1670
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT

--- a/algorithms/resharp/algorithm.yml
+++ b/algorithms/resharp/algorithm.yml
@@ -5,6 +5,9 @@ engine: QSMxT / QSM.rs
 description: >
   Regularized SHARP with Tikhonov regularization of the deconvolution.
 citation: Sun & Wilman, Magn Reson Med 2014
+authors:
+- name: Hongfu Sun
+- name: Alan H. Wilman
 doi: 10.1002/mrm.24765
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT

--- a/algorithms/romeo-fieldmap/algorithm.yml
+++ b/algorithms/romeo-fieldmap/algorithm.yml
@@ -7,6 +7,7 @@ authors:
 - name: Dymerska and Eckstein et al.
   affiliation: Medical University of Vienna
 doi: 10.1002/mrm.28563
+code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/romeo-fieldmap:v1
 run: bash run.sh

--- a/algorithms/sharp/algorithm.yml
+++ b/algorithms/sharp/algorithm.yml
@@ -5,6 +5,11 @@ engine: QSMxT / QSM.rs
 description: >
   Sophisticated Harmonic Artifact Reduction for Phase data: SMV deconvolution.
 citation: Schweser et al., NeuroImage 2011
+authors:
+- name: Ferdinand Schweser
+- name: Andreas Deistung
+- name: Berengar Wendel Lehr
+- name: Jürgen Rainer Reichenbach
 doi: 10.1016/j.neuroimage.2010.10.070
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT

--- a/algorithms/tgv/algorithm.yml
+++ b/algorithms/tgv/algorithm.yml
@@ -5,6 +5,17 @@ engine: QSMxT / QSM.rs
 description: >
   Total Generalized Variation single-step reconstruction: total field -> susceptibility, doing its own background field removal.
 citation: Langkammer et al., NeuroImage 2015
+authors:
+- name: Christian Langkammer
+- name: Kristian Bredies
+- name: Benedikt A. Poser
+- name: Markus Barth
+- name: Gernot Reishofer
+- name: Audrey Peiwen Fan
+- name: Berkin Bilgic
+- name: Franz Fazekas
+- name: Caterina Mainero
+- name: Stefan Ropele
 doi: 10.1016/j.neuroimage.2015.02.041
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
@@ -15,8 +26,8 @@ parameters:
     default: 1000
     description: iterations
   - name: alpha1
-    default: 0.0015
-    description: first-order weight
+    default: 0.0005
+    description: first-order (gradient) weight
   - name: alpha0
-    default: 0.003
+    default: 0.0015
     description: second-order weight

--- a/algorithms/tgv/run.sh
+++ b/algorithms/tgv/run.sh
@@ -7,14 +7,24 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 #   $QSMCI_SET_<NAME>  for each  qsm-ci run --set NAME=VALUE  override
 B0=$(jq -r '.B0_dir | join(" ")' "$IN/params.json")
 
+# REGULARIZATION DEFAULT. The bare `qsmxt invert tgv` defaults (qsm_core TgvParams::default:
+# alpha1=alpha0=0.001) OVER-SMOOTH this data: alpha1 is the first-order (gradient) TGV weight, and
+# 0.001 flattens genuine susceptibility contrast (measured mean|grad| ~40% of ground truth, xsim
+# 0.32). The TGV-QSM reference (Langkammer et al., NeuroImage 2015 — the citation in algorithm.yml,
+# and the classic tgv_qsm default) uses alpha = [alpha1=0.0005, alpha0=0.0015], i.e. a weaker
+# gradient penalty. Passing those explicitly recovers the contrast (mean|grad| ~0.0094 vs 0.0074,
+# xsim 0.32 -> 0.47, nrmse 64.8% -> 56.1% on data/sim/scoring). These stay overridable via config.json.
+ALPHA1=0.0005; ALPHA0=0.0015; ITERS=""
+
 # Parameter overrides (qsm-ci run --set NAME=VALUE) arrive as /input/config.json.
-SET=""
 CFG="$IN/config.json"
 if [ -f "$CFG" ]; then
-  V=$(jq -r '.iterations // empty' "$CFG"); [ -n "$V" ] && SET="$SET --iterations $V"
-  V=$(jq -r '.alpha1 // empty' "$CFG"); [ -n "$V" ] && SET="$SET --alpha1 $V"
-  V=$(jq -r '.alpha0 // empty' "$CFG"); [ -n "$V" ] && SET="$SET --alpha0 $V"
+  V=$(jq -r '.iterations // empty' "$CFG"); [ -n "$V" ] && ITERS="$V"
+  V=$(jq -r '.alpha1 // empty' "$CFG"); [ -n "$V" ] && ALPHA1="$V"
+  V=$(jq -r '.alpha0 // empty' "$CFG"); [ -n "$V" ] && ALPHA0="$V"
 fi
+SET="--alpha1 $ALPHA1 --alpha0 $ALPHA0"
+[ -n "$ITERS" ] && SET="$SET --iterations $ITERS"
 # UNIT FIX (QSM-CI contract: totalfield is in ppm; QSMxT/QSM.rs `invert tgv` expects the field in
 # RADIANS). Internally tgv_qsm scales its result to ppm with  chi_ppm = chi_raw / (2*pi*gamma*TE*B0),
 # gamma = 42.5781 Hz/T (see QSM.rs src/inversion/tgv.rs). QSM.rs's own pipeline (run_tgv in

--- a/algorithms/tikhonov/algorithm.yml
+++ b/algorithms/tikhonov/algorithm.yml
@@ -4,8 +4,16 @@ stage: dipole
 engine: QSMxT / QSM.rs
 description: >
   Closed-form L2 (Tikhonov) regularized inversion.
-citation: Kames et al., 2018
-doi: null
+citation: Bilgic et al., JMRI 2014
+authors:
+- name: Berkin Bilgic
+- name: Itthi Chatnuntawech
+- name: Audrey P. Fan
+- name: Kawin Setsompop
+- name: Stephen F. Cauley
+- name: Lawrence L. Wald
+- name: Elfar Adalsteinsson
+doi: 10.1002/jmri.24365
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/algorithms/tsvd/algorithm.yml
+++ b/algorithms/tsvd/algorithm.yml
@@ -5,6 +5,10 @@ engine: QSMxT / QSM.rs
 description: >
   Truncated Singular Value Decomposition inversion.
 citation: Wharton et al., Magn Reson Med 2010
+authors:
+- name: Sam Wharton
+- name: Andreas Schäfer
+- name: Richard Bowtell
 doi: 10.1002/mrm.22334
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT

--- a/algorithms/tv/algorithm.yml
+++ b/algorithms/tv/algorithm.yml
@@ -4,8 +4,17 @@ stage: dipole
 engine: QSMxT / QSM.rs
 description: >
   Total Variation regularized dipole inversion solved with ADMM.
-citation: Bilgic et al., 2014
-doi: null
+citation: Bilgic et al., MRM 2014
+authors:
+- name: Berkin Bilgic
+- name: Audrey P. Fan
+- name: Jonathan R. Polimeni
+- name: Stephen F. Cauley
+- name: Marta Bianciardi
+- name: Elfar Adalsteinsson
+- name: Lawrence L. Wald
+- name: Kawin Setsompop
+doi: 10.1002/mrm.25029
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
 image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -217,7 +217,7 @@
       "description": "Multi-echo B0 field mapping by Laplacian phase unwrapping + linear fit over echoes. Reference `field-mapping`-stage submission (raw phase -> total field).",
       "citation": null,
       "doi": null,
-      "code_url": null,
+      "code_url": "https://github.com/QSMxT/QSM-CI",
       "license": "MIT",
       "authors": [
         "QSM-CI"
@@ -234,7 +234,12 @@
       "doi": "10.1002/nbm.3064",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Dong Zhou",
+        "Tian Liu",
+        "Pascal Spincemaille",
+        "Yi Wang"
+      ],
       "parameters": [
         {
           "name": "tol",
@@ -285,7 +290,7 @@
       "description": "Morphology Enabled Dipole Inversion (Cornell MEDI toolbox), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field, removes the background field with PDF, then solves the L1 morphology-regularized dipole inversion.",
       "citation": "Liu et al., NeuroImage 2012",
       "doi": "10.1016/j.neuroimage.2011.08.082",
-      "code_url": null,
+      "code_url": "http://pre.weill.cornell.edu/mri/pages/qsm.html",
       "license": "See Cornell MEDI toolbox license",
       "authors": [
         "Jing Liu",
@@ -331,7 +336,7 @@
       "description": "Integrated phase unwrapping + background field removal (iHARPERELLA) from STI Suite v3, compiled from MATLAB and run on the license-free MATLAB Runtime. Operates on wrapped multi-echo phase and yields the local tissue field (echoes combined with optimal TE^2 weights).",
       "citation": "Li et al., NMR Biomed 2014",
       "doi": "10.1002/nbm.3056",
-      "code_url": null,
+      "code_url": "https://people.eecs.berkeley.edu/~chunlei.liu/software.html",
       "license": "See STI Suite license",
       "authors": [
         "Wei Li",
@@ -361,7 +366,7 @@
       "description": "Iterative LSQR dipole inversion from STI Suite v3 (the reference iLSQR implementation), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the local field and solves for susceptibility with streaking-artifact reduction.",
       "citation": "Li et al., NeuroImage 2015",
       "doi": "10.1016/j.neuroimage.2014.12.043",
-      "code_url": null,
+      "code_url": "https://people.eecs.berkeley.edu/~chunlei.liu/software.html",
       "license": "See STI Suite license",
       "authors": [
         "Wei Li",
@@ -390,7 +395,7 @@
       "description": "STAR-QSM (streaking artifact reduction) dipole inversion from STI Suite v3, compiled from MATLAB and run on the license-free MATLAB Runtime. Fast two-level susceptibility inversion of the local field.",
       "citation": null,
       "doi": "10.1002/nbm.3383",
-      "code_url": null,
+      "code_url": "https://people.eecs.berkeley.edu/~chunlei.liu/software.html",
       "license": "See STI Suite license",
       "authors": [
         "Hongjiang Wei and Chunlei Liu"
@@ -411,7 +416,7 @@
       "description": "V-SHARP background field removal from STI Suite v3 (spatially-varying SMV deconvolution), compiled from MATLAB and run on the license-free MATLAB Runtime. Takes the total field and removes the background field to yield the local tissue field.",
       "citation": "Wu et al., Magn Reson Med 2012",
       "doi": "10.1002/mrm.23000",
-      "code_url": null,
+      "code_url": "https://people.eecs.berkeley.edu/~chunlei.liu/software.html",
       "license": "See STI Suite license",
       "authors": [
         "Bing Wu",
@@ -435,7 +440,7 @@
       "description": "Thresholded k-space division dipole inversion implemented in MATLAB and run on the license-free MATLAB Runtime. Reference `dipole`-stage submission demonstrating the MATLAB path.",
       "citation": "Shmueli et al., Magn Reson Med 2009",
       "doi": "10.1002/mrm.22135",
-      "code_url": null,
+      "code_url": "https://github.com/QSMxT/QSM-CI",
       "license": "MIT",
       "authors": [
         "Karin Shmueli",
@@ -530,11 +535,15 @@
       "stage": "dipole",
       "engine": "QSMxT / QSM.rs",
       "description": "Nonlocal Total Variation regularized inversion.",
-      "citation": "\u2014",
-      "doi": null,
+      "citation": "Kames et al., NeuroImage 2018",
+      "doi": "10.1016/j.neuroimage.2017.11.018",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Christian Kames",
+        "Vanessa Wiggermann",
+        "Alexander Rauscher"
+      ],
       "parameters": [
         {
           "name": "lambda",
@@ -558,7 +567,15 @@
       "doi": "10.1002/nbm.1670",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Tian Liu",
+        "Ildar Khalidov",
+        "Ludovic de Rochefort",
+        "Pascal Spincemaille",
+        "Jing Liu",
+        "A. John Tsiouris",
+        "Yi Wang"
+      ],
       "parameters": [
         {
           "name": "tol",
@@ -671,7 +688,10 @@
       "doi": "10.1002/mrm.24765",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Hongfu Sun",
+        "Alan H. Wilman"
+      ],
       "parameters": [
         {
           "name": "radius",
@@ -693,7 +713,7 @@
       "description": "Multi-echo B0 field mapping by ROMEO phase unwrapping (via the QSMxT/QSM.rs engine) with a per-voxel linear fit of unwrapped phase over echoes. Alternative to Laplacian field mapping.",
       "citation": null,
       "doi": "10.1002/mrm.28563",
-      "code_url": null,
+      "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
       "authors": [
         "Dymerska and Eckstein et al."
@@ -743,7 +763,12 @@
       "doi": "10.1016/j.neuroimage.2010.10.070",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Ferdinand Schweser",
+        "Andreas Deistung",
+        "Berengar Wendel Lehr",
+        "J\u00fcrgen Rainer Reichenbach"
+      ],
       "parameters": [
         {
           "name": "threshold",
@@ -767,7 +792,18 @@
       "doi": "10.1016/j.neuroimage.2015.02.041",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Christian Langkammer",
+        "Kristian Bredies",
+        "Benedikt A. Poser",
+        "Markus Barth",
+        "Gernot Reishofer",
+        "Audrey Peiwen Fan",
+        "Berkin Bilgic",
+        "Franz Fazekas",
+        "Caterina Mainero",
+        "Stefan Ropele"
+      ],
       "parameters": [
         {
           "name": "iterations",
@@ -776,12 +812,12 @@
         },
         {
           "name": "alpha1",
-          "default": 0.0015,
-          "description": "first-order weight"
+          "default": 0.0005,
+          "description": "first-order (gradient) weight"
         },
         {
           "name": "alpha0",
-          "default": 0.003,
+          "default": 0.0015,
           "description": "second-order weight"
         }
       ]
@@ -792,11 +828,19 @@
       "stage": "dipole",
       "engine": "QSMxT / QSM.rs",
       "description": "Closed-form L2 (Tikhonov) regularized inversion.",
-      "citation": "Kames et al., 2018",
-      "doi": null,
+      "citation": "Bilgic et al., JMRI 2014",
+      "doi": "10.1002/jmri.24365",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Berkin Bilgic",
+        "Itthi Chatnuntawech",
+        "Audrey P. Fan",
+        "Kawin Setsompop",
+        "Stephen F. Cauley",
+        "Lawrence L. Wald",
+        "Elfar Adalsteinsson"
+      ],
       "parameters": [
         {
           "name": "lambda",
@@ -841,7 +885,11 @@
       "doi": "10.1002/mrm.22334",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Sam Wharton",
+        "Andreas Sch\u00e4fer",
+        "Richard Bowtell"
+      ],
       "parameters": [
         {
           "name": "threshold",
@@ -856,11 +904,20 @@
       "stage": "dipole",
       "engine": "QSMxT / QSM.rs",
       "description": "Total Variation regularized dipole inversion solved with ADMM.",
-      "citation": "Bilgic et al., 2014",
-      "doi": null,
+      "citation": "Bilgic et al., MRM 2014",
+      "doi": "10.1002/mrm.25029",
       "code_url": "https://github.com/astewartau/QSM.rs",
       "license": "MIT",
-      "authors": [],
+      "authors": [
+        "Berkin Bilgic",
+        "Audrey P. Fan",
+        "Jonathan R. Polimeni",
+        "Stephen F. Cauley",
+        "Marta Bianciardi",
+        "Elfar Adalsteinsson",
+        "Lawrence L. Wald",
+        "Kawin Setsompop"
+      ],
       "parameters": [
         {
           "name": "lambda",


### PR DESCRIPTION
Two submission-quality fixes, bundled because they share `algorithms/tgv/algorithm.yml` + the generated manifest.

### 1. Metadata completeness
Every submission now has a **CrossRef-verified DOI**, **full authors**, and a **source/toolbox `code_url`**:
- **nltv / tikhonov / tv** — added DOIs (`10.1016/j.neuroimage.2017.11.018`, `10.1002/jmri.24365`, `10.1002/mrm.25029`) + authors + corrected citations.
- **lbv / pdf / resharp / sharp / tgv / tsvd** — filled author lists.
- **matlab-medi** → Cornell MEDI Toolbox; **matlab-sti-\*** → STI Suite; **matlab-tkd / laplacian-fieldmap** → in-repo; **romeo-fieldmap** → QSM.rs.
- `laplacian-fieldmap` DOI intentionally left null (composite reference method, no single primary paper).
- All 11 DL methods + medi/rts/tkd/etc. re-audited — already correct, unchanged.

### 2. TGV regularization
Override to the Langkammer reference **alpha1=0.0005, alpha0=0.0015** in `run.sh` (the qsmxt/QSM.rs default `0.001` over-smooths; verified **xsim 0.325 → 0.468**). The upstream default fix is **QSM.rs #47**; this override applies it now for the pinned `qsmxt:v9.4.0` image.

Manifest regenerated; drift-guard + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)