### PR TITLE
web: viewer + leaderboard overhaul

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+This repository is about benchmarking QSM pipelines and making them publicly available including a results leaderboard.
+
+At the start of reading this repo, ensure to read the README.md. 
+
+Before getting into any new task, ensure:
+
+ - Different approaches have been considered and communicated to the user, if there are any reasonable ones.
+ - To offer to spin up an agent to complete the task, if it is a well-defined and constrained one. 
+ - Do not do decide to do git commits, pushes, PRs, etc. on your own unless the user has specifically approved their use for the specific task. 
+ - If the task involves changing the website or something the user could test themselves, particularly if it's something that's difficult for you to automatically test (e.g. UI stuff), ensure the site is running locally at the completion of the task, and give the user a link or specific instructions to test what they should test.
+ 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -66,16 +66,21 @@ ARTIFACT_KIND = {"totalfield": "field", "localfield": "field", "chimap": "chi"}
 EMIT_VOLUMES = False  # when set, write recon/truth/error NIfTIs per run for the web viewer
 
 
-def emit_volumes(run_id, recon, truth):
-    """Write recon / truth / error volumes under results/<run_id>/ for the NiiVue viewer."""
+def emit_volumes(run_id, recon, truth, mask=None):
+    """Write recon / truth / error volumes under results/<run_id>/ for the NiiVue viewer.
+
+    The error map is the signed difference recon - truth, zeroed outside the raw brain mask so the
+    background stays clean (the viewer shows it with a diverging red↔blue colormap)."""
     import nibabel as nib
     d = ROOT / "results" / run_id
     d.mkdir(parents=True, exist_ok=True)
     shutil.copy(recon, d / "recon.nii.gz")
     shutil.copy(truth, d / "truth.nii.gz")
     r, t = nib.load(str(recon)), nib.load(str(truth))
-    err = nib.Nifti1Image((r.get_fdata() - t.get_fdata()).astype("float32"), r.affine)
-    nib.save(err, str(d / "error.nii.gz"))
+    err = (r.get_fdata() - t.get_fdata()).astype("float32")
+    if mask is not None:
+        err[nib.load(str(mask)).get_fdata() <= 0.5] = 0.0
+    nib.save(nib.Nifti1Image(err, r.affine), str(d / "error.nii.gz"))
 
 
 def discover_algorithms() -> list[dict]:
@@ -173,6 +178,7 @@ def _valid_mask(volume: Path, base_mask: Path, out: Path) -> Path:
 
 def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, meta: dict) -> dict:
     kind = ARTIFACT_KIND[artifact]
+    raw_mask = mask  # the full brain mask, before erosion — used to mask the viewer's error map
     # Score only where the method actually produced a value (its non-zero support), so an eroded
     # rim isn't penalised as error — consistent with masking that rim out of the pipeline.
     mask = _valid_mask(recon, mask, out_json.parent / (out_json.stem + "_scoremask.nii.gz"))
@@ -192,7 +198,7 @@ def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, 
     if "combo" in meta:
         result["combo"] = meta["combo"]
     if EMIT_VOLUMES and "id" in meta:
-        emit_volumes(meta["id"], recon, gt_dir / ARTIFACT_FILE[artifact])
+        emit_volumes(meta["id"], recon, gt_dir / ARTIFACT_FILE[artifact], raw_mask)
     return result
 
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -73,19 +73,73 @@ const MOON = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor
   document.addEventListener("DOMContentLoaded", () => document.head.appendChild(s));
 })();
 
-// Metric metadata: label, unit, better direction, decimals.
+// Global hover tooltip: any element with a [data-tip] attribute shows a styled tooltip. Rendered in a
+// single body-level layer (position:fixed) so it never clips inside overflow/scroll containers such as
+// the leaderboard table. Add `has-tip` for the dotted-underline "hover me" affordance.
+(function tooltips() {
+  const css = `
+  .has-tip{cursor:help;border-bottom:1px dotted rgba(107,114,128,.55)}
+  .qsm-tip{position:fixed;z-index:9999;max-width:270px;background:#111827;color:#f3f4f6;font-size:11px;
+    font-weight:400;line-height:1.5;letter-spacing:normal;text-transform:none;text-align:left;
+    padding:8px 10px;border-radius:8px;box-shadow:0 10px 30px rgba(0,0,0,.35);pointer-events:none;
+    opacity:0;transition:opacity .12s;display:none}
+  .qsm-tip.show{opacity:1}
+  html.dark .qsm-tip{background:#0b1220;box-shadow:0 10px 30px rgba(0,0,0,.6);outline:1px solid rgba(148,163,184,.15)}`;
+  let tip = null, cur = null;
+  // Follow the cursor: offset below-right, flipping to the other side near a viewport edge.
+  const positionAt = (x, y) => {
+    if (!tip) return;
+    const tw = tip.offsetWidth, th = tip.offsetHeight, pad = 8, off = 16;
+    let left = x + off, top = y + off;
+    if (left + tw > window.innerWidth - pad) left = x - tw - off;
+    if (top + th > window.innerHeight - pad) top = y - th - off;
+    tip.style.left = Math.max(pad, left) + "px";
+    tip.style.top = Math.max(pad, top) + "px";
+  };
+  const show = (target, x, y) => {
+    const text = target.getAttribute("data-tip"); if (!text) return;
+    cur = target;
+    if (!tip) { tip = document.createElement("div"); tip.className = "qsm-tip"; document.body.appendChild(tip); }
+    tip.textContent = text; tip.style.display = "block";
+    positionAt(x, y); tip.classList.add("show");
+  };
+  const hide = () => { cur = null; if (tip) { tip.classList.remove("show"); tip.style.display = "none"; } };
+  document.addEventListener("mouseover", (e) => { const t = e.target.closest?.("[data-tip]"); if (t) show(t, e.clientX, e.clientY); });
+  document.addEventListener("mousemove", (e) => {
+    if (!cur) return;
+    if (e.target.closest?.("[data-tip]") === cur) positionAt(e.clientX, e.clientY); else hide();
+  });
+  document.addEventListener("mouseout", (e) => { const t = e.target.closest?.("[data-tip]"); if (t === cur && !t?.contains(e.relatedTarget)) hide(); });
+  document.addEventListener("mousedown", hide, true);
+  const s = document.createElement("style"); s.textContent = css;
+  document.addEventListener("DOMContentLoaded", () => document.head.appendChild(s));
+})();
+
+// Metric metadata: label, unit, better direction, decimals, and a plain-language description
+// (surfaced as hover tooltips). Descriptions mirror eval/qsm_eval.py (ported from QSM.rs).
 const METRICS = {
-  nrmse:           { label: "NRMSE",            unit: "%", better: "lower",  dp: 1 },
-  nrmse_detrend:   { label: "Detrended NRMSE",  unit: "%", better: "lower",  dp: 1 },
-  nrmse_tissue:    { label: "Tissue NRMSE",     unit: "%", better: "lower",  dp: 1 },
-  nrmse_blood:     { label: "Blood NRMSE",      unit: "%", better: "lower",  dp: 1 },
-  nrmse_dgm:       { label: "DGM NRMSE",        unit: "%", better: "lower",  dp: 1 },
-  dgm_linearity:   { label: "DGM linearity",    unit: "",  better: "lower",  dp: 3 },
-  calc_moment_dev: { label: "Calcification dev.",unit: "", better: "lower",  dp: 2 },
-  calc_streak:     { label: "Streak",           unit: "",  better: "lower",  dp: 3 },
-  correlation:     { label: "Correlation",      unit: "",  better: "higher", dp: 3 },
-  xsim:            { label: "XSIM",             unit: "",  better: "higher", dp: 3 },
-  runtime_s:       { label: "Runtime",          unit: "s", better: "lower",  dp: 1 },
+  nrmse:           { label: "NRMSE",            unit: "%", better: "lower",  dp: 1,
+    desc: "Normalized root-mean-square error within the mask, after demeaning both maps. 0 = perfect; ~100% ≈ a flat map (the do-nothing baseline)." },
+  nrmse_detrend:   { label: "Detrended NRMSE",  unit: "%", better: "lower",  dp: 1,
+    desc: "NRMSE after correcting a global linear scaling of the reconstruction — measures error independent of overall contrast/gain." },
+  nrmse_tissue:    { label: "Tissue NRMSE",     unit: "%", better: "lower",  dp: 1,
+    desc: "Demeaned NRMSE restricted to brain-tissue regions (grey + white matter)." },
+  nrmse_blood:     { label: "Blood NRMSE",      unit: "%", better: "lower",  dp: 1,
+    desc: "Demeaned NRMSE restricted to venous blood regions." },
+  nrmse_dgm:       { label: "DGM NRMSE",        unit: "%", better: "lower",  dp: 1,
+    desc: "Demeaned NRMSE restricted to the deep grey-matter nuclei." },
+  dgm_linearity:   { label: "DGM linearity",    unit: "",  better: "lower",  dp: 3,
+    desc: "|1 − slope| of mean reconstructed vs. true susceptibility across the six deep grey-matter nuclei. 0 = a perfectly linear response." },
+  calc_moment_dev: { label: "Calcification dev.",unit: "", better: "lower",  dp: 2,
+    desc: "Absolute error in the total susceptibility moment recovered inside the calcification." },
+  calc_streak:     { label: "Streak",           unit: "",  better: "lower",  dp: 3,
+    desc: "Streaking-artefact level around the calcification: residual spread near its rim, relative to the calcification's mean susceptibility." },
+  correlation:     { label: "Correlation",      unit: "",  better: "higher", dp: 3,
+    desc: "Pearson correlation between reconstructed and ground-truth χ within the mask. 1 = perfect." },
+  xsim:            { label: "XSIM",             unit: "",  better: "higher", dp: 3,
+    desc: "Structural-similarity index tuned for QSM (5×5×5 windows). 1 = identical to the ground truth." },
+  runtime_s:       { label: "Runtime",          unit: "s", better: "lower",  dp: 1,
+    desc: "Wall-clock time taken by this run." },
 };
 const PREFERRED = ["nrmse", "nrmse_detrend", "nrmse_tissue", "nrmse_blood", "nrmse_dgm",
   "dgm_linearity", "calc_moment_dev", "calc_streak", "correlation", "xsim"];
@@ -133,6 +187,26 @@ function doiFor(registry, slug) {
 }
 
 function val(run, key) { return run.metrics?.[key] ?? run[key]; }
+
+// Robust [lo,hi] colour-scale window via Tukey fences: a few extreme outliers saturate at the ends
+// instead of crushing everyone else into one colour. Shared by the leaderboard matrix and the
+// submission-page metric ranks so their colouring matches. Falls back to min/max when too few points.
+function robustRange(vals) {
+  const s = vals.filter((v) => v != null && isFinite(v)).sort((a, b) => a - b);
+  const n = s.length;
+  if (n < 4) return [s[0] ?? 0, s[n - 1] ?? 1];
+  const q = (p) => s[Math.min(n - 1, Math.max(0, Math.round(p * (n - 1))))];
+  const q1 = q(0.25), q3 = q(0.75), iqr = q3 - q1;
+  const lo = Math.max(s[0], q1 - 1.5 * iqr), hi = Math.min(s[n - 1], q3 + 1.5 * iqr);
+  return lo < hi ? [lo, hi] : [s[0], s[n - 1]];
+}
+// Muted red → gold → sage for t in [0,1] (0 = worst, 1 = best) — the combination-matrix heat scale.
+function heatScale(t) {
+  const stops = [[190, 107, 107], [196, 158, 96], [110, 168, 134]];
+  const x = Math.max(0, Math.min(1, t)) * 2, i = Math.min(1, Math.floor(x)), f = x - i;
+  const c = stops[i].map((a, k) => Math.round(a + (stops[i + 1][k] - a) * f));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
 
 function fmt(v, key) {
   if (v == null) return "—";
@@ -212,4 +286,4 @@ function injectChrome() {
 document.addEventListener("DOMContentLoaded", injectChrome);
 
 // Exposed for module scripts (e.g. the NiiVue viewer, which must be a module for `import`).
-window.QSM = { GH, METRICS, STAGE_LABEL, MEDALS, loadRuns, loadAlgos, loadRegistry, doiFor, val, fmt, metricCols, heatColor };
+window.QSM = { GH, METRICS, STAGE_LABEL, MEDALS, loadRuns, loadAlgos, loadRegistry, doiFor, val, fmt, metricCols, heatColor, robustRange, heatScale };

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -1,8 +1,9 @@
 // Submission detail + NiiVue viewer: run sidebar, in-place switching, cohesive controls,
-// interactive dual-range windowing, and per-algorithm docs. Module scope; helpers via window.QSM.
+// histogram-backed dual-range windowing with typed bounds, and per-algorithm docs.
+// Module scope; helpers via window.QSM.
 import { Niivue } from "https://unpkg.com/@niivue/niivue@0.57.0/dist/index.js";
 
-const { loadRuns, loadAlgos, loadRegistry, doiFor, METRICS, STAGE_LABEL, val, fmt } = window.QSM;
+const { loadRuns, loadAlgos, loadRegistry, doiFor, METRICS, STAGE_LABEL, val, fmt, robustRange, heatScale } = window.QSM;
 
 const STAGE_COLOR = {
   "field-mapping": "bg-indigo-50 text-indigo-700 ring-indigo-100 dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-500/20",
@@ -79,7 +80,10 @@ function renderHowToRun() {
 
 let allRuns = [], algos = [], registry = {};
 let nv = null, run, baseUrl, filter = "", navMode = "stages";
-let gmin = 0, gmax = 1;  // data range for the windowing slider
+let curBase = "recon";       // base map shown underneath: recon | truth
+let showError = false;       // whether the error map is overlaid on top of the base
+let loadedBase = null, loadedError = false;  // what's actually in nv.volumes right now
+let baseCtl = null, errorCtl = null;         // the two windowing controls (base + error overlay)
 
 const $ = (id) => document.getElementById(id);
 function badge(text, cls) {
@@ -155,10 +159,16 @@ function pipelinesHTML() {
   const matrix = composedRuns().length
     ? axis("Field mapping", fmapsList(), "fmap") + axis("Background removal", bfrList(), "bfr") + axis("Dipole inversion", dipoleList(), "dipole")
     : "";
+  // Single-step χ producers, grouped by their self-described stage (not hardcoded per method) — the
+  // same split as the Stages view and the leaderboard: bfr+dipole and end-to-end are distinct spans.
   const combined = combinedRuns().filter((r) => !f || r.name.toLowerCase().includes(f));
-  const combinedSection = combined.length
-    ? `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Combined (single-step)</div>${combined.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("")}</div>`
-    : "";
+  const combinedGroup = (stage) => {
+    const rs = combined.filter((r) => r.stage === stage);
+    return rs.length
+      ? `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">${STAGE_LABEL[stage] || stage}</div>${rs.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("")}</div>`
+      : "";
+  };
+  const combinedSection = combinedGroup("bfr+dipole") + combinedGroup("end-to-end");
   return (matrix + combinedSection) ||
     `<p class="p-3 text-sm text-gray-400">No pipeline combinations available yet — the composed matrix is computed by the nightly job.</p>`;
 }
@@ -248,23 +258,52 @@ async function loadRun() {
     nv.setSliceType(nv.sliceTypeMultiplanar);
     wireControls();
   }
-  setLayerActive("recon");
-  try { await showLayer("recon"); } catch (e) {
+  // New run → nothing loaded yet; the base map (recon/truth) selection carries over between runs.
+  loadedBase = null; loadedError = false;
+  const hasError = !run.volumes || !!run.volumes.error;  // HF-backed runs advertise which volumes exist
+  if (!hasError) showError = false;
+  $("t-error").disabled = !hasError;
+  $("t-error").checked = showError;
+  setLayerActive(curBase);
+  try { await refreshView(); } catch (e) {
     canvas.style.visibility = "hidden";
     note.textContent = "Interactive volumes aren't available for this run.";
     note.classList.remove("hidden"); note.classList.add("flex");
   }
 }
 
+// Rank this run's value for metric `k` among comparable runs (same job: composed pipelines together,
+// or isolated runs sharing this run's stage). Returns { rank, n, t } where t is 0..1 goodness for
+// colour, or null when there's nothing to compare against.
+function metricRank(k) {
+  const meta = METRICS[k], v = run.metrics?.[k];
+  if (v == null) return null;
+  const sameGroup = (r) => (run.combo ? r.mode === "composed" : r.mode === "isolated" && r.stage === run.stage);
+  const peers = allRuns.filter((r) => r.status !== "DNF" && sameGroup(r) && val(r, k) != null);
+  if (peers.length < 2) return null;
+  const higher = meta.better !== "lower";
+  const rank = 1 + peers.filter((r) => (higher ? val(r, k) > v : val(r, k) < v)).length;
+  const [lo, hi] = robustRange(peers.map((r) => val(r, k)));
+  let t = hi === lo ? 0.5 : (v - lo) / (hi - lo);
+  if (!higher) t = 1 - t;
+  return { rank, n: peers.length, t };
+}
+
 function renderMetrics() {
   const m = run.metrics || {};
   $("metrics-sub").textContent = run.mode === "composed" ? "Final χ map vs. ground truth" : `${run.artifact || "output"} vs. ground truth`;
   const order = Object.keys(METRICS).filter((k) => m[k] != null);
+  const groupLabel = run.combo ? "composed pipelines" : `isolated ${STAGE_LABEL[run.stage] || run.stage} methods`;
   $("metrics-body").innerHTML = order.map((k) => {
     const meta = METRICS[k], arrow = meta.better === "higher" ? "↑" : "↓", hero = k === "xsim" || k === "nrmse";
+    const rk = metricRank(k);
+    const rankCell = rk
+      ? `<span class="inline-block rounded-md px-1.5 py-0.5 text-xs font-semibold text-white shadow-sm" style="background:${heatScale(rk.t)}" data-tip="Rank ${rk.rank} of ${rk.n} ${groupLabel} for ${meta.label}">#${rk.rank}<span class="opacity-70"> / ${rk.n}</span></span>`
+      : `<span class="text-gray-300 dark:text-gray-600">—</span>`;
     return `<tr>
-      <td class="py-2.5 text-gray-500 dark:text-gray-400">${meta.label} <span class="text-gray-300 dark:text-gray-600" title="${meta.better} is better">${arrow}</span></td>
+      <td class="py-2.5 text-gray-500 dark:text-gray-400"><span class="has-tip" data-tip="${(meta.desc || "").replace(/"/g, "&quot;")}">${meta.label}</span> <span class="text-gray-300 dark:text-gray-600" title="${meta.better} is better">${arrow}</span></td>
       <td class="py-2.5 text-right tabular-nums ${hero ? "font-bold text-gray-900 dark:text-gray-100" : "font-medium text-gray-700 dark:text-gray-300"}">${fmt(m[k], k)}</td>
+      <td class="py-2.5 pl-3 text-right">${rankCell}</td>
     </tr>`;
   }).join("") || `<tr><td class="py-3 text-gray-400">No metrics for this run.</td></tr>`;
 }
@@ -288,39 +327,248 @@ function defaultWindow(vol) {
   else autoWin(vol);                                                  // fields / everything else: auto
 }
 const fmtWin = (v) => (Math.abs(v) >= 100 ? v.toFixed(0) : Math.abs(v) >= 1 ? v.toFixed(2) : v.toPrecision(2));
+const fmtNum = (v) => String(+Number(v).toPrecision(4));
 
-function setupWindow() {
-  const v = baseVol(); if (!v) return;
-  gmin = v.global_min; gmax = v.global_max;
-  const step = (gmax - gmin) / 1000 || 1e-6;
-  for (const el of [$("win-lo"), $("win-hi")]) { el.min = gmin; el.max = gmax; el.step = step; }
-  $("win-lo").value = v.cal_min; $("win-hi").value = v.cal_max;
-  updateWindowUI();
+// Colormaps for the error overlay. Every option windows on |error| with a transparency floor (so the
+// masked, near-zero background stays clear); "diverging" colours the two signs differently (NiiVue
+// colormapNegative) for a signed red↔blue view, the rest reuse one map for both signs (magnitude only).
+const ERROR_CMAPS = {
+  diverging: { colormap: "warm", colormapNegative: "winter" },  // signed: red = recon>truth, blue = recon<truth
+  warm:    { colormap: "warm",    colormapNegative: "warm" },
+  hot:     { colormap: "hot",     colormapNegative: "hot" },
+  viridis: { colormap: "viridis", colormapNegative: "viridis" },
+  plasma:  { colormap: "plasma",  colormapNegative: "plasma" },
+  cool:    { colormap: "cool",    colormapNegative: "cool" },
+  gray:    { colormap: "gray",    colormapNegative: "gray" },
+};
+
+function setLoading(on) {
+  const el = $("viewer-loading");
+  el.classList.toggle("hidden", !on);
+  el.classList.toggle("flex", on);
 }
-function updateWindowUI() {
-  let lo = parseFloat($("win-lo").value), hi = parseFloat($("win-hi").value);
-  if (lo > hi) { [lo, hi] = [hi, lo]; }
-  const v = baseVol(); if (v) { v.cal_min = lo; v.cal_max = hi; nv.updateGLVolume(); }
-  const pct = (x) => (gmax === gmin ? 0 : ((x - gmin) / (gmax - gmin)) * 100);
-  $("win-fill").style.left = pct(lo) + "%";
-  $("win-fill").style.width = (pct(hi) - pct(lo)) + "%";
-  $("win-lo-bubble").style.left = pct(lo) + "%"; $("win-lo-bubble").textContent = fmtWin(lo);
-  $("win-hi-bubble").style.left = pct(hi) + "%"; $("win-hi-bubble").textContent = fmtWin(hi);
+
+// A self-contained windowing control: label, typed lo/hi bounds, Auto, a dual-range slider and an
+// intensity histogram drawn behind it. `getVol` returns the NiiVue volume it drives, so the same
+// widget serves both the base map and the error overlay. Instances live in `winControls` so a theme
+// toggle or resize can repaint every histogram at once. cal_min/cal_max are the source of truth;
+// typed bounds may fall outside [global_min, global_max] (the slider thumb clamps, the volume doesn't).
+const winControls = [];
+function makeWindowControl(getVol, cmapCfg) {
+  const el = document.createElement("div");
+  el.innerHTML = `
+    <div class="flex items-center gap-2">
+      <div class="dualrange flex-1" title="Scroll to zoom the range · double-click to reset">
+        <canvas class="hist"></canvas>
+        <div class="track"></div><div class="fill"></div>
+        <input class="rng-lo" type="range" /><input class="rng-hi" type="range" />
+        <span class="win-bubble bub-lo" contenteditable="true" inputmode="decimal" spellcheck="false" title="Click to edit this bound"></span>
+        <span class="win-bubble bub-hi" contenteditable="true" inputmode="decimal" spellcheck="false" title="Click to edit this bound"></span>
+      </div>
+      <div class="flex w-28 shrink-0 flex-col gap-1.5">
+        <select class="cmap-sel hidden w-full !py-1 !pl-2 !pr-6 text-[11px] leading-tight" title="Colormap"></select>
+        <button class="btn-auto w-full rounded-lg bg-white px-2.5 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700" title="Reset to an automatic window">Auto</button>
+      </div>
+    </div>
+    <div class="zoom-hint mt-0.5 text-[10px] text-gray-400 dark:text-gray-500"></div>`;
+  const q = (s) => el.querySelector(s);
+  const rngLo = q(".rng-lo"), rngHi = q(".rng-hi"),
+    fill = q(".fill"), bubLo = q(".bub-lo"), bubHi = q(".bub-hi"), canvas = q(".hist"),
+    dr = q(".dualrange"), hintEl = q(".zoom-hint"), cmapSel = q(".cmap-sel");
+  // Optional compact colormap dropdown sits above the Auto button. Fixed-width so a long selection
+  // (e.g. "Diverging (red ↔ blue)") truncates rather than widening the control; the native option list
+  // still shows each label in full.
+  if (cmapCfg) {
+    cmapSel.classList.remove("hidden");
+    cmapSel.innerHTML = cmapCfg.options.map(([v, l]) => `<option value="${v}">${l}</option>`).join("");
+    cmapSel.value = cmapCfg.value;
+    cmapSel.addEventListener("change", () => cmapCfg.onChange(cmapSel.value));
+  }
+  // magnitude=true windows on |value| over [0, maxAbs] — used for the signed error map under a diverging
+  // colormap, where cal_min/cal_max act as a magnitude transparency floor + saturation (mirrored to negatives).
+  // [dmin,dmax] is the full data range; [vmin,vmax] is the zoomed *view* the slider+histogram span, so
+  // scrolling to a narrow view makes each pixel of drag fine. cal_min/cal_max stay the source of truth.
+  let dmin = 0, dmax = 1, vmin = 0, vmax = 1, winLo = 0, winHi = 1, hist = null, magnitude = false;
+  const clampV = (x) => Math.min(vmax, Math.max(vmin, x));  // into the zoom view; thumbs pin, cal_* stay exact
+  const pct = (x) => (vmax === vmin ? 0 : ((clampV(x) - vmin) / (vmax - vmin)) * 100);
+
+  // Read the volume's current window + data range, reset the zoom to the full range, and sync the UI.
+  function setup() {
+    const v = getVol(); if (!v) return;
+    if (magnitude) { dmin = 0; dmax = Math.max(Math.abs(v.global_min), Math.abs(v.global_max)) || 1; }
+    else { dmin = v.global_min; dmax = v.global_max; }
+    vmin = dmin; vmax = dmax;
+    winLo = v.cal_min; winHi = v.cal_max;
+    applyView();
+  }
+  // Re-point the slider + histogram at the current zoom view [vmin,vmax] and reposition the window.
+  function applyView() {
+    const step = (vmax - vmin) / 1000 || 1e-6;
+    for (const r of [rngLo, rngHi]) { r.min = vmin; r.max = vmax; r.step = step; }
+    const zoomed = vmax - vmin < (dmax - dmin) * 0.999;
+    hintEl.textContent = zoomed
+      ? `zoomed to ${fmtWin(vmin)} – ${fmtWin(vmax)} · double-click to reset`
+      : "scroll over the bar to zoom in for finer control";
+    buildHistogram(getVol());
+    apply(winLo, winHi);
+  }
+  // Zoom the view by `factor` about the value under `frac` (0..1 across the bar), clamped to the data.
+  function zoom(factor, frac) {
+    const full = dmax - dmin || 1;
+    const span = Math.min(full, Math.max(full / 5000, (vmax - vmin) * factor));
+    const center = vmin + frac * (vmax - vmin);
+    let nmin = center - frac * span, nmax = nmin + span;
+    if (nmin < dmin) { nmin = dmin; nmax = dmin + span; }
+    if (nmax > dmax) { nmax = dmax; nmin = dmax - span; }
+    vmin = nmin; vmax = nmax;
+    applyView();
+  }
+  function apply(lo, hi) {
+    if (!isFinite(lo)) lo = dmin;
+    if (!isFinite(hi)) hi = dmax;
+    if (lo > hi) [lo, hi] = [hi, lo];
+    if (magnitude) { lo = Math.max(0, lo); hi = Math.max(0, hi); }  // magnitudes only
+    winLo = lo; winHi = hi;
+    const v = getVol(); if (v) { v.cal_min = lo; v.cal_max = hi; nv.updateGLVolume(); }
+    rngLo.value = clampV(lo); rngHi.value = clampV(hi);
+    fill.style.left = pct(lo) + "%"; fill.style.width = (pct(hi) - pct(lo)) + "%";
+    if (document.activeElement !== bubLo) bubLo.textContent = fmtWin(lo);  // don't clobber a bubble mid-edit
+    if (document.activeElement !== bubHi) bubHi.textContent = fmtWin(hi);
+    positionBubbles();
+    draw();
+  }
+  // Place the two value bubbles at their thumbs, but when they'd overlap nudge them apart symmetrically
+  // (clamped to the bar edges) so both stay readable when the bounds are close together.
+  function positionBubbles() {
+    const bw = dr.clientWidth || 1;
+    let cLo = (pct(winLo) / 100) * bw, cHi = (pct(winHi) / 100) * bw;
+    const wLo = bubLo.offsetWidth, wHi = bubHi.offsetWidth, minSep = wLo / 2 + wHi / 2 + 4;
+    if (cHi - cLo < minSep) {
+      const mid = (cLo + cHi) / 2;
+      cLo = mid - minSep / 2; cHi = mid + minSep / 2;
+      if (cLo < wLo / 2) { cLo = wLo / 2; cHi = cLo + minSep; }
+      if (cHi > bw - wHi / 2) { cHi = bw - wHi / 2; cLo = cHi - minSep; }
+    }
+    bubLo.style.left = cLo + "px"; bubHi.style.left = cHi + "px";
+  }
+  // Intensity histogram over the current zoom view. Exact-zero voxels are skipped (the masked background
+  // dominates otherwise) and counts are log-scaled so the tissue distribution stays visible next to the mode.
+  function buildHistogram(v) {
+    hist = null;
+    const img = v && v.img;
+    if (img && img.length && vmax > vmin) {
+      const slope = v.hdr?.scl_slope || 1, inter = v.hdr?.scl_inter || 0;
+      const NB = 128, counts = new Float64Array(NB);
+      const stride = Math.max(1, Math.floor(img.length / 400000));  // sample large volumes
+      for (let i = 0; i < img.length; i += stride) {
+        let x = img[i] * slope + inter;
+        if (magnitude) x = Math.abs(x);
+        if (!isFinite(x) || x === 0 || x < vmin || x > vmax) continue;  // only voxels in the zoom view
+        counts[Math.min(NB - 1, Math.max(0, Math.floor(((x - vmin) / (vmax - vmin)) * NB)))]++;
+      }
+      let max = 0;
+      for (let b = 0; b < NB; b++) { counts[b] = Math.log1p(counts[b]); if (counts[b] > max) max = counts[b]; }
+      if (max > 0) { for (let b = 0; b < NB; b++) counts[b] /= max; hist = counts; }
+    }
+    draw();
+  }
+  function draw() {
+    const w = canvas.clientWidth, h = canvas.clientHeight;
+    if (!w || !h) return;
+    const dpr = window.devicePixelRatio || 1;
+    if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) { canvas.width = Math.round(w * dpr); canvas.height = Math.round(h * dpr); }
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+    if (!hist) return;
+    const dark = document.documentElement.classList.contains("dark");
+    const px = (x) => ((x - vmin) / (vmax - vmin || 1)) * w;
+    const loX = px(winLo), hiX = px(winHi);
+    const NB = hist.length, bw = w / NB;
+    for (let b = 0; b < NB; b++) {
+      const bh = hist[b] * (h - 1);
+      if (!bh) continue;
+      const x = b * bw, mid = x + bw / 2;
+      ctx.fillStyle = mid >= loX && mid <= hiX ? (dark ? "#818cf8" : "#6366f1") : (dark ? "#4b5563" : "#d1d5db");
+      ctx.fillRect(x + 0.5, h - bh, Math.max(bw - 1, 0.75), bh);
+    }
+  }
+  // Slider drag moves only the dragged bound, so a typed out-of-range bound on the other side survives.
+  const onRange = (e) => {
+    const x = parseFloat(e.target.value);
+    const [lo, hi] = e.target === rngLo ? [x, winHi] : [winLo, x];
+    apply(Math.min(lo, hi), Math.max(lo, hi));
+  };
+  rngLo.addEventListener("input", onRange);
+  rngHi.addEventListener("input", onRange);
+  // The value bubbles are editable: click to type an exact bound (out-of-range allowed). On focus show the
+  // full-precision value and select it; Enter/blur commits, Escape reverts.
+  const bubVal = (b) => (b === bubLo ? winLo : winHi);
+  for (const b of [bubLo, bubHi]) {
+    b.addEventListener("focus", () => {
+      b.textContent = fmtNum(bubVal(b));
+      const r = document.createRange(); r.selectNodeContents(b);
+      const s = window.getSelection(); s.removeAllRanges(); s.addRange(r);
+    });
+    b.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") { e.preventDefault(); b.blur(); }
+      else if (e.key === "Escape") { e.preventDefault(); b.textContent = fmtWin(bubVal(b)); b.blur(); }
+    });
+    b.addEventListener("blur", () => {
+      const v = parseFloat(b.textContent);
+      apply(b === bubLo ? v : winLo, b === bubHi ? v : winHi);  // apply() handles NaN + lo/hi order
+    });
+  }
+  q(".btn-auto").addEventListener("click", () => { const v = getVol(); if (!v) return; autoWin(v); apply(v.cal_min, v.cal_max); });
+  // Scroll to zoom the view about the cursor (finer control in a narrow range); double-click resets.
+  dr.addEventListener("wheel", (e) => {
+    if (!getVol()) return;
+    e.preventDefault();
+    const rect = dr.getBoundingClientRect();
+    const frac = rect.width ? Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width)) : 0.5;
+    zoom(e.deltaY < 0 ? 0.8 : 1.25, frac);
+  }, { passive: false });
+  dr.addEventListener("dblclick", () => { if (!getVol()) return; vmin = dmin; vmax = dmax; applyView(); });
+
+  const ctl = { el, setup, redraw: () => { draw(); positionBubbles(); }, setMagnitude: (on) => { magnitude = on; }, cmapSelect: cmapSel };
+  winControls.push(ctl);
+  return ctl;
 }
 
 function wireControls() {
+  // base map colormap (recon/truth) — compact dropdown above this control's Auto button
+  baseCtl = makeWindowControl(() => nv.volumes[0], {
+    value: "gray",
+    options: [["gray", "Gray"], ["viridis", "Viridis"], ["plasma", "Plasma"], ["hot", "Hot"], ["cool", "Cool"]],
+    onChange: (v) => { const vol = baseVol(); if (vol) { vol.colormap = v; nv.updateGLVolume(); } },
+  });
+  // error overlay colormap — dropdown above the error window's Auto button; drives setErrorColormap
+  errorCtl = makeWindowControl(() => nv.volumes[1], {
+    value: "diverging",
+    options: [["diverging", "Diverging (red ↔ blue)"], ["warm", "Warm"], ["hot", "Hot"], ["viridis", "Viridis"], ["plasma", "Plasma"], ["cool", "Cool"], ["gray", "Gray"]],
+    onChange: () => setErrorColormap(),
+  });
+  $("win-base").appendChild(baseCtl.el);
+  $("win-error").appendChild(errorCtl.el);
+
   $("layer-tabs").querySelectorAll("button").forEach((t) =>
-    t.addEventListener("click", () => { setLayerActive(t.dataset.layer); showLayer(t.dataset.layer); }));
+    t.addEventListener("click", () => { curBase = t.dataset.layer; setLayerActive(curBase); refreshView(); }));
+  $("t-error").addEventListener("change", (e) => { showError = e.target.checked; refreshView(); });
   $("view-tabs").querySelectorAll("button").forEach((t) =>
     t.addEventListener("click", () => { setViewActive(t.dataset.view); nv.setSliceType(nv["sliceType" + cap(t.dataset.view)]); }));
-  $("cmap").addEventListener("change", () => { const v = baseVol(); if (v) { v.colormap = $("cmap").value; nv.updateGLVolume(); } });
   $("t-colorbar").addEventListener("change", (e) => { nv.opts.isColorbar = e.target.checked; nv.drawScene(); });
   $("t-crosshair").addEventListener("change", (e) => { nv.setCrosshairWidth(e.target.checked ? 0.75 : 0); });
   $("t-interp").addEventListener("change", (e) => { nv.setInterpolation(!e.target.checked); nv.drawScene(); });
-  $("win-lo").addEventListener("input", updateWindowUI);
-  $("win-hi").addEventListener("input", updateWindowUI);
-  $("win-auto").addEventListener("click", () => { const v = baseVol(); if (!v) return; autoWin(v); $("win-lo").value = v.cal_min; $("win-hi").value = v.cal_max; updateWindowUI(); });
-  $("opacity").addEventListener("input", (e) => { for (let i = 1; i < nv.volumes.length; i++) nv.setOpacity(i, parseFloat(e.target.value)); nv.updateGLVolume(); });
+  $("opacity").addEventListener("input", (e) => {
+    const o = parseFloat(e.target.value);
+    for (let i = 1; i < nv.volumes.length; i++) nv.setOpacity(i, o);
+    $("opacity-val").textContent = Math.round(o * 100) + "%";
+    nv.updateGLVolume();
+  });
+  const redrawAll = () => winControls.forEach((c) => c.redraw());
+  window.addEventListener("resize", redrawAll);
+  // theme toggle flips html.dark without reloading — recolour every histogram
+  new MutationObserver(redrawAll).observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
   nv.setInterpolation(true);
   setViewActive("multiplanar");
 }
@@ -328,21 +576,50 @@ function wireControls() {
 // Volumes are served from the Hugging Face Hub (run.volumes[kind]); fall back to local results/<id>/ for dev.
 const volUrl = (kind) => (run && run.volumes && run.volumes[kind]) || (baseUrl + kind + ".nii.gz");
 
-async function showLayer(layer) {
-  const cmap = $("cmap").value, overlayCtl = $("overlay-ctl");
-  if (layer === "error") {
-    await nv.loadVolumes([{ url: volUrl("truth"), colormap: cmap }]);
-    defaultWindow(baseVol());
-    await nv.addVolumeFromUrl({ url: volUrl("error"), colormap: "warm", opacity: parseFloat($("opacity").value) });
-    autoWin(nv.volumes[nv.volumes.length - 1]);
-    overlayCtl.classList.remove("hidden"); overlayCtl.classList.add("flex");
-  } else {
-    await nv.loadVolumes([{ url: volUrl(layer === "truth" ? "truth" : "recon"), colormap: cmap }]);
-    defaultWindow(baseVol());
-    overlayCtl.classList.add("hidden"); overlayCtl.classList.remove("flex");
-  }
+// Reconcile the viewer with (curBase, showError): reload the base only when it changes, add/remove the
+// error overlay independently, and show a second windowing section for the error map when it's on.
+async function refreshView() {
+  const cmap = baseCtl.cmapSelect.value;
+  const baseKind = curBase === "truth" ? "truth" : "recon";
+  const needBase = loadedBase !== baseKind || !nv.volumes.length;
+  if (needBase || (showError && !loadedError)) setLoading(true);  // only when a fetch is actually pending
+  try {
+    if (needBase) {
+      await nv.loadVolumes([{ url: volUrl(baseKind), colormap: cmap }]);  // replaces all volumes (drops any overlay)
+      defaultWindow(baseVol());
+      loadedBase = baseKind; loadedError = false;
+      baseCtl.setup();
+    }
+    if (showError && !loadedError) {
+      await nv.addVolumeFromUrl({ url: volUrl("error"), opacity: parseFloat($("opacity").value) });
+      loadedError = true;
+      setErrorColormap();  // sets colormap (+ diverging negative), window, magnitude mode and label
+    } else if (!showError && loadedError) {
+      nv.removeVolumeByUrl(volUrl("error"));
+      loadedError = false;
+    }
+  } finally { setLoading(false); }
   nv.updateGLVolume();
-  setupWindow();
+  $("win-error-section").classList.toggle("hidden", !showError);
+}
+
+// Apply the chosen error-overlay colormap. The error is always windowed on |error| (magnitude) with a
+// transparency floor: cal_min hides near-zero background, cal_max saturates, both mirrored to the
+// negative side. χ error uses the eval's ppm scale (floor 0.01, sat 0.1 ppm).
+function setErrorColormap() {
+  if (!loadedError) return;
+  const ov = nv.volumes[nv.volumes.length - 1];
+  const cfg = ERROR_CMAPS[errorCtl.cmapSelect.value] || ERROR_CMAPS.diverging;
+  ov.colormap = cfg.colormap;
+  ov.colormapNegative = cfg.colormapNegative;
+  if (run.kind === "chi") { ov.cal_min = 0.01; ov.cal_max = 0.1; }
+  else {
+    const m = Math.max(Math.abs(ov.robust_min ?? ov.global_min), Math.abs(ov.robust_max ?? ov.global_max)) || 1;
+    ov.cal_min = 0.02 * m; ov.cal_max = m;
+  }
+  errorCtl.setMagnitude(true);
+  errorCtl.setup();
+  nv.updateGLVolume();
 }
 
 // ---- boot -------------------------------------------------------------------
@@ -359,7 +636,12 @@ async function init() {
   navMode = run.mode === "composed" ? "pipelines" : "stages";
   $("run-filter").addEventListener("input", (e) => { filter = e.target.value; buildSidebar(); });
   document.querySelectorAll("#nav-toggle button").forEach((b) => b.addEventListener("click", () => { navMode = b.dataset.mode; buildSidebar(); }));
+  // Deep links: ?layer=truth selects the ground-truth base; ?layer=error (or ?error=1) turns on the
+  // error overlay. Applied before the first render so loadRun picks them up.
+  const layer = q.get("layer");
+  if (layer === "truth") curBase = "truth";
+  if (layer === "error" || q.get("error") === "1") showError = true;
   buildSidebar();
-  loadRun();
+  await loadRun();
 }
 init();

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -39,11 +39,21 @@ function runLine(slug, stage, truth) {
 
 // The qsm-ci command(s) that reproduce this run: one line for an isolated method, the
 // field-mapping → bfr → dipole chain for a composed pipeline.
+// QSM-CI reproduces the scored artifact; QSMxT runs the same method(s) end-to-end from BIDS. Which
+// slugs QSMxT can run is read from each algorithm's self-described `engine` (contains "QSM.rs") — no
+// per-method hardcoding — and the qsmxt flag follows from the stage.
+const QSMXT_FLAG = {
+  bfr: "--bf-algorithm", "unwrap+bfr": "--bf-algorithm",
+  dipole: "--qsm-algorithm", "bfr+dipole": "--qsm-algorithm", "end-to-end": "--qsm-algorithm",
+};
 function renderHowToRun() {
   const el = $("how-to-run");
   if (!el) return;
   const bySlug = Object.fromEntries(algos.map((a) => [a.slug, a]));
   const stageOf = (s) => (bySlug[s] ? bySlug[s].stage : null);
+  const isQsmRs = (slug) => { const a = bySlug[slug]; return !!(a && a.engine && a.engine.includes("QSM.rs")); };
+
+  // ---- QSM-CI command (reproduces the scored artifact) ----
   const lines = [];
   if (run.combo) {
     const { field_mapping: fm, bfr, dipole } = run.combo;
@@ -54,28 +64,66 @@ function renderHowToRun() {
     lines.push(runLine(run.slug, run.stage, true));
   }
   if (!lines.length) { el.classList.add("hidden"); return; }
-  el.classList.remove("hidden");  // the div ships with Tailwind `hidden`; clear the class, not just inline style
-  const full = "pip install qsm-ci\n" + lines.join("\n");
+  const ciCmd = "pip install qsm-ci\n" + lines.join("\n");
   const chained = lines.length > 1;
+
+  // ---- QSMxT command (only when every method step is QSM.rs-backed) ----
+  const xtCmd = (() => {
+    const parts = ["qsmxt run /path/to/bids /path/to/output"];
+    if (run.combo) {
+      const { field_mapping: fm, bfr, dipole } = run.combo;
+      if (!isQsmRs(bfr) || !isQsmRs(dipole)) return null;
+      if (fm && fm !== "gt") { if (!isQsmRs(fm)) return null; parts.push(`--unwrapping-algorithm ${fm.replace(/-fieldmap$/, "")}`); }
+      parts.push(`--bf-algorithm ${bfr}`, `--qsm-algorithm ${dipole}`);
+    } else {
+      if (!isQsmRs(run.slug) || !QSMXT_FLAG[run.stage]) return null;
+      parts.push(`${QSMXT_FLAG[run.stage]} ${run.slug}`);
+    }
+    return parts.join(" \\\n  ");
+  })();
+
+  el.classList.remove("hidden");  // the div ships with Tailwind `hidden`; clear the class, not just inline style
+
+  const codePane = (cmd, key, hidden) =>
+    `<div data-pane="${key}" class="relative mt-3 ${hidden ? "hidden" : ""}">
+      <button data-copy="${key}" class="absolute right-2 top-2 rounded-md bg-gray-800/80 px-2 py-1 text-xs font-medium text-gray-100 hover:bg-gray-700">Copy</button>
+      <pre class="overflow-x-auto rounded-xl bg-gray-900 p-4 text-xs leading-relaxed text-gray-100"><code>${escapeHtml(cmd)}</code></pre>
+    </div>`;
+  const tabBtn = (key, label, active) =>
+    `<button data-tab="${key}" class="rounded-md px-3 py-1 transition ${active ? "bg-white shadow-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100" : "text-gray-500 hover:text-gray-700 dark:text-gray-400"}">${label}</button>`;
+
+  const ciDesc = `Reproduce the scored artifact with the <a href="running.html" class="text-emerald-600 hover:underline"><code>qsm-ci</code></a> CLI —
+      bring your own NIfTIs${chained ? ", chained stage by stage," : ""} or make a phantom with <code>qsm-forward</code>. Drop <code>--truth</code> to run without scoring.`;
+  const xtDesc = `Run this ${run.combo ? "pipeline" : "method"} end-to-end on your own BIDS data with
+      <a href="https://qsmxt.github.io" class="text-emerald-600 hover:underline">QSMxT</a> — unwrapping, background removal and dipole
+      inversion in one command, on the same <a href="https://github.com/astewartau/QSM.rs" class="text-emerald-600 hover:underline">QSM.rs</a> engine QSM-CI uses.`;
+
   el.innerHTML = `
     <div class="flex items-baseline justify-between gap-3">
       <h2 class="font-semibold text-gray-900 dark:text-gray-100">Run this yourself</h2>
       <a href="running.html" class="text-xs text-emerald-600 hover:underline">Guide to running algorithms →</a>
     </div>
-    <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-      Reproduce it with the <a href="running.html" class="text-emerald-600 hover:underline"><code>qsm-ci</code></a> CLI —
-      bring your own NIfTIs${chained ? ", chained stage by stage," : ""} or make a phantom with
-      <code>qsm-forward</code>. Drop <code>--truth</code> to run without scoring.
-    </p>
-    <div class="relative mt-3">
-      <button data-copy class="absolute right-2 top-2 rounded-md bg-gray-800/80 px-2 py-1 text-xs font-medium text-gray-100 hover:bg-gray-700">Copy</button>
-      <pre class="overflow-x-auto rounded-xl bg-gray-900 p-4 text-xs leading-relaxed text-gray-100"><code>${escapeHtml(full)}</code></pre>
-    </div>`;
-  const btn = el.querySelector("[data-copy]");
-  if (btn) btn.addEventListener("click", () => {
-    navigator.clipboard.writeText(full);
+    ${xtCmd ? `<div class="mt-2 inline-flex rounded-lg bg-gray-100 p-1 text-xs font-medium dark:bg-gray-800" data-howto-tabs>${tabBtn("ci", "QSM-CI", true)}${tabBtn("xt", "QSMxT", false)}</div>` : ""}
+    <p data-desc="ci" class="mt-2 text-sm text-gray-600 dark:text-gray-400">${ciDesc}</p>
+    ${xtCmd ? `<p data-desc="xt" class="mt-2 hidden text-sm text-gray-600 dark:text-gray-400">${xtDesc}</p>` : ""}
+    ${codePane(ciCmd, "ci", false)}
+    ${xtCmd ? codePane(xtCmd, "xt", true) : ""}`;
+
+  const cmds = { ci: ciCmd, xt: xtCmd };
+  el.querySelectorAll("[data-copy]").forEach((btn) => btn.addEventListener("click", () => {
+    navigator.clipboard.writeText(cmds[btn.dataset.copy]);
     btn.textContent = "Copied"; setTimeout(() => (btn.textContent = "Copy"), 1200);
-  });
+  }));
+  const tabs = el.querySelector("[data-howto-tabs]");
+  if (tabs) tabs.querySelectorAll("[data-tab]").forEach((b) => b.addEventListener("click", () => {
+    const key = b.dataset.tab;
+    tabs.querySelectorAll("[data-tab]").forEach((t) =>
+      t.className = "rounded-md px-3 py-1 transition " + (t.dataset.tab === key ? "bg-white shadow-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100" : "text-gray-500 hover:text-gray-700 dark:text-gray-400"));
+    for (const k of ["ci", "xt"]) {
+      el.querySelector(`[data-pane="${k}"]`)?.classList.toggle("hidden", k !== key);
+      el.querySelector(`[data-desc="${k}"]`)?.classList.toggle("hidden", k !== key);
+    }
+  }));
 }
 
 let allRuns = [], algos = [], registry = {};

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -46,66 +46,47 @@
       <template x-if="view==='composed' && fmaps().length>1">
         <label class="inline-flex items-center gap-2 text-sm text-gray-600">Field mapping
           <select x-model="fmap" class="rounded-lg border-gray-300 text-sm py-1.5 pr-8">
-            <template x-for="f in fmaps()" :key="f"><option :value="f" x-text="f==='gt' ? 'ground truth' : f"></option></template>
+            <template x-for="f in fmaps()" :key="f"><option :value="f" :selected="f===fmap" x-text="f==='gt' ? 'ground truth' : f"></option></template>
           </select>
         </label>
       </template>
-      <div class="grow"></div>
-      <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
-      <!-- metric column picker -->
-      <div class="relative" @click.outside="colMenu=false">
-        <button @click="colMenu=!colMenu" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-          Metrics
-          <span class="rounded bg-gray-100 px-1.5 text-xs" x-text="displayCols.length"></span>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        </button>
-        <div x-show="colMenu" x-cloak class="absolute right-0 z-20 mt-2 w-56 rounded-xl border border-gray-200 bg-white p-1.5 shadow-lg" style="display:none">
-          <template x-for="c in cols" :key="c">
-            <label class="flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm hover:bg-gray-50 cursor-pointer">
-              <input type="checkbox" class="accent-emerald-600" :checked="selectedCols.includes(c)" @change="toggleCol(c)" />
-              <span x-text="METRICS[c].label"></span>
-              <span class="ml-auto text-xs text-gray-400" x-text="METRICS[c].unit || (METRICS[c].better==='higher'?'↑':'↓')"></span>
-            </label>
-          </template>
-        </div>
-      </div>
     </div>
 
     <!-- combination matrix -->
-    <template x-if="view==='composed' && matrix.bfrs.length">
+    <template x-if="view==='composed' && matrix.rows.length">
       <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
         <div class="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 class="font-semibold text-gray-900">Combination matrix</h2>
-            <p class="mt-0.5 text-xs text-gray-500">Background removal <span class="text-gray-400">↓</span> × dipole inversion <span class="text-gray-400">→</span>, chained end-to-end · click a cell to inspect.</p>
+            <p class="mt-0.5 text-xs text-gray-500">Dipole inversion <span class="text-gray-400">↓</span> × background removal <span class="text-gray-400">→</span>, chained end-to-end · best methods top-left · click a cell to inspect.</p>
           </div>
           <label class="inline-flex items-center gap-2 text-sm text-gray-600">Colour by
             <select x-model="metric" class="rounded-lg border-gray-300 text-sm py-1.5 pr-8">
-              <template x-for="c in cols.filter(c=>c!=='runtime_s')" :key="c"><option :value="c" x-text="METRICS[c].label"></option></template>
+              <template x-for="c in cols.filter(c=>c!=='runtime_s')" :key="c"><option :value="c" :selected="c===metric" x-text="METRICS[c].label"></option></template>
             </select>
           </label>
         </div>
 
         <div class="mt-5 overflow-x-auto">
-          <div class="inline-grid gap-1.5" :style="`grid-template-columns: auto repeat(${matrix.dips.length}, minmax(6.5rem,1fr))`">
+          <div class="inline-grid gap-1.5" :style="`grid-template-columns: auto repeat(${matrix.cols.length}, minmax(6.5rem,1fr))`">
             <div></div>
-            <template x-for="d in matrix.dips" :key="'h'+d">
-              <div class="pb-1 text-center text-xs font-semibold text-gray-500 truncate" x-text="d"></div>
+            <template x-for="c in matrix.cols" :key="'h'+c">
+              <div class="pb-1 text-center text-xs font-semibold text-gray-500 truncate" x-text="c"></div>
             </template>
-            <template x-for="b in matrix.bfrs" :key="b">
-              <template x-for="(d,di) in ['__row__', ...matrix.dips]" :key="b+'-'+d+di">
+            <template x-for="rw in matrix.rows" :key="rw">
+              <template x-for="(c,ci) in ['__row__', ...matrix.cols]" :key="rw+'-'+c+ci">
                 <div>
-                  <div x-show="d==='__row__'" class="flex h-14 items-center justify-end pr-3 text-xs font-semibold text-gray-500 whitespace-nowrap" x-text="b"></div>
-                  <template x-if="d!=='__row__'">
-                    <template x-if="matrix.cell[b+'|'+d]">
-                      <button @click="go(matrix.cell[b+'|'+d])"
-                        :title="b+' + '+d+' — '+METRICS[metric].label+': '+fmt(val(matrix.cell[b+'|'+d],metric),metric)"
+                  <div x-show="c==='__row__'" class="flex h-14 items-center justify-end pr-3 text-xs font-semibold text-gray-500 whitespace-nowrap" x-text="rw"></div>
+                  <template x-if="c!=='__row__'">
+                    <template x-if="matrix.cell[c+'|'+rw]">
+                      <button @click="go(matrix.cell[c+'|'+rw])"
+                        :title="c+' + '+rw+' — '+METRICS[metric].label+': '+fmt(val(matrix.cell[c+'|'+rw],metric),metric)"
                         class="group relative h-14 w-full rounded-xl text-white font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none ring-1 ring-black/5"
-                        :style="'background:'+heat(norm(val(matrix.cell[b+'|'+d],metric)))">
-                        <span x-text="fmt(val(matrix.cell[b+'|'+d], metric), metric)"></span>
+                        :style="'background:'+heat(norm(val(matrix.cell[c+'|'+rw],metric)))">
+                        <span x-text="fmt(val(matrix.cell[c+'|'+rw], metric), metric)"></span>
                       </button>
                     </template>
-                    <template x-if="!matrix.cell[b+'|'+d]">
+                    <template x-if="!matrix.cell[c+'|'+rw]">
                       <div class="flex h-14 w-full items-center justify-center rounded-xl border border-dashed border-gray-200 text-gray-300 text-sm">—</div>
                     </template>
                   </template>
@@ -120,18 +101,25 @@
           <div class="mt-6 border-t border-gray-100 pt-5">
             <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-500">
               Combined single-method algorithms
-              <span class="font-normal normal-case tracking-normal text-gray-400">— background removal + dipole inversion in one step</span>
+              <span class="font-normal normal-case tracking-normal text-gray-400">— one step straight to a χ map</span>
             </p>
-            <div class="flex flex-col gap-1.5">
-              <template x-for="r in combinedAlgos" :key="r.id">
-                <div class="flex items-center gap-3">
-                  <div class="w-40 shrink-0 truncate pr-1 text-right text-xs font-semibold text-gray-500" x-text="r.name"></div>
-                  <button @click="go(r)"
-                    :title="r.name+' — '+METRICS[metric].label+': '+fmt(val(r,metric),metric)"
-                    class="group relative h-14 w-40 shrink-0 rounded-xl text-white font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none ring-1 ring-black/5"
-                    :style="'background:'+heat(norm(val(r,metric)))">
-                    <span x-text="fmt(val(r, metric), metric)"></span>
-                  </button>
+            <div class="grid gap-x-10 gap-y-4 sm:grid-cols-2">
+              <template x-for="grp in [{stage:'bfr+dipole', label:'Background removal + dipole inversion'}, {stage:'end-to-end', label:'End-to-end'}]" :key="grp.stage">
+                <div x-show="combinedAlgos.some(r=>r.stage===grp.stage)">
+                  <p class="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400" x-text="grp.label"></p>
+                  <div class="flex flex-col gap-1.5">
+                    <template x-for="r in combinedAlgos.filter(r=>r.stage===grp.stage)" :key="r.id">
+                      <div class="flex items-center gap-3">
+                        <div class="w-36 shrink-0 truncate pr-1 text-right text-xs font-semibold text-gray-500" x-text="r.name"></div>
+                        <button @click="go(r)"
+                          :title="r.name+' — '+METRICS[metric].label+': '+fmt(val(r,metric),metric)"
+                          class="group relative h-14 w-40 shrink-0 rounded-xl text-white font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none ring-1 ring-black/5"
+                          :style="'background:'+heat(norm(val(r,metric)))">
+                          <span x-text="fmt(val(r, metric), metric)"></span>
+                        </button>
+                      </div>
+                    </template>
+                  </div>
                 </div>
               </template>
             </div>
@@ -148,16 +136,39 @@
       </div>
     </template>
 
+    <!-- table controls (filter + metric columns), sitting right above the leaderboard -->
+    <div class="mt-8 flex flex-wrap items-center gap-3">
+      <div class="grow"></div>
+      <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
+      <!-- metric column picker -->
+      <div class="relative" @click.outside="colMenu=false">
+        <button @click="colMenu=!colMenu" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          Metrics
+          <span class="rounded bg-gray-100 px-1.5 text-xs" x-text="displayCols.length"></span>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <div x-show="colMenu" x-cloak class="absolute right-0 z-20 mt-2 w-56 rounded-xl border border-gray-200 bg-white p-1.5 shadow-lg" style="display:none">
+          <template x-for="c in cols" :key="c">
+            <label class="flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-sm hover:bg-gray-50 cursor-pointer">
+              <input type="checkbox" class="accent-emerald-600" :checked="selectedCols.includes(c)" @change="toggleCol(c)" />
+              <span x-text="METRICS[c].label" :data-tip="METRICS[c].desc"></span>
+              <span class="ml-auto text-xs text-gray-400" x-text="METRICS[c].unit || (METRICS[c].better==='higher'?'↑':'↓')"></span>
+            </label>
+          </template>
+        </div>
+      </div>
+    </div>
+
     <!-- table -->
-    <div class="mt-6 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+    <div class="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
       <div class="overflow-x-auto" x-show="!loading" x-cloak>
         <table class="w-full text-sm whitespace-nowrap">
           <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
             <tr>
               <th class="px-5 py-3 text-left font-medium sticky left-0 bg-gray-50" x-text="view==='composed' ? 'Pipeline' : 'Algorithm'"></th>
               <template x-for="c in displayCols" :key="c">
-                <th @click="sort(c)" class="px-4 py-3 text-right font-medium cursor-pointer select-none hover:text-gray-800">
-                  <span x-text="METRICS[c].label"></span>
+                <th @click="sort(c)" class="px-4 py-3 text-right font-medium cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100">
+                  <span x-text="METRICS[c].label" :data-tip="METRICS[c].desc"></span>
                   <span x-show="sortKey===c" x-text="sortDir==='asc' ? '↑' : '↓'"></span>
                 </th>
               </template>
@@ -276,7 +287,14 @@
             const dips = [...new Set(rs.map((r) => r.combo.dipole))];
             const cell = {}; rs.forEach((r) => { cell[r.combo.bfr + "|" + r.combo.dipole] = r; });
             const [lo, hi] = robustRange(rs.map((r) => val(r, this.metric)));
-            return { bfrs, dips, cell, lo, hi };
+            // Rank each axis by mean "goodness" (direction-aware, 0=worst..1=best) so the strongest
+            // methods sit toward the top-left. Rows = dipole inversion, columns = background removal.
+            const better = METRICS[this.metric]?.better || "higher";
+            const good = (r) => { const v = r ? val(r, this.metric) : null; if (v == null) return null; const t = hi === lo ? 0.5 : (v - lo) / (hi - lo); return better === "lower" ? 1 - t : t; };
+            const mean = (ks) => { const g = ks.map((k) => good(cell[k])).filter((v) => v != null); return g.length ? g.reduce((a, c) => a + c, 0) / g.length : -Infinity; };
+            const rows = dips.slice().sort((a, b) => mean(bfrs.map((x) => x + "|" + b)) - mean(bfrs.map((x) => x + "|" + a)));
+            const cols = bfrs.slice().sort((a, b) => mean(dips.map((x) => b + "|" + x)) - mean(dips.map((x) => a + "|" + x)));
+            return { rows, cols, cell, lo, hi };
           });
         },
         // Single-method algorithms that span background removal + dipole inversion (e.g. TGV,

--- a/web/submission.html
+++ b/web/submission.html
@@ -10,18 +10,28 @@
   <script>tailwind.config = { darkMode: "class", theme: { extend: { fontFamily: { sans: ["Inter", "system-ui", "sans-serif"] } } } };</script>
   <script src="js/app.js"></script>
   <style>
-    /* dual-range windowing slider with value bubbles */
-    .dualrange { position: relative; height: 40px; }
-    .dualrange .track { position: absolute; top: 24px; left: 0; right: 0; height: 6px; border-radius: 9999px; background: #e5e7eb; }
+    /* dual-range windowing slider with value bubbles + intensity histogram */
+    .dualrange { position: relative; height: 66px; }
+    .dualrange .hist { position: absolute; top: 16px; left: 0; width: 100%; height: 26px; display: block; }
+    .dualrange .track { position: absolute; top: 46px; left: 0; right: 0; height: 6px; border-radius: 9999px; background: #e5e7eb; }
     .dark .dualrange .track { background: #374151; }
-    .dualrange .fill { position: absolute; top: 24px; height: 6px; border-radius: 9999px; background: #6366f1; }
-    .dualrange input[type=range] { position: absolute; top: 19px; left: 0; width: 100%; height: 16px; margin: 0; background: none; pointer-events: none; -webkit-appearance: none; appearance: none; }
+    .dualrange .fill { position: absolute; top: 46px; height: 6px; border-radius: 9999px; background: #6366f1; }
+    .dualrange input[type=range] { position: absolute; top: 41px; left: 0; width: 100%; height: 16px; margin: 0; background: none; pointer-events: none; -webkit-appearance: none; appearance: none; }
     .dualrange input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; pointer-events: auto; height: 16px; width: 16px; border-radius: 9999px; background: #fff; border: 2px solid #6366f1; cursor: grab; box-shadow: 0 1px 3px rgba(0,0,0,.15); }
     .dualrange input[type=range]::-moz-range-thumb { pointer-events: auto; height: 16px; width: 16px; border-radius: 9999px; background: #fff; border: 2px solid #6366f1; cursor: grab; box-shadow: 0 1px 3px rgba(0,0,0,.15); }
     .dark .dualrange input[type=range]::-webkit-slider-thumb { background: #1f2937; }
     .dark .dualrange input[type=range]::-moz-range-thumb { background: #1f2937; }
-    .win-bubble { position: absolute; top: 0; transform: translateX(-50%); font-size: 11px; line-height: 1; padding: 3px 6px; border-radius: 6px; background: #111827; color: #fff; white-space: nowrap; font-variant-numeric: tabular-nums; }
+    /* value bubbles double as click-to-edit inputs (contenteditable) */
+    .win-bubble { position: absolute; top: 0; transform: translateX(-50%); font-size: 11px; line-height: 1; padding: 3px 6px; border-radius: 6px; background: #111827; color: #fff; white-space: nowrap; font-variant-numeric: tabular-nums; cursor: text; }
+    .win-bubble:hover { background: #1f2937; }
+    .win-bubble:focus { outline: none; box-shadow: 0 0 0 2px #a5b4fc; }
     .dark .win-bubble { background: #4f46e5; }
+    .dark .win-bubble:hover { background: #6366f1; }
+    /* viewer loading spinner */
+    .spinner { width: 20px; height: 20px; border-radius: 9999px; border: 2px solid rgba(255,255,255,.3); border-top-color: #fff; animation: spin .7s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    /* intensity readout pill: hide until NiiVue populates it (avoids an empty box) */
+    #intensity:empty { display: none; }
   </style>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
@@ -64,19 +74,25 @@
 
         <div class="mt-6 grid xl:grid-cols-5 gap-6">
           <section class="xl:col-span-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-            <!-- layer selector -->
-            <div id="layer-row" class="flex flex-wrap items-center justify-between gap-3">
+            <!-- canvas -->
+            <div class="relative rounded-xl overflow-hidden bg-black" style="height:480px">
+              <canvas id="gl1" class="absolute inset-0 h-full w-full block"></canvas>
+              <!-- intensity readout floats over the canvas so a long value string never reflows the layout -->
+              <div id="intensity" class="pointer-events-none absolute bottom-2 left-2 z-10 max-w-[calc(100%-1rem)] truncate rounded-md bg-black/50 px-2 py-0.5 text-xs tabular-nums text-gray-200 backdrop-blur-sm"></div>
+              <div id="viewer-loading" class="absolute inset-0 z-10 hidden items-center justify-center gap-3 bg-black/40 backdrop-blur-sm text-sm font-medium text-gray-100">
+                <span class="spinner"></span> Loading volume…
+              </div>
+              <div id="viewer-note" class="absolute inset-0 hidden items-center justify-center px-6 text-center text-sm text-gray-400 bg-gray-50 dark:bg-gray-900"></div>
+            </div>
+            <!-- layer selector (beneath the viewer) -->
+            <div id="layer-row" class="mt-4 flex flex-wrap items-center gap-3">
               <div class="inline-flex rounded-lg bg-gray-100 p-1 text-sm font-medium dark:bg-gray-800" id="layer-tabs">
                 <button data-layer="recon" class="rounded-md px-3 py-1 transition">Reconstruction</button>
                 <button data-layer="truth" class="rounded-md px-3 py-1 transition">Ground truth</button>
-                <button data-layer="error" class="rounded-md px-3 py-1 transition">Error</button>
               </div>
-              <span id="intensity" class="text-xs tabular-nums text-gray-400 dark:text-gray-500"></span>
-            </div>
-            <!-- canvas -->
-            <div class="relative mt-4 rounded-xl overflow-hidden bg-black" style="height:480px">
-              <canvas id="gl1" class="absolute inset-0 h-full w-full block"></canvas>
-              <div id="viewer-note" class="absolute inset-0 hidden items-center justify-center px-6 text-center text-sm text-gray-400 bg-gray-50 dark:bg-gray-900"></div>
+              <label class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-300" title="Overlay the error map on top of the selected map">
+                <input id="t-error" type="checkbox" class="accent-emerald-600" /> Error map
+              </label>
             </div>
             <!-- control panel -->
             <div id="viewer-controls" class="mt-4 rounded-xl bg-gray-50 p-4 space-y-4 dark:bg-gray-800/50">
@@ -88,33 +104,22 @@
                   <button data-view="sagittal" class="rounded-md px-2.5 py-1 transition">Sagittal</button>
                   <button data-view="render" class="rounded-md px-2.5 py-1 transition">3D</button>
                 </div>
-                <label class="flex items-center gap-1.5 text-gray-500 dark:text-gray-400">Colour
-                  <select id="cmap" class="rounded-lg border-gray-300 text-sm py-1 pr-7 dark:bg-gray-800 dark:border-gray-700">
-                    <option value="gray">Gray</option><option value="viridis">Viridis</option>
-                    <option value="plasma">Plasma</option><option value="hot">Hot</option><option value="cool">Cool</option>
-                  </select>
-                </label>
                 <div class="flex items-center gap-3 text-gray-500 dark:text-gray-400">
                   <label class="flex items-center gap-1.5"><input id="t-colorbar" type="checkbox" class="accent-emerald-600" /> Colorbar</label>
                   <label class="flex items-center gap-1.5"><input id="t-crosshair" type="checkbox" class="accent-emerald-600" checked /> Crosshair</label>
                   <label class="flex items-center gap-1.5"><input id="t-interp" type="checkbox" class="accent-emerald-600" /> Smooth</label>
                 </div>
               </div>
-              <!-- windowing -->
-              <div>
-                <div class="flex items-center justify-between text-sm mb-1">
-                  <span class="font-medium text-gray-600 dark:text-gray-300">Window</span>
-                  <button id="win-auto" class="rounded-lg bg-white px-2.5 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700">Auto</button>
+              <!-- windowing: one section per shown map (base, then error overlay) -->
+              <div class="space-y-3">
+                <div id="win-base"></div>
+                <div id="win-error-section" class="hidden space-y-2 border-t border-gray-200 pt-3 dark:border-gray-700">
+                  <div id="win-error"></div>
+                  <label class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">Error overlay opacity
+                    <input id="opacity" type="range" min="0" max="1" step="0.05" value="1" class="accent-emerald-600 flex-1" />
+                    <span id="opacity-val" class="w-9 shrink-0 text-right text-xs tabular-nums">100%</span>
+                  </label>
                 </div>
-                <div class="dualrange" id="win">
-                  <div class="track"></div><div class="fill" id="win-fill"></div>
-                  <input id="win-lo" type="range" /><input id="win-hi" type="range" />
-                  <div class="win-bubble" id="win-lo-bubble"></div>
-                  <div class="win-bubble" id="win-hi-bubble"></div>
-                </div>
-                <label id="overlay-ctl" class="hidden items-center gap-2 text-sm text-gray-500 mt-1 dark:text-gray-400">Overlay opacity
-                  <input id="opacity" type="range" min="0" max="1" step="0.05" value="1" class="accent-emerald-600 flex-1" />
-                </label>
               </div>
             </div>
           </section>
@@ -123,6 +128,13 @@
             <h2 class="font-semibold text-gray-900 dark:text-gray-100">Metrics</h2>
             <p id="metrics-sub" class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"></p>
             <table class="mt-4 w-full text-sm">
+              <thead>
+                <tr class="text-xs uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                  <th class="pb-2 text-left font-medium">Metric</th>
+                  <th class="pb-2 text-right font-medium">Value</th>
+                  <th class="pb-2 pl-3 text-right font-medium">Rank</th>
+                </tr>
+              </thead>
               <tbody id="metrics-body" class="divide-y divide-gray-100 dark:divide-gray-800"></tbody>
             </table>
           </section>


### PR DESCRIPTION
Accumulated web/UI improvements to the submission viewer and leaderboard (all tested locally in a real browser).

## Submission viewer (`submission.html`, `js/viewer.js`)
- **Windowing control redesign**: click-to-edit value bubbles, Auto beside the slider, per-map colormap dropdown stacked above Auto; histogram-backed dual-range with **scroll-to-zoom** (double-click resets); non-overlapping value bubbles; loading spinner.
- **Error map** is a checkbox overlay over the selected base (recon/truth) with its own windowing section; default **diverging** colormap with |error|-magnitude windowing + transparency floor.
- **Intensity readout** floats over the canvas (no more layout jump); layer tabs moved beneath the viewer.
- **Metrics**: hover tooltips explaining each metric + a colour-coded **per-metric rank** column.
- **"Run this yourself"** now has **QSM-CI / QSMxT tabs** — the QSMxT tab appears only when every step is QSM.rs-backed (driven by each algorithm's self-described `engine`).
- Pipelines sidebar splits single-step methods into bfr+dipole vs end-to-end.

## Leaderboard (`leaderboard.html`, `js/app.js`)
- Combination matrix **axes swapped** (dipole = rows, background removal = columns) and **ordered best-top-left**.
- Filter + metric-column controls moved below the matrix, above the table.
- Combined single-method algorithms split into bfr+dipole and end-to-end.
- Metric hover tooltips (shared cursor-following tooltip); fixed dark-mode header hover contrast; fixed the "Colour by"/"Field mapping" selects showing the wrong option on load.
- Shared `robustRange` + heat scale exposed via `window.QSM`.

## Pipeline (`scripts/pipeline.py`)
- `emit_volumes` masks the signed error map to the raw brain mask (applies on the next `--emit-volumes` run; existing published maps unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)