### PR TITLE
algorithms: bump iLSQR + TGV to qsmxt v9.8.0

### DIFF
--- a/algorithms/ilsqr/algorithm.yml
+++ b/algorithms/ilsqr/algorithm.yml
@@ -18,7 +18,7 @@ authors:
 doi: 10.1016/j.neuroimage.2014.12.043
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
-image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0
+image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.8.0
 run: bash run.sh
 parameters:
   - name: tol

--- a/algorithms/tgv/algorithm.yml
+++ b/algorithms/tgv/algorithm.yml
@@ -19,7 +19,7 @@ authors:
 doi: 10.1016/j.neuroimage.2015.02.041
 code_url: https://github.com/astewartau/QSM.rs
 license: MIT
-image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.4.0
+image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.8.0
 run: bash run.sh
 parameters:
   - name: iterations


### PR DESCRIPTION
Points the **iLSQR** and **TGV** submissions at `ghcr.io/astewartau/qsm-ci/qsmxt:v9.8.0` (qsm-core **v0.19.0** — pushed to ghcr).

- **iLSQR** uses default `tol`/`max_iter`, so it picks up v0.19.0's LSQR convergence fix — **its score will change** (isolated + composed combos re-score).
- **TGV** already passes explicit `--alpha1 0.0005 --alpha0 0.0015` in `run.sh` (now also the qsm-core default), so its engine is updated but **score is unchanged**.

Merging triggers `score.yml` to re-score both (auto-detected from the `algorithms/**` diff), then the leaderboard redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)