### PR TITLE
ci: retry the apptainer .deb download (fix flaky exit-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install apptainer  # docker + podman are preinstalled on ubuntu-latest
         run: |
           ver=1.3.6
-          wget -q "https://github.com/apptainer/apptainer/releases/download/v${ver}/apptainer_${ver}_amd64.deb"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 -o "apptainer_${ver}_amd64.deb" "https://github.com/apptainer/apptainer/releases/download/v${ver}/apptainer_${ver}_amd64.deb"
           sudo apt-get update -qq
           sudo apt-get install -y "./apptainer_${ver}_amd64.deb"
 
@@ -82,7 +82,7 @@ jobs:
       - name: Install apptainer
         run: |
           ver=1.3.6
-          wget -q "https://github.com/apptainer/apptainer/releases/download/v${ver}/apptainer_${ver}_amd64.deb"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 -o "apptainer_${ver}_amd64.deb" "https://github.com/apptainer/apptainer/releases/download/v${ver}/apptainer_${ver}_amd64.deb"
           sudo apt-get update -qq
           sudo apt-get install -y "./apptainer_${ver}_amd64.deb"
 


### PR DESCRIPTION
The `Install apptainer` step fetched the release `.deb` with `wget -q` and **no retry**, so a transient GitHub-releases network hiccup failed it with **exit 4** (network failure). Same commit passed on the branch and failed on `main` — a flake, not a code issue.

Swapped for `curl -fsSL --retry 5 --retry-all-errors --retry-delay 5` in both the `cli` and `interfaces` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)