### PR TITLE
Parameter tuning + tuned/default toggle, portability fixes, parallel scorer

### DIFF
--- a/.github/workflows/score-parallel.yml
+++ b/.github/workflows/score-parallel.yml
@@ -1,0 +1,125 @@
+name: score-parallel
+
+# EXPERIMENTAL parallel scorer — for measuring wall-clock and validating correctness before we
+# adopt it. Runs pipeline.py sharded across N GitHub-hosted runners (each `--shard i/N`), then a
+# merge job combines the shard outputs into a CANDIDATE index.json uploaded as an artifact.
+#
+# SAFE BY DESIGN: it never commits, never publishes volumes, and never touches production
+# results/index.json — the merged index is only an artifact for inspection. Trigger manually
+# (workflow_dispatch) or by pushing the test branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      shards:
+        description: "number of parallel shards"
+        default: "8"
+      include:
+        description: "comma-separated slugs to restrict to (blank = everything)"
+        default: ""
+      mode:
+        description: "isolated | composed | both"
+        default: "both"
+  push:
+    branches: [test/score-parallel]
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      indices: ${{ steps.gen.outputs.indices }}
+      shards: ${{ steps.gen.outputs.shards }}
+      include: ${{ steps.gen.outputs.include }}
+      mode: ${{ steps.gen.outputs.mode }}
+    steps:
+      - id: gen
+        run: |
+          N="${{ github.event.inputs.shards || '8' }}"
+          INCLUDE="${{ github.event.inputs.include }}"
+          MODE="${{ github.event.inputs.mode || 'both' }}"
+          # A push to the test branch (no dispatch inputs) runs a cheap SMOKE scope by default, so
+          # iterating on the workflow doesn't launch a full ~1h matrix every time. Dispatch manually
+          # (with an empty `include`) for the full run.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            N="4"; INCLUDE="tkd,tsvd,sharp,medi"; MODE="both"
+          fi
+          echo "indices=$(python3 -c "import json;print(json.dumps(list(range(int('$N')))))")" >>"$GITHUB_OUTPUT"
+          echo "shards=$N" >>"$GITHUB_OUTPUT"
+          echo "include=$INCLUDE" >>"$GITHUB_OUTPUT"
+          echo "mode=$MODE" >>"$GITHUB_OUTPUT"
+
+  score:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        i: ${{ fromJson(needs.plan.outputs.indices) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install qsm-ci CLI + scorer deps
+        run: |
+          pip install -r eval/requirements.txt
+          pip install --upgrade setuptools setuptools_scm wheel
+          pip install --no-build-isolation .
+
+      - name: Fetch scoring dataset
+        env:
+          OSF_TOKEN: ${{ secrets.OSF_TOKEN }}
+        run: scripts/fetch_dataset.sh sim data/sim/scoring
+
+      - name: Score shard ${{ matrix.i }} / ${{ needs.plan.outputs.shards }}
+        run: |
+          INC=""; [ -n "${{ needs.plan.outputs.include }}" ] && INC="--include ${{ needs.plan.outputs.include }}"
+          t0=$(date +%s)
+          python scripts/pipeline.py --dataset data/sim/scoring \
+            --mode "${{ needs.plan.outputs.mode }}" \
+            --shard ${{ matrix.i }}/${{ needs.plan.outputs.shards }} \
+            --runner docker $INC \
+            --runs-out "shard-${{ matrix.i }}.json"
+          echo "== shard ${{ matrix.i }} wall-clock: $(( $(date +%s) - t0 ))s =="
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shard-${{ matrix.i }}
+          path: shard-${{ matrix.i }}.json
+
+  merge:
+    needs: score
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: shard-*
+          merge-multiple: true
+          path: shards
+      - name: Merge shard runs into a candidate index.json
+        run: |
+          python3 - <<'PY'
+          import json, glob
+          runs = []
+          for f in sorted(glob.glob("shards/shard-*.json")):
+              runs += json.load(open(f))
+          idx = json.load(open("results/index.json"))
+          ids = {r["id"] for r in runs}
+          merged = [r for r in idx["runs"] if r.get("id") not in ids] + runs
+          json.dump({"generated": None, "runs": merged}, open("index-candidate.json", "w"), indent=2)
+          dnf = sorted(r["id"] for r in runs if r.get("status") == "DNF")
+          print(f"shards contributed {len(runs)} runs; candidate index has {len(merged)} total")
+          print(f"DNF ({len(dnf)}): {', '.join(dnf) if dnf else 'none'}")
+          # duplicate-id guard — shards must be disjoint
+          from collections import Counter
+          dup = [i for i, c in Counter(r["id"] for r in runs).items() if c > 1]
+          print(f"duplicate ids across shards: {dup or 'none (partition OK)'}")
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: index-candidate
+          path: index-candidate.json

--- a/algorithms/autoqsm/predict.py
+++ b/algorithms/autoqsm/predict.py
@@ -15,7 +15,12 @@ whole-head map with values ~[-0.9, 0.5], std ~0.11, exactly the scale of a 3T to
 voxels through unchanged. The network's final activation is tanh, so its output susceptibility is in
 ppm as well; we write it out unchanged. No Hz/rad rescaling is applied.
 
-Usage:  predict.py <totalfield.nii.gz> <chimap.nii.gz>
+AutoQSM runs on the whole head (no brain extraction), so its raw output is a dense whole-head map.
+QSM-CI scores only inside the brain mask, so masking doesn't change the metrics — but an unmasked
+whole-head χ renders as noise in the volume viewer and isn't a usable susceptibility map. When a mask
+is given we zero the output outside it, matching the canonical brain-masked χ every other method emits.
+
+Usage:  predict.py <totalfield.nii.gz> <chimap.nii.gz> [mask.nii.gz]
 """
 import os
 import sys
@@ -38,7 +43,7 @@ INPUT_PATCH_SHAPE = [64, 64, 64]
 OUTPUT_PATCH_SHAPE = [32, 32, 32]
 
 
-def main(in_path, out_path):
+def main(in_path, out_path, mask_path=None):
     nii = nib.load(in_path)
     field = np.asarray(nii.get_fdata(), dtype=np.float32)   # totalfield, ppm
     if field.ndim != 3:
@@ -53,6 +58,14 @@ def main(in_path, out_path):
     chi, _patches = data_predict(model, field, INPUT_PATCH_SHAPE, OUTPUT_PATCH_SHAPE)
     chi = np.asarray(chi, dtype=np.float32)                 # susceptibility, ppm
 
+    # AutoQSM has no brain extraction — zero the whole-head output outside the brain mask so it's a
+    # canonical brain-masked χ (cosmetic for the viewer; scoring is already mask-restricted).
+    if mask_path:
+        mask = np.asarray(nib.load(mask_path).get_fdata(), dtype=np.float32) > 0.5
+        if mask.shape != chi.shape:
+            raise ValueError("mask shape {} != chi shape {}".format(mask.shape, chi.shape))
+        chi = chi * mask
+
     # Preserve the input grid / voxel size / affine (QSM-CI 3D artifacts all share the mask grid).
     out = nib.Nifti1Image(chi, nii.affine, nii.header)
     out.set_data_dtype(np.float32)
@@ -61,6 +74,6 @@ def main(in_path, out_path):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        sys.exit("usage: predict.py <totalfield.nii.gz> <chimap.nii.gz>")
-    main(sys.argv[1], sys.argv[2])
+    if len(sys.argv) not in (3, 4):
+        sys.exit("usage: predict.py <totalfield.nii.gz> <chimap.nii.gz> [mask.nii.gz]")
+    main(*sys.argv[1:])

--- a/algorithms/autoqsm/run.sh
+++ b/algorithms/autoqsm/run.sh
@@ -45,6 +45,9 @@ neg.set_data_dtype(np.float32)
 nib.save(neg, sys.argv[2])
 PY
 
+# Pass the mounted brain mask so the whole-head V-Net output is zeroed outside the brain (AutoQSM
+# does no brain extraction). Cosmetic for the viewer — scoring is already mask-restricted.
 python "$HERE/predict.py" \
   "$WORK/totalfield.nii.gz" \
-  "$OUT/chimap.nii.gz"
+  "$OUT/chimap.nii.gz" \
+  "$IN/mask.nii.gz"

--- a/algorithms/harperella/algorithm.yml
+++ b/algorithms/harperella/algorithm.yml
@@ -19,6 +19,7 @@ run: bash run.sh
 parameters:
   - name: radius
     default: 5.0
+    tuned: 3.0
     description: SMV kernel radius (mm)
   - name: max_iter
     default: 100

--- a/algorithms/matlab-bfrnet/run.sh
+++ b/algorithms/matlab-bfrnet/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-medi/algorithm.yml
+++ b/algorithms/matlab-medi/algorithm.yml
@@ -25,9 +25,10 @@ run: bash run.sh
 matlab:
   entry: recon.m
   runtime: r2026a
-params:
+parameters:
 - name: lambda
   default: 100
+  tuned: 520
   description: data-fidelity weight (larger = closer data fit, less regularization)
 - name: smv_radius
   default: 5

--- a/algorithms/matlab-medi/run.sh
+++ b/algorithms/matlab-medi/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-sti-iharperella/run.sh
+++ b/algorithms/matlab-sti-iharperella/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-sti-ilsqr/run.sh
+++ b/algorithms/matlab-sti-ilsqr/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-sti-star/run.sh
+++ b/algorithms/matlab-sti-star/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-sti-vsharp/run.sh
+++ b/algorithms/matlab-sti-vsharp/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/matlab-tkd/run.sh
+++ b/algorithms/matlab-tkd/run.sh
@@ -7,4 +7,8 @@ IN="${1:-/input}"; OUT="${2:-/output}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
 exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/nltv/algorithm.yml
+++ b/algorithms/nltv/algorithm.yml
@@ -17,6 +17,7 @@ run: bash run.sh
 parameters:
   - name: lambda
     default: 1e-4
+    tuned: 3e-3
     description: regularization
   - name: max_iter
     default: 1000

--- a/algorithms/resharp/algorithm.yml
+++ b/algorithms/resharp/algorithm.yml
@@ -16,6 +16,7 @@ run: bash run.sh
 parameters:
   - name: radius
     default: 15.0
+    tuned: 12.0
     description: SMV kernel radius (mm)
   - name: tik_reg
     default: 1e-3

--- a/algorithms/sharp/algorithm.yml
+++ b/algorithms/sharp/algorithm.yml
@@ -18,6 +18,7 @@ run: bash run.sh
 parameters:
   - name: threshold
     default: 0.02
+    tuned: 0.01
     description: deconvolution threshold
   - name: radius_factor
     default: 0.5

--- a/algorithms/tgv/algorithm.yml
+++ b/algorithms/tgv/algorithm.yml
@@ -27,6 +27,7 @@ parameters:
     description: iterations
   - name: alpha1
     default: 0.0005
+    tuned: 0.00015
     description: first-order (gradient) weight
   - name: alpha0
     default: 0.0015

--- a/algorithms/tikhonov/algorithm.yml
+++ b/algorithms/tikhonov/algorithm.yml
@@ -21,4 +21,5 @@ run: bash run.sh
 parameters:
   - name: lambda
     default: 1e-4
+    tuned: 3e-3
     description: L2 regularization

--- a/algorithms/tsvd/algorithm.yml
+++ b/algorithms/tsvd/algorithm.yml
@@ -17,4 +17,5 @@ run: bash run.sh
 parameters:
   - name: threshold
     default: 0.1
+    tuned: 0.05
     description: singular-value threshold

--- a/algorithms/tv/algorithm.yml
+++ b/algorithms/tv/algorithm.yml
@@ -22,6 +22,7 @@ run: bash run.sh
 parameters:
   - name: lambda
     default: 1e-4
+    tuned: 3e-5
     description: TV regularization
   - name: rho
     default: 1.0

--- a/qsm_ci/runner.py
+++ b/qsm_ci/runner.py
@@ -409,17 +409,21 @@ def _build_oci(algo: dict, engine: str, log) -> str:
 
 
 def _apptainer_image(algo: dict) -> str:
-    """apptainer runs from a docker:// ref or a .sif — it can't build a Dockerfile itself."""
+    """apptainer runs from a docker:// ref or a .sif — it can't build a Dockerfile itself.
+
+    A published ``image:`` is used as-is (pulled & converted on the fly) exactly like the docker
+    path does — a folder Dockerfile is only the build recipe, never built here. Only when no
+    ``image:`` is set does a local Dockerfile become a hard error (apptainer can't build it)."""
+    img = algo.get("image")
+    if img:
+        if "://" in img or img.endswith(".sif") or os.path.exists(img):
+            return img
+        return f"docker://{img}"  # plain registry ref -> pull & convert on the fly
     if (algo["dir"] / "Dockerfile").exists():
         raise SystemExit(
             "apptainer can't build a Dockerfile. Build it first with --runner docker/podman, "
             "or set image: to a prebuilt reference (docker://…, a registry ref, or a .sif).")
-    img = algo["image"]
-    if not img:
-        raise SystemExit("algorithm.yml has no image: for apptainer to run")
-    if "://" in img or img.endswith(".sif") or os.path.exists(img):
-        return img
-    return f"docker://{img}"  # plain registry ref -> pull & convert on the fly
+    raise SystemExit("algorithm.yml has no image: for apptainer to run")
 
 
 def _param_env(input_dir: Path) -> "dict[str, str]":

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -83,6 +83,22 @@ def emit_volumes(run_id, recon, truth, mask=None):
     nib.save(nib.Nifti1Image(err, r.affine), str(d / "error.nii.gz"))
 
 
+def _tuned_overrides(text: str) -> dict:
+    """Extract `{param: tuned_value}` from an algorithm.yml `parameters:` block — the settings we
+    optimised on the scoring phantom (each parameter may carry a `tuned:` alongside its `default:`).
+    Regex, not YAML, to keep this module dependency-free like the rest of the runner."""
+    m = re.search(r"^parameters:\s*\n(.*?)(?=^\S|\Z)", text, re.M | re.S)
+    if not m:
+        return {}
+    out = {}
+    for item in re.split(r"^[ \t]*-[ \t]*name:[ \t]*", m.group(1), flags=re.M)[1:]:
+        name = item.splitlines()[0].strip()
+        tm = re.search(r"^[ \t]*tuned:[ \t]*(\S+)", item, re.M)
+        if tm:
+            out[name] = tm.group(1)
+    return out
+
+
 def discover_algorithms() -> list[dict]:
     algos = []
     for d in sorted((ROOT / "algorithms").glob("*/")):
@@ -105,6 +121,7 @@ def discover_algorithms() -> list[dict]:
         algos.append({
             "slug": d.name, "dir": d, "stage": s, "image": image.group(1) if image else None,
             "consumes": consumes, "produces": STAGES[s]["produces"],
+            "tuned": _tuned_overrides(text),
         })
     return algos
 
@@ -121,13 +138,15 @@ def prepare_input(consumes: list[str], sources: dict[str, Path], dest: Path) -> 
         shutil.copy(src, dest / ARTIFACT_FILE[art])
 
 
-def _cli_run_argv(algo: dict, input_dir: Path, output_dir: Path) -> list[str]:
-    """Build the `qsm-ci run …` argv that reproduces this submission's isolated docker run.
+def _cli_run_argv(algo: dict, input_dir: Path, output_dir: Path,
+                  runner: str = "docker", overrides: "dict | None" = None) -> list[str]:
+    """Build the `qsm-ci run …` argv that reproduces this submission's isolated container run.
 
     Each consumed artifact becomes a `--<artifact> <input_dir>/<file>` flag (magnitude is optional —
-    only passed when present); the produced artifact is written with `-o <output_dir>/<file>`. The
-    CLI owns image resolution, mounting run.sh, and injecting the QSMCI_* acquisition env vars — so
-    the scorer no longer duplicates (and drifts from) that logic."""
+    only passed when present); the produced artifact is written with `-o <output_dir>/<file>`. Any
+    `overrides` become `--set NAME=VALUE` (the tuned pass). The CLI owns image resolution, mounting
+    run.sh, and injecting the QSMCI_* acquisition env vars — so the scorer no longer duplicates
+    (and drifts from) that logic."""
     produced = algo["produces"][0]
     argv = ["qsm-ci", "run", str(algo["dir"])]
     for art in algo["consumes"]:
@@ -135,22 +154,27 @@ def _cli_run_argv(algo: dict, input_dir: Path, output_dir: Path) -> list[str]:
         if art == "magnitude" and not f.exists():
             continue  # optional — only some methods use it
         argv += [f"--{art}", str(f)]
-    argv += ["-o", str(output_dir / ARTIFACT_FILE[produced]), "--runner", "docker"]
+    for k, v in (overrides or {}).items():
+        argv += ["--set", f"{k}={v}"]
+    argv += ["-o", str(output_dir / ARTIFACT_FILE[produced]), "--runner", runner]
     return argv
 
 
-def run_algo(algo: dict, input_dir: Path, output_dir: Path, runner: str = "local") -> float:
+def run_algo(algo: dict, input_dir: Path, output_dir: Path, runner: str = "local",
+             overrides: "dict | None" = None) -> float:
     if output_dir.exists():
         shutil.rmtree(output_dir)
     output_dir.mkdir(parents=True)
     t0 = time.time()
-    if runner == "docker":
+    if runner != "local":
         # Delegate to the installed `qsm-ci` CLI (a console script) rather than reimplementing the
         # container run here. The CLI resolves the folder, pulls the prebuilt image, mounts run.sh
         # read-only, and injects the QSMCI_* env vars (TE/B0/…) — the very env vars this scorer used
         # to omit, which DNF'd submissions that read acquisition params through them.
-        subprocess.run(_cli_run_argv(algo, input_dir, output_dir), check=True)
+        subprocess.run(_cli_run_argv(algo, input_dir, output_dir, runner, overrides), check=True)
     else:
+        if overrides:  # run.sh reads overrides from $IN/config.json (mirrors `qsm-ci run --set`)
+            (input_dir / "config.json").write_text(json.dumps(overrides))
         subprocess.run(["bash", str(algo["dir"] / "run.sh"), str(input_dir), str(output_dir)],
                        check=True)
     return time.time() - t0
@@ -194,7 +218,7 @@ def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, 
     subprocess.run(cmd, check=True)
     result = json.loads(out_json.read_text())
     result["status"] = "ok"
-    result.update({k: meta[k] for k in ("id", "slug", "mode") if k in meta})
+    result.update({k: meta[k] for k in ("id", "slug", "mode", "variant", "params") if k in meta})
     if "combo" in meta:
         result["combo"] = meta["combo"]
     if EMIT_VOLUMES and "id" in meta:
@@ -202,9 +226,9 @@ def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, 
     return result
 
 
-def dnf(rid, slug, name, stage, mode, track, combo=None):
+def dnf(rid, slug, name, stage, mode, track, combo=None, variant="default"):
     e = {"name": name, "track": track, "stage": stage, "mode": mode,
-         "status": "DNF", "metrics": {}, "id": rid, "slug": slug}
+         "status": "DNF", "metrics": {}, "id": rid, "slug": slug, "variant": variant}
     if combo:
         e["combo"] = combo
     return e
@@ -233,7 +257,16 @@ def main() -> None:
                     help="incremental: isolated for this slug, and every composed combo that includes "
                          "it (its own stage is pinned to it; complementary stages stay full)")
     ap.add_argument("--include", default=None, help="comma-separated slugs to restrict the run to")
+    ap.add_argument("--shard", default=None, metavar="i/n",
+                    help="run only shard i of n disjoint shards (0-indexed), for parallel scoring "
+                         "across jobs. Composed work is split by (field-map, bfr) COLUMN so each "
+                         "column's bfr localfield is computed in exactly one shard; isolated runs "
+                         "and spans are split round-robin. Union of all n shards == a full run.")
     ap.add_argument("--track", default="sim")
+    ap.add_argument("--runs-out", type=Path, default=None,
+                    help="write ONLY the runs produced by this invocation to this JSON file, instead "
+                         "of merging into results/index.json. For sharded scoring: each shard writes "
+                         "its own runs; a merge step combines them into index.json.")
     ap.add_argument("--work", type=Path, default=ROOT / ".work")
     ap.add_argument("--emit-volumes", action="store_true",
                     help="write recon/truth/error NIfTIs per run under results/<id>/ for the web viewer")
@@ -245,6 +278,16 @@ def main() -> None:
 
     global EMIT_VOLUMES
     EMIT_VOLUMES = args.emit_volumes
+
+    # --shard i/n : this job runs shard i of n. `_owns(index)` is a deterministic round-robin over a
+    # stable ordering, so the n shards partition the work with no overlap and no gaps.
+    shard_i, shard_n = (None, None)
+    if args.shard:
+        shard_i, shard_n = (int(x) for x in args.shard.split("/"))
+        if not (0 <= shard_i < shard_n):
+            raise SystemExit(f"--shard i/n needs 0 <= i < n, got {args.shard}")
+    def _owns(index):
+        return shard_n is None or index % shard_n == shard_i
 
     inputs, gt = args.dataset / "inputs", args.dataset / "groundtruth"
     mask, params = inputs / "mask.nii.gz", inputs / "params.json"
@@ -273,29 +316,48 @@ def main() -> None:
     if args.mode in ("isolated", "both"):
         iso_algos = [a for a in algos if not (iso_target and a["slug"] != iso_target)]
 
-        def do_isolated(a):
-            idir, odir = args.work / f"iso_{a['slug']}_in", args.work / f"iso_{a['slug']}_out"
+        # Each algorithm runs at its defaults; one that declares `tuned:` params also runs a second
+        # "tuned" variant (same isolated inputs, overrides applied) so the leaderboard's default/tuned
+        # toggle has both. Variants are independent runs — expand them into the parallel pool.
+        def iso_variants(a):
+            vs = [("default", None)]
+            if a.get("tuned"):
+                vs.append(("tuned", a["tuned"]))
+            return [(a, name, ov) for name, ov in vs]
+
+        def do_isolated(task):
+            a, variant, overrides = task
+            sfx = "" if variant == "default" else "-tuned"
+            idir = args.work / f"iso_{a['slug']}{sfx}_in"
+            odir = args.work / f"iso_{a['slug']}{sfx}_out"
             try:
                 prepare_input(a["consumes"], gt_sources, idir)
-                rt = run_algo(a, idir, odir, args.runner)
+                rt = run_algo(a, idir, odir, args.runner, overrides)
                 out = []
                 for art in a["produces"]:
-                    meta = {"id": f"{a['slug']}-iso", "slug": a["slug"], "name": a["slug"],
-                            "stage": a["stage"], "mode": "isolated", "track": args.track, "runtime": rt}
+                    meta = {"id": f"{a['slug']}-iso{sfx}", "slug": a["slug"], "name": a["slug"],
+                            "stage": a["stage"], "mode": "isolated", "track": args.track, "runtime": rt,
+                            "variant": variant}
+                    if overrides:
+                        meta["params"] = overrides
                     r = score(odir / ARTIFACT_FILE[art], art, gt, mask,
-                              args.work / f"iso_{a['slug']}.json", meta)
+                              args.work / f"iso_{a['slug']}{sfx}.json", meta)
                     out.append(r)
                     m = r["metrics"]
-                    print(f"  isolated  {a['slug']:<16} {art:<11} "
+                    print(f"  isolated  {a['slug']:<16} {variant:<8} {art:<11} "
                           f"xsim={m.get('xsim'):.4f} nrmse={m.get('nrmse'):.2f}%")
                 return out
             except Exception as e:  # DNF — record and continue
-                print(f"  isolated  {a['slug']:<16} DNF ({e})")
-                return [dnf(f"{a['slug']}-iso", a["slug"], a["slug"], a["stage"], "isolated", args.track)]
+                print(f"  isolated  {a['slug']:<16} {variant:<8} DNF ({e})")
+                return [dnf(f"{a['slug']}-iso{sfx}", a["slug"], a["slug"], a["stage"], "isolated",
+                            args.track, variant=variant)]
 
-        for out in _pmap(iso_algos, do_isolated):
+        iso_tasks = [t for a in iso_algos for t in iso_variants(a)]
+        iso_tasks = [t for idx, t in enumerate(iso_tasks) if _owns(idx)]  # --shard: round-robin
+        for out in _pmap(iso_tasks, do_isolated):
             runs.extend(out)
-        flush_index(runs)
+        if not args.runs_out:
+            flush_index(runs)
 
     # -------- composed: (field-mapping) x bfr x dipole, chaining real outputs --------
     # Dependency order is fieldmap -> bfr -> dipole, so each stage is a barrier; but every
@@ -318,6 +380,18 @@ def main() -> None:
                 fmap, spans = [f], []
             else:                                     # a bfr+dipole / end-to-end span — run it alone
                 fmap, bfr, dipole, spans = [], [], [], [f]
+
+        # --shard: own each composed COLUMN = (totalfield-source, bfr) via round-robin over a stable
+        # ordering. A column's bfr localfield is computed in exactly one shard (no cross-shard bfr
+        # recomputation); a field-map runs only in shards that own a column consuming it.
+        fm_keys = ["gt"] + sorted(f["slug"] for f in fmap)
+        col_owner = {(tfk, bs): idx for idx, (tfk, bs)
+                     in enumerate((tfk, b["slug"]) for tfk in fm_keys for b in sorted(bfr, key=lambda x: x["slug"]))}
+        owns_col = lambda tfk, bs: _owns(col_owner.get((tfk, bs), 0))
+        if shard_n is not None:
+            needed_fm = {tfk for (tfk, bs) in col_owner if tfk != "gt" and owns_col(tfk, bs)}
+            fmap = [f for f in fmap if f["slug"] in needed_fm]
+            spans = [s for idx, s in enumerate(sorted(spans, key=lambda x: x["slug"])) if _owns(idx)]
 
         # Stage 1 — totalfield sources: the ground-truth field ("gt") plus each field-mapping
         # submission's output (run on raw inputs), so the matrix can start from raw phase.
@@ -361,7 +435,8 @@ def main() -> None:
                 print(f"  composed  {tfk}+{b['slug']} bfr DNF ({e})")
                 return None
 
-        bfr_tasks = [(tfk, tfp, tf_mask, b) for tfk, (tfp, tf_mask) in tf_sources.items() for b in bfr]
+        bfr_tasks = [(tfk, tfp, tf_mask, b) for tfk, (tfp, tf_mask) in tf_sources.items() for b in bfr
+                     if owns_col(tfk, b["slug"])]  # --shard: only this shard's columns
         for res in _pmap(bfr_tasks, do_bfr):
             if res:
                 lf_cache[res[0]] = res[1]
@@ -397,7 +472,8 @@ def main() -> None:
                      if (tfk, b["slug"]) in lf_cache for d in dipole]
         for r in _pmap(dip_tasks, do_dipole):
             runs.append(r)
-        flush_index(runs)
+        if not args.runs_out:
+            flush_index(runs)
 
         # Stage 4 — spans (bfr+dipole / end-to-end submissions), independent.
         def do_span(s):
@@ -416,8 +492,13 @@ def main() -> None:
         for r in _pmap(spans, do_span):
             runs.append(r)
 
-    total = flush_index(runs)
-    print(f"\nmerged {len(runs)} runs into results/index.json ({total} total)")
+    if args.runs_out:
+        args.runs_out.parent.mkdir(parents=True, exist_ok=True)
+        args.runs_out.write_text(json.dumps(runs, indent=2) + "\n")
+        print(f"\nwrote {len(runs)} runs to {args.runs_out} (shard output; not merged into index.json)")
+    else:
+        total = flush_index(runs)
+        print(f"\nmerged {len(runs)} runs into results/index.json ({total} total)")
 
     if args.fail_on_dnf:
         dnfs = [r for r in runs if r.get("status") == "DNF"]

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -42,6 +42,7 @@
         {
           "name": "radius",
           "default": 5.0,
+          "tuned": 3.0,
           "description": "SMV kernel radius (mm)"
         },
         {
@@ -309,6 +310,7 @@
         {
           "name": "lambda",
           "default": 100,
+          "tuned": 520,
           "description": "data-fidelity weight (larger = closer data fit, less regularization)"
         },
         {
@@ -548,6 +550,7 @@
         {
           "name": "lambda",
           "default": "1e-4",
+          "tuned": "3e-3",
           "description": "regularization"
         },
         {
@@ -696,6 +699,7 @@
         {
           "name": "radius",
           "default": 15.0,
+          "tuned": 12.0,
           "description": "SMV kernel radius (mm)"
         },
         {
@@ -773,6 +777,7 @@
         {
           "name": "threshold",
           "default": 0.02,
+          "tuned": 0.01,
           "description": "deconvolution threshold"
         },
         {
@@ -813,6 +818,7 @@
         {
           "name": "alpha1",
           "default": 0.0005,
+          "tuned": 0.00015,
           "description": "first-order (gradient) weight"
         },
         {
@@ -845,6 +851,7 @@
         {
           "name": "lambda",
           "default": "1e-4",
+          "tuned": "3e-3",
           "description": "L2 regularization"
         }
       ]
@@ -894,6 +901,7 @@
         {
           "name": "threshold",
           "default": 0.1,
+          "tuned": 0.05,
           "description": "singular-value threshold"
         }
       ]
@@ -922,6 +930,7 @@
         {
           "name": "lambda",
           "default": "1e-4",
+          "tuned": "3e-5",
           "description": "TV regularization"
         },
         {

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -150,6 +150,7 @@ const combinedRuns = () => {
   const bySlug = {};
   for (const r of allRuns) {
     if (r.combo) continue;  // matrix combos carry stage bfr+dipole too — they belong on the axes
+    if (r.variant === "tuned") continue;  // tuned variants are reached via the toggle, not the list
     if (r.stage !== "bfr+dipole" && r.stage !== "end-to-end") continue;
     if (!bySlug[r.slug] || r.mode === "composed") bySlug[r.slug] = r;
   }
@@ -187,7 +188,7 @@ function stagesHTML() {
   // Pipeline order: field mapping → background removal → dipole inversion, then the combined
   // single-method spans (bfr+dipole like TGV/QSMART/MEDI, unwrap+bfr like HARPERELLA, end-to-end).
   return ["field-mapping", "bfr", "dipole", "bfr+dipole", "unwrap+bfr", "end-to-end"].map((s) => {
-    const rs = allRuns.filter((r) => r.mode === "isolated" && r.stage === s && (!f || r.name.toLowerCase().includes(f)));
+    const rs = allRuns.filter((r) => r.mode === "isolated" && r.stage === s && (r.variant || "default") === "default" && (!f || r.name.toLowerCase().includes(f)));
     if (!rs.length) return "";
     const rows = rs.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("");
     return `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">${STAGE_LABEL[s] || s}</div>${rows}</div>`;
@@ -242,15 +243,27 @@ function methodCard(a) {
   if (zdoi) links.push(`<a href="${zdoi.url}" class="text-emerald-600 hover:underline" title="Cite this QSM-CI submission (Zenodo v${zdoi.version})">submission doi</a>`);
   if (a.doi) links.push(`<a href="https://doi.org/${a.doi}" class="text-indigo-600 hover:underline">paper doi</a>`);
   if (a.code_url) links.push(`<a href="${a.code_url}" class="text-indigo-600 hover:underline">source code</a>`);
-  const params = (a.parameters || []).map((p) =>
-    `<tr class="border-t border-gray-100 dark:border-gray-800"><td class="py-1 pr-3 font-mono text-gray-700 dark:text-gray-300">${p.name}</td><td class="py-1 pr-3 tabular-nums text-gray-500 dark:text-gray-400">${p.default}</td><td class="py-1 text-gray-400 dark:text-gray-500">${p.description || ""}</td></tr>`).join("");
+  // A parameter may carry a `tuned:` value — the setting optimised on the QSM-CI scoring phantom,
+  // shown next to the method's usual `default:`. Only disclosed (submission page); the leaderboard
+  // still ranks methods at their defaults.
+  const plist = a.parameters || [];
+  const hasTuned = plist.some((p) => p.tuned != null && String(p.tuned) !== String(p.default));
+  const params = plist.map((p) => {
+    const tuned = (p.tuned != null && String(p.tuned) !== String(p.default))
+      ? `<span class="text-emerald-600 dark:text-emerald-400" title="Optimised on the QSM-CI scoring phantom">⚙ ${p.tuned}</span>`
+      : `<span class="text-gray-300 dark:text-gray-600">—</span>`;
+    return `<tr class="border-t border-gray-100 dark:border-gray-800"><td class="py-1 pr-3 font-mono text-gray-700 dark:text-gray-300">${p.name}</td><td class="py-1 pr-3 tabular-nums text-gray-500 dark:text-gray-400">${p.default}</td>${hasTuned ? `<td class="py-1 pr-3 tabular-nums">${tuned}</td>` : ""}<td class="py-1 text-gray-400 dark:text-gray-500">${p.description || ""}</td></tr>`;
+  }).join("");
+  const paramHead = hasTuned
+    ? `<thead><tr class="text-left text-gray-400 dark:text-gray-500"><th class="py-1 pr-3 font-normal">parameter</th><th class="py-1 pr-3 font-normal">default</th><th class="py-1 pr-3 font-normal"><span class="has-tip text-emerald-600 dark:text-emerald-400" data-tip="Value optimised on the QSM-CI scoring phantom (maximising xSIM). The default is the method's usual setting; the leaderboard still ranks methods at their defaults.">⚙ tuned</span></th><th class="py-1 font-normal"></th></tr></thead>`
+    : "";
   return `<div>
     <div class="flex items-baseline gap-2">
       <span class="font-medium text-gray-900 dark:text-gray-100">${a.name}</span>
       <span class="text-xs text-gray-400">${a.stage ? (STAGE_LABEL[a.stage] || a.stage) : ""}</span>
     </div>
     <p class="mt-0.5 text-sm text-gray-600 dark:text-gray-400">${a.description || ""}</p>
-    ${params ? `<table class="mt-2 w-full text-xs"><tbody>${params}</tbody></table>` : ""}
+    ${params ? `<table class="mt-2 w-full text-xs">${paramHead}<tbody>${params}</tbody></table>` : ""}
     ${(a.citation || links.length) ? `<p class="mt-1.5 text-xs text-gray-400 dark:text-gray-500">${a.citation || ""} ${links.length ? "· " + links.join(" · ") : ""}</p>` : ""}
   </div>`;
 }
@@ -269,13 +282,37 @@ function renderMethodInfo() {
 }
 
 // ---- detail + viewer --------------------------------------------------------
+// Default + tuned isolated runs for the current method, if both exist (drives the Defaults/Tuned
+// toggle — switching swaps the metrics AND the NiiVue volumes, since each variant is its own run).
+function variantRuns() {
+  if (!run || run.mode !== "isolated") return null;
+  const sib = allRuns.filter((r) => r.slug === run.slug && r.mode === "isolated" && r.artifact === run.artifact);
+  const def = sib.find((r) => (r.variant || "default") === "default");
+  const tun = sib.find((r) => r.variant === "tuned" && r.status !== "DNF");
+  return def && tun ? { def, tun } : null;
+}
+function variantToggleHTML() {
+  const v = variantRuns();
+  if (!v) return "";
+  const cur = run.variant === "tuned" ? "tuned" : "default";
+  const btn = (key, id, label) =>
+    `<button data-variant-id="${id}" class="px-2 py-0.5 rounded-md transition ${cur === key
+      ? "bg-white shadow-sm text-emerald-700 dark:bg-gray-700 dark:text-emerald-400"
+      : "text-gray-500 hover:text-gray-700 dark:text-gray-400"}">${label}</button>`;
+  return `<span class="inline-flex items-center rounded-lg bg-gray-100 dark:bg-gray-800 p-0.5 text-xs font-medium align-middle"
+    title="Switch between the method's default parameters and the values optimised on the QSM-CI scoring phantom. Metrics and the volumes below update to match.">${btn("default", v.def.id, "Defaults")}${btn("tuned", v.tun.id, "⚙ Tuned")}</span>`;
+}
+
 async function loadRun() {
   $("sub-title").textContent = run.name;
   const stageCls = STAGE_COLOR[run.stage] || "bg-gray-100 text-gray-600 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700";
   $("sub-badges").innerHTML =
     badge(STAGE_LABEL[run.stage] || run.stage, stageCls) +
     badge(run.mode === "composed" ? "Composed pipeline" : "Isolated", "bg-gray-100 text-gray-600 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700") +
-    (run.status === "DNF" ? badge("DNF", "bg-red-50 text-red-600 ring-red-100 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/20") : "");
+    (run.status === "DNF" ? badge("DNF", "bg-red-50 text-red-600 ring-red-100 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/20") : "") +
+    variantToggleHTML();
+  $("sub-badges").querySelectorAll("[data-variant-id]").forEach((b) =>
+    b.addEventListener("click", () => selectRun(b.dataset.variantId)));
   const bits = [];
   if (run.artifact) bits.push(`scored artifact <code class="text-gray-700 dark:text-gray-300">${run.artifact}</code>`);
   if (run.runtime_s != null) bits.push(`runtime ${run.runtime_s.toFixed(1)}s`);

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -36,6 +36,12 @@
 
     <!-- sub-controls -->
     <div class="mt-6 flex flex-wrap items-center gap-3">
+      <template x-if="hasTuned()">
+        <div class="inline-flex rounded-lg bg-gray-100 p-0.5 text-xs font-medium">
+          <button @click="variant='default'" :class="variant==='default' ? 'bg-white shadow-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'" class="rounded-md px-3 py-1 transition">Defaults</button>
+          <button @click="variant='tuned'" data-tip="Each method's parameters optimised on the QSM-CI scoring phantom (maximising xSIM). Tuning on the scored data is a form of overfitting, and only some methods are tunable (pretrained networks aren't) — so Defaults is the fair cross-method ranking. Applies to the per-stage tables and combined-method rows; the combination matrix stays at defaults." :class="variant==='tuned' ? 'bg-white shadow-sm text-emerald-700' : 'text-gray-500 hover:text-gray-700'" class="rounded-md px-3 py-1 transition">⚙ Tuned</button>
+        </div>
+      </template>
       <template x-if="view==='isolated'">
         <div class="inline-flex flex-wrap gap-2">
           <template x-for="s in stages()" :key="s">
@@ -235,6 +241,7 @@
       return {
         METRICS, STAGE_LABEL, MEDALS, fmt, val,
         runs: [], registry: {}, view: "composed", stage: "dipole", fmap: "gt",
+        variant: "default",
         metric: "xsim", sortKey: "xsim", sortDir: "desc", filter: "",
         colMenu: false, selectedCols: ["nrmse", "correlation", "xsim", "runtime_s"],
         loading: true,
@@ -252,13 +259,26 @@
         doi(r) { return this.view === "isolated" ? doiFor(this.registry, r.slug) : null; },
         stages() { return [...new Set(this.runs.filter((r) => r.mode === "isolated").map((r) => r.stage))]; },
         fmaps() { return [...new Set(this.runs.filter((r) => r.mode === "composed" && r.combo).map((r) => r.combo.field_mapping || "gt"))]; },
+        // Any tuned (optimised-on-the-scoring-phantom) runs present? Gates the Defaults/Tuned toggle.
+        hasTuned() { return this.runs.some((r) => r.variant === "tuned"); },
+        // Pick one run per method for the selected variant. In "tuned" mode a method with no tuned run
+        // (pretrained nets, or already-optimal defaults) falls back to its default run, so the toggle
+        // never drops methods — it only lifts the ones we optimised.
+        pickVariant(pool) {
+          if (this.variant !== "tuned") return pool.filter((r) => (r.variant || "default") === "default");
+          const by = {};
+          pool.forEach((r) => { (by[r.slug] ||= {})[r.variant || "default"] = r; });
+          return Object.values(by).map((v) => v.tuned || v.default).filter(Boolean);
+        },
         get baseRows() {
-          return _cache("baseRows", this.view + "|" + this.stage + "|" + this.fmap + "|" + this.runs.length, () =>
+          return _cache("baseRows", this.view + "|" + this.stage + "|" + this.fmap + "|" + this.variant + "|" + this.runs.length, () =>
             this.view === "isolated"
-              ? this.runs.filter((r) => r.mode === "isolated" && r.stage === this.stage)
+              ? this.pickVariant(this.runs.filter((r) => r.mode === "isolated" && r.stage === this.stage))
+              // Composed matrix is default-only (we don't run the tuned combinatorial matrix), so it
+              // ignores the variant toggle.
               : this.runs.filter((r) => r.mode === "composed" && (!r.combo || (r.combo.field_mapping || "gt") === this.fmap)));
         },
-        get cols() { return _cache("cols", this.view + "|" + this.stage + "|" + this.fmap + "|" + this.runs.length, () => metricCols(this.baseRows)); },
+        get cols() { return _cache("cols", this.view + "|" + this.stage + "|" + this.fmap + "|" + this.variant + "|" + this.runs.length, () => metricCols(this.baseRows)); },
         get displayCols() {
           const sel = this.cols.filter((c) => this.selectedCols.includes(c));
           return sel.length ? sel : this.cols.filter((c) => c === "xsim");
@@ -268,7 +288,7 @@
         },
         get rows() {
           return _cache("rows",
-            [this.view, this.stage, this.fmap, this.filter, this.sortKey, this.sortDir, this.runs.length].join("|"), () => {
+            [this.view, this.stage, this.fmap, this.variant, this.filter, this.sortKey, this.sortDir, this.runs.length].join("|"), () => {
               const f = this.filter.toLowerCase();
               return this.baseRows.filter((r) => !f || r.name.toLowerCase().includes(f)).slice().sort((a, b) => {
                 const av = val(a, this.sortKey), bv = val(b, this.sortKey);
@@ -312,10 +332,10 @@
         // so they're directly comparable to full pipelines, but can't be a cell in the BFR×dipole
         // grid. Shown as a separate row-group below the matrix (composed view only).
         get combinedAlgos() {
-          return _cache("combinedAlgos", this.fmap + "|" + this.metric + "|" + this.runs.length, () =>
-            this.runs.filter((r) => r.mode === "isolated"
+          return _cache("combinedAlgos", this.fmap + "|" + this.metric + "|" + this.variant + "|" + this.runs.length, () =>
+            this.pickVariant(this.runs.filter((r) => r.mode === "isolated"
               && (r.stage === "bfr+dipole" || r.stage === "end-to-end")
-              && r.artifact === "chimap" && val(r, this.metric) != null)
+              && r.artifact === "chimap" && val(r, this.metric) != null))
               .slice().sort((a, b) => this.norm(val(b, this.metric)) - this.norm(val(a, this.metric))));
         },
         norm(v) { // 0 = worst, 1 = best (respecting metric direction)


### PR DESCRIPTION
Ships parameter optimisation (tuned on the scoring phantom, disclosed via a Defaults/Tuned toggle — leaderboard ranking stays on defaults), plus portability/CLI fixes surfaced along the way, and an experimental parallel scorer.

**Tuning** — `tuned:` params for 9 methods; `pipeline.py` runs a tuned isolated variant each. Largest gains: matlab-medi 0.30→0.58 (λ 100→520), tsvd 0.60→0.72, tv 0.76→0.85, tgv 0.47→0.52.

**Fixes**
- MATLAB `run.sh` ×7: `MCR_CACHE_ROOT` → writable temp (fixes MATLAB DNF on GitHub-hosted runners).
- `qsm_ci` apptainer: use a published `image:` even when a folder Dockerfile exists.
- matlab-medi `params:`→`parameters:` (so `--set` works).
- autoqsm: mask the whole-head output to the brain.

**Parallel scorer (opt-in)** — `pipeline.py --shard i/n` (column-sharded) + `--runs-out`, and `score-parallel.yml` (dispatch/test-branch matrix → candidate index artifact, never commits). Validated on GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)