### PR TITLE
ci: merge results/index.json by run-id instead of rebasing (fix lost scores)

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -134,14 +134,21 @@ jobs:
         run: |
           git config user.name  "qsm-ci-bot"
           git config user.email "qsm-ci@users.noreply.github.com"
-          git add results/index.json
-          git commit -m "Update results" || { echo "no changes"; exit 0; }
-          # main can advance while this long scoring job runs (a PR merge, a registry commit),
-          # which would reject a plain push as non-fast-forward and LOSE the scores. Rebase the
-          # results commit onto latest main and retry. Only score writes results/index.json (and
-          # score runs are serialised by the concurrency group), so the rebase applies cleanly.
+          # main can advance while this long scoring job runs (a PR merge, a registry commit, or an
+          # earlier rescore whose results this run was based *before*). Do NOT rebase index.json onto
+          # it — concurrent rescores touch the same file and rebasing conflicts, losing the scores
+          # (that was the #72 failure). Instead re-apply only the runs THIS rescore changed, by id,
+          # onto the latest index.json each attempt (scripts/merge_index.py).
+          cp results/index.json /tmp/scored.json
+          git show HEAD:results/index.json > /tmp/base.json 2>/dev/null || echo '{"runs":[]}' > /tmp/base.json
           for attempt in 1 2 3 4 5; do
-            git pull --rebase origin main && git push && exit 0
-            echo "push attempt $attempt rejected — retrying"; sleep $((attempt * 5))
+            git fetch -q origin main
+            git reset -q --hard origin/main            # latest main (discards any prior failed attempt)
+            python3 scripts/merge_index.py /tmp/base.json /tmp/scored.json results/index.json results/index.json
+            git add results/index.json
+            git diff --cached --quiet && { echo "no score changes to commit"; exit 0; }
+            git commit -q -m "Update results"
+            git push -q && exit 0
+            echo "push attempt $attempt rejected — main moved; retrying"; sleep $((attempt * 5))
           done
           echo "::error::could not push results after 5 attempts"; exit 1

--- a/scripts/merge_index.py
+++ b/scripts/merge_index.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Re-apply the runs a rescore changed onto the latest results/index.json, by run id.
+
+score.yml must not `git pull --rebase` its `results/index.json` commit: a rescore can be based on a
+commit *before* a prior rescore's results landed, so rebasing conflicts on the same file (that's the
+#72 failure — "Pulling is not possible because you have unmerged files"). Instead, at push time we
+take the LATEST index.json from main and upsert only the run entries THIS rescore actually changed
+(the diff of its own checkout base vs. its scored output, keyed by run id). So concurrent rescores
+of different slugs never clobber each other, and a stale base is harmless — a full rescore still
+overwrites everything (every id differs), a focused one touches only its slugs.
+
+Existing run order is preserved (changed entries replaced in place; brand-new ids appended).
+
+Usage: merge_index.py BASE SCORED CURRENT OUT
+  BASE     index.json this rescore started from (checkout HEAD)
+  SCORED   index.json this rescore produced (base + freshly scored runs)
+  CURRENT  latest index.json from origin/main
+  OUT      where to write the merged result (may equal CURRENT)
+"""
+import json
+import sys
+
+
+def _runs(path: str) -> list:
+    try:
+        return json.loads(open(path).read()).get("runs", [])
+    except Exception:  # noqa: BLE001 — a missing/empty index is just "no runs"
+        return []
+
+
+def main() -> int:
+    base_p, scored_p, current_p, out_p = sys.argv[1:5]
+    base = {r["id"]: r for r in _runs(base_p)}
+    # Runs this rescore owns = present in its output and new-or-different vs. the base it started from.
+    changed = {r["id"]: r for r in _runs(scored_p) if base.get(r["id"]) != r}
+
+    doc = json.loads(open(current_p).read())
+    seen, merged = set(), []
+    for r in doc.get("runs", []):
+        merged.append(changed.get(r["id"], r))
+        seen.add(r["id"])
+    for rid, r in changed.items():
+        if rid not in seen:
+            merged.append(r)
+    doc["runs"] = merged
+
+    with open(out_p, "w") as f:
+        f.write(json.dumps(doc, indent=2) + "\n")
+    print(f"re-applied {len(changed)} changed run(s); index now has {len(merged)} runs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`score.yml` committed `results/index.json` then `git pull --rebase origin main`. When a rescore is based on a commit *before* a prior rescore's results landed, rebasing its `index.json` onto the newer one **conflicts** (`Pulling is not possible because you have unmerged files`) and the run fails after 5 retries — scores computed but never committed. That's what killed **#72** (the focused iLSQR+TGV rescore, based on a pre-full-rescore commit).

**Fix:** replace the rebase with `scripts/merge_index.py` — each push attempt resets to latest `origin/main` and re-applies only the runs **this** rescore changed (its base-vs-scored diff, keyed by run id). So:
- concurrent rescores of different slugs never clobber each other,
- a full rescore still overwrites everything (every id differs),
- a stale base is harmless.

Unit-tested against the exact #72 scenario (rescore changes run `b` while main concurrently gains run `c` → result keeps both). New script + workflow-only edit, so it doesn't trip score.yml's full-rescore path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)