### PR TITLE
Rank runtime as a metric; full-pipeline timing; pannable histograms

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -395,48 +395,51 @@ def main() -> None:
 
         # Stage 1 — totalfield sources: the ground-truth field ("gt") plus each field-mapping
         # submission's output (run on raw inputs), so the matrix can start from raw phase.
-        # Each source is (totalfield, valid-region mask) so downstream stages inherit any erosion.
-        tf_sources: dict[str, tuple] = {"gt": (gt / ARTIFACT_FILE["totalfield"], mask)}
+        # Each source is (totalfield, valid-region mask, cumulative runtime s) so downstream stages
+        # inherit any erosion and can accumulate the full pipeline's wall-clock time. The ground-truth
+        # field costs nothing to "produce", so its runtime is 0.
+        tf_sources: dict[str, tuple] = {"gt": (gt / ARTIFACT_FILE["totalfield"], mask, 0.0)}
 
         def do_fieldmap(f):
             idir, odir = args.work / f"cmp_fm_{f['slug']}_in", args.work / f"cmp_fm_{f['slug']}_out"
             try:
                 prepare_input(f["consumes"], gt_sources, idir)
-                run_algo(f, idir, odir, args.runner)
+                fm_rt = run_algo(f, idir, odir, args.runner)
                 tf = odir / "totalfield.nii.gz"
                 # A field-mapping method may erode (e.g. Laplacian unwrapping) — carry its valid region.
                 fm_mask = _valid_mask(tf, mask, odir / "validmask.nii.gz")
-                return (f["slug"], tf, fm_mask)
+                return (f["slug"], tf, fm_mask, fm_rt)
             except Exception as e:
                 print(f"  composed  fieldmap {f['slug']} DNF ({e}) — skipping its pipelines")
                 return None
 
         for res in _pmap(fmap, do_fieldmap):
             if res:
-                tf_sources[res[0]] = (res[1], res[2])
+                tf_sources[res[0]] = (res[1], res[2], res[3])
 
         # Stage 2 — bfr: localfield for each (totalfield source, bfr), keyed (tfk, bfr slug).
-        # Each entry caches (localfield, valid-region mask) so the dipole inherits any erosion.
+        # Each entry caches (localfield, valid-region mask, cumulative runtime s) so the dipole
+        # inherits any erosion and the upstream field-mapping + BFR wall-clock time.
         lf_cache: dict[tuple, tuple] = {}
 
         def do_bfr(task):
-            tfk, tfp, tf_mask, b = task
+            tfk, tfp, tf_mask, fm_rt, b = task
             idir, odir = args.work / f"cmp_{tfk}_{b['slug']}_in", args.work / f"cmp_{tfk}_{b['slug']}_out"
             try:
                 # Run within the incoming valid region (not the full mask) so a field-mapping erosion
                 # already narrows the boundary before the BFR erodes further.
                 src = dict(gt_sources); src["totalfield"] = tfp; src["mask"] = tf_mask
                 prepare_input(b["consumes"], src, idir)
-                run_algo(b, idir, odir, args.runner)
+                bfr_rt = run_algo(b, idir, odir, args.runner)
                 lf = odir / "localfield.nii.gz"
                 bfr_mask = _valid_mask(lf, tf_mask, odir / "validmask.nii.gz")
-                return ((tfk, b["slug"]), (lf, bfr_mask))
+                return ((tfk, b["slug"]), (lf, bfr_mask, fm_rt + bfr_rt))
             except Exception as e:
                 print(f"  composed  {tfk}+{b['slug']} bfr DNF ({e})")
                 return None
 
-        bfr_tasks = [(tfk, tfp, tf_mask, b) for tfk, (tfp, tf_mask) in tf_sources.items() for b in bfr
-                     if owns_col(tfk, b["slug"])]  # --shard: only this shard's columns
+        bfr_tasks = [(tfk, tfp, tf_mask, fm_rt, b) for tfk, (tfp, tf_mask, fm_rt) in tf_sources.items()
+                     for b in bfr if owns_col(tfk, b["slug"])]  # --shard: only this shard's columns
         for res in _pmap(bfr_tasks, do_bfr):
             if res:
                 lf_cache[res[0]] = res[1]
@@ -448,16 +451,17 @@ def main() -> None:
             cid = f"{tfk}~{b['slug']}~{d['slug']}-cmp"
             cinfo = {"field_mapping": tfk, "bfr": b["slug"], "dipole": d["slug"]}
             try:
-                lf, bfr_mask = lf_cache[(tfk, b["slug"])]
+                lf, bfr_mask, upstream_rt = lf_cache[(tfk, b["slug"])]
                 # Invert within the BFR's eroded region — not the original full mask — so the dipole
                 # never deconvolves a zero-field rim into a blurry boundary.
                 src = dict(gt_sources); src["localfield"] = lf; src["mask"] = bfr_mask
                 idir, odir = args.work / f"cmp_{cid}_in", args.work / f"cmp_{cid}_out"
                 prepare_input(d["consumes"], src, idir)
                 rt = run_algo(d, idir, odir, args.runner)
+                # runtime_s is the whole pipeline's wall-clock: field-mapping + BFR (upstream_rt) + dipole.
                 meta = {"id": cid, "slug": combo, "name": combo,
                         "stage": "bfr+dipole" if tfk == "gt" else "field-mapping+bfr+dipole",
-                        "mode": "composed", "track": args.track, "runtime": rt, "combo": cinfo}
+                        "mode": "composed", "track": args.track, "runtime": upstream_rt + rt, "combo": cinfo}
                 r = score(odir / "chimap.nii.gz", "chimap", gt, mask,
                           args.work / f"cmp_{cid}.json", meta)
                 m = r["metrics"]

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -139,7 +139,7 @@ const METRICS = {
   xsim:            { label: "XSIM",             unit: "",  better: "higher", dp: 3,
     desc: "Structural-similarity index tuned for QSM (5×5×5 windows). 1 = identical to the ground truth." },
   runtime_s:       { label: "Runtime",          unit: "s", better: "lower",  dp: 1,
-    desc: "Wall-clock time taken by this run." },
+    desc: "Wall-clock time to produce this output — for a combined pipeline, the sum of its field-mapping, background-removal and dipole-inversion stages. Measured on GitHub-hosted runners (≈4 vCPU, 16 GB RAM, no GPU — so learning-based methods run on CPU); treat it as relative speed, not an absolute benchmark." },
 };
 const PREFERRED = ["nrmse", "nrmse_detrend", "nrmse_tissue", "nrmse_blood", "nrmse_dgm",
   "dgm_linearity", "calc_moment_dev", "calc_streak", "correlation", "xsim"];

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -315,7 +315,6 @@ async function loadRun() {
     b.addEventListener("click", () => selectRun(b.dataset.variantId)));
   const bits = [];
   if (run.artifact) bits.push(`scored artifact <code class="text-gray-700 dark:text-gray-300">${run.artifact}</code>`);
-  if (run.runtime_s != null) bits.push(`runtime ${run.runtime_s.toFixed(1)}s`);
   if (run.image) bits.push(`image <code class="text-gray-700 dark:text-gray-300">${run.image}</code>`);
   $("sub-meta").innerHTML = bits.join(" · ");
   renderMethodInfo();
@@ -361,7 +360,7 @@ async function loadRun() {
 // or isolated runs sharing this run's stage). Returns { rank, n, t } where t is 0..1 goodness for
 // colour, or null when there's nothing to compare against.
 function metricRank(k) {
-  const meta = METRICS[k], v = run.metrics?.[k];
+  const meta = METRICS[k], v = val(run, k);   // val() also reaches top-level fields (e.g. runtime_s)
   if (v == null) return null;
   const sameGroup = (r) => (run.combo ? r.mode === "composed" : r.mode === "isolated" && r.stage === run.stage);
   const peers = allRuns.filter((r) => r.status !== "DNF" && sameGroup(r) && val(r, k) != null);
@@ -375,9 +374,10 @@ function metricRank(k) {
 }
 
 function renderMetrics() {
-  const m = run.metrics || {};
   $("metrics-sub").textContent = run.mode === "composed" ? "Final χ map vs. ground truth" : `${run.artifact || "output"} vs. ground truth`;
-  const order = Object.keys(METRICS).filter((k) => m[k] != null);
+  // Include runtime_s (a top-level field, not under run.metrics) via val(), so it's ranked alongside
+  // the accuracy metrics. Object.keys(METRICS) keeps it last, matching its registry order.
+  const order = Object.keys(METRICS).filter((k) => val(run, k) != null);
   const groupLabel = run.combo ? "composed pipelines" : `isolated ${STAGE_LABEL[run.stage] || run.stage} methods`;
   $("metrics-body").innerHTML = order.map((k) => {
     const meta = METRICS[k], arrow = meta.better === "higher" ? "↑" : "↓", hero = k === "xsim" || k === "nrmse";
@@ -387,7 +387,7 @@ function renderMetrics() {
       : `<span class="text-gray-300 dark:text-gray-600">—</span>`;
     return `<tr>
       <td class="py-2.5 text-gray-500 dark:text-gray-400"><span class="has-tip" data-tip="${(meta.desc || "").replace(/"/g, "&quot;")}">${meta.label}</span> <span class="text-gray-300 dark:text-gray-600" title="${meta.better} is better">${arrow}</span></td>
-      <td class="py-2.5 text-right tabular-nums ${hero ? "font-bold text-gray-900 dark:text-gray-100" : "font-medium text-gray-700 dark:text-gray-300"}">${fmt(m[k], k)}</td>
+      <td class="py-2.5 text-right tabular-nums ${hero ? "font-bold text-gray-900 dark:text-gray-100" : "font-medium text-gray-700 dark:text-gray-300"}">${fmt(val(run, k), k)}</td>
       <td class="py-2.5 pl-3 text-right">${rankCell}</td>
     </tr>`;
   }).join("") || `<tr><td class="py-3 text-gray-400">No metrics for this run.</td></tr>`;
@@ -443,7 +443,7 @@ function makeWindowControl(getVol, cmapCfg) {
   const el = document.createElement("div");
   el.innerHTML = `
     <div class="flex items-center gap-2">
-      <div class="dualrange flex-1" title="Scroll to zoom the range · double-click to reset">
+      <div class="dualrange flex-1" title="Scroll to zoom the range · drag to pan when zoomed · double-click to reset">
         <canvas class="hist"></canvas>
         <div class="track"></div><div class="fill"></div>
         <input class="rng-lo" type="range" /><input class="rng-hi" type="range" />
@@ -474,6 +474,7 @@ function makeWindowControl(getVol, cmapCfg) {
   // [dmin,dmax] is the full data range; [vmin,vmax] is the zoomed *view* the slider+histogram span, so
   // scrolling to a narrow view makes each pixel of drag fine. cal_min/cal_max stay the source of truth.
   let dmin = 0, dmax = 1, vmin = 0, vmax = 1, winLo = 0, winHi = 1, hist = null, magnitude = false;
+  let pan = null, panRAF = 0;   // active drag-to-pan state (of the zoomed view) + its rAF handle
   const clampV = (x) => Math.min(vmax, Math.max(vmin, x));  // into the zoom view; thumbs pin, cal_* stay exact
   const pct = (x) => (vmax === vmin ? 0 : ((clampV(x) - vmin) / (vmax - vmin)) * 100);
 
@@ -492,8 +493,9 @@ function makeWindowControl(getVol, cmapCfg) {
     for (const r of [rngLo, rngHi]) { r.min = vmin; r.max = vmax; r.step = step; }
     const zoomed = vmax - vmin < (dmax - dmin) * 0.999;
     hintEl.textContent = zoomed
-      ? `zoomed to ${fmtWin(vmin)} – ${fmtWin(vmax)} · double-click to reset`
+      ? `zoomed to ${fmtWin(vmin)} – ${fmtWin(vmax)} · drag to pan · double-click to reset`
       : "scroll over the bar to zoom in for finer control";
+    dr.style.cursor = pan ? "grabbing" : zoomed ? "grab" : "";  // affordance: grab when there's room to pan
     buildHistogram(getVol());
     apply(winLo, winHi);
   }
@@ -614,6 +616,38 @@ function makeWindowControl(getVol, cmapCfg) {
     zoom(e.deltaY < 0 ? 0.8 : 1.25, frac);
   }, { passive: false });
   dr.addEventListener("dblclick", () => { if (!getVol()) return; vmin = dmin; vmax = dmax; applyView(); });
+  // Drag across the bar to pan the zoomed-in view (scroll zooms; this slides the [vmin,vmax] window
+  // left/right). Ignores drags that begin on a slider thumb or a value bubble — those keep their own
+  // behaviour — and does nothing until the view is actually zoomed in. rAF-coalesced so a fast drag
+  // repaints the histogram at most once per frame.
+  const onThumbOrBubble = (t) => t === rngLo || t === rngHi || !!(t.closest && t.closest(".win-bubble"));
+  dr.addEventListener("pointerdown", (e) => {
+    if (!getVol() || onThumbOrBubble(e.target)) return;
+    if (vmax - vmin >= (dmax - dmin) * 0.999) return;   // not zoomed — nothing to pan
+    pan = { x0: e.clientX, x1: e.clientX, vmin0: vmin, vmax0: vmax, w: dr.getBoundingClientRect().width || 1 };
+    dr.setPointerCapture(e.pointerId); dr.style.cursor = "grabbing"; e.preventDefault();
+  });
+  dr.addEventListener("pointermove", (e) => {
+    if (!pan) return;
+    pan.x1 = e.clientX;
+    if (panRAF) return;
+    panRAF = requestAnimationFrame(() => {
+      panRAF = 0; if (!pan) return;
+      const span = pan.vmax0 - pan.vmin0, dx = ((pan.x1 - pan.x0) / pan.w) * span;  // drag right → view moves left
+      let nmin = pan.vmin0 - dx, nmax = pan.vmax0 - dx;
+      if (nmin < dmin) { nmin = dmin; nmax = dmin + span; }
+      if (nmax > dmax) { nmax = dmax; nmin = dmax - span; }
+      vmin = nmin; vmax = nmax; applyView();
+    });
+  });
+  const endPan = (e) => {
+    if (!pan) return;
+    pan = null; if (panRAF) { cancelAnimationFrame(panRAF); panRAF = 0; }
+    applyView();  // restores the idle grab/none cursor
+    try { dr.releasePointerCapture(e.pointerId); } catch (_) { /* pointer already released */ }
+  };
+  dr.addEventListener("pointerup", endPan);
+  dr.addEventListener("pointercancel", endPan);
 
   const ctl = { el, setup, redraw: () => { draw(); positionBubbles(); }, setMagnitude: (on) => { magnitude = on; }, cmapSelect: cmapSel };
   winControls.push(ctl);

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -68,7 +68,7 @@
           </div>
           <label class="inline-flex items-center gap-2 text-sm text-gray-600">Colour by
             <select x-model="metric" class="rounded-lg border-gray-300 text-sm py-1.5 pr-8">
-              <template x-for="c in cols.filter(c=>c!=='runtime_s')" :key="c"><option :value="c" :selected="c===metric" x-text="METRICS[c].label"></option></template>
+              <template x-for="c in cols" :key="c"><option :value="c" :selected="c===metric" x-text="METRICS[c].label"></option></template>
             </select>
           </label>
         </div>


### PR DESCRIPTION
Makes wall-clock **runtime** a first-class, ranked metric across the site, fixes composed-pipeline timing to be the true end-to-end cost, and adds drag-to-pan on the viewer's intensity histograms.

## Runtime as a ranked metric
Runtime was already captured and stored (`runtime_s`) and shown as a leaderboard column, but it wasn't *ranked* on submission pages and was excluded from the matrix.

- **Submission page** (`web/js/viewer.js`): `renderMetrics`/`metricRank` now read through the `val()` helper (which reaches top-level fields), so Runtime appears as a ranked row — rank badge + heat colour — next to the accuracy metrics. Removed the now-redundant "runtime Xs" from the metadata line.
- **Combination matrix** (`web/leaderboard.html`): Runtime is now selectable in the "Colour by" dropdown.
- **Tooltip** (`web/js/app.js`): explains it's the summed pipeline time and gives approximate runner specs.

## Composed-pipeline timing fix (`scripts/pipeline.py`)
Composed `runtime_s` previously measured **only the dipole stage** — the field-mapping and BFR stage times were computed then thrown away. Cumulative runtime is now threaded through `tf_sources → lf_cache → dipole`, so a combined pipeline's `runtime_s` is **field-mapping + BFR + dipole**. Isolated runs were already correct.

⚠️ Existing composed entries in `results/index.json` stay dipole-only (the upstream stage times were never recorded and can't be reconstructed); the **next scoring run backfills** them with true full-pipeline times. The frontend is forward-compatible.

## Runner specs on runtime
The leaderboard's runtimes come from `score.yml` on GitHub-hosted `ubuntu-latest`, so the tooltip now notes ≈4 vCPU / 16 GB RAM / **no GPU** — i.e. learning-based methods run on CPU. Treat runtime as relative speed, not an absolute benchmark. *(If `ubuntu-latest` is mapped to larger runners in this org, the numbers should be adjusted.)*

## Pannable windowing histograms (`web/js/viewer.js`)
The intensity-window widget already supported scroll-to-zoom; added **click-and-drag to pan** the zoomed view. Engages only when zoomed, ignores drags that begin on a slider thumb or value bubble, `requestAnimationFrame`-coalesced, with grab/grabbing cursor and updated hint text.

## Testing
- Frontend verified locally; Runtime ranks on submission pages and colours the matrix; histogram pans after scroll-zoom.
- `scripts/pipeline.py` parses/compiles; the timing change is internal threading (the phantom-backed pipeline test doesn't exercise runtime and skips without data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)