### PR TITLE
Runtime-as-a-metric, viewer error-map + histogram improvements, sweep tooling

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -250,8 +250,8 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--dataset", type=Path, default=ROOT / "data/sim/dev")
     ap.add_argument("--mode", choices=["isolated", "composed", "both"], default="both")
-    ap.add_argument("--runner", choices=["local", "docker"], default="local",
-                    help="local runs run.sh directly; docker runs each submission's image (CI)")
+    ap.add_argument("--runner", choices=["local", "docker", "apptainer"], default="local",
+                    help="local runs run.sh directly; docker/apptainer run each submission's image")
     ap.add_argument("--only", default=None, help="restrict isolated evaluation to this slug")
     ap.add_argument("--focus", default=None,
                     help="incremental: isolated for this slug, and every composed combo that includes "

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -395,48 +395,51 @@ def main() -> None:
 
         # Stage 1 — totalfield sources: the ground-truth field ("gt") plus each field-mapping
         # submission's output (run on raw inputs), so the matrix can start from raw phase.
-        # Each source is (totalfield, valid-region mask) so downstream stages inherit any erosion.
-        tf_sources: dict[str, tuple] = {"gt": (gt / ARTIFACT_FILE["totalfield"], mask)}
+        # Each source is (totalfield, valid-region mask, cumulative runtime s) so downstream stages
+        # inherit any erosion and can accumulate the full pipeline's wall-clock time. The ground-truth
+        # field costs nothing to "produce", so its runtime is 0.
+        tf_sources: dict[str, tuple] = {"gt": (gt / ARTIFACT_FILE["totalfield"], mask, 0.0)}
 
         def do_fieldmap(f):
             idir, odir = args.work / f"cmp_fm_{f['slug']}_in", args.work / f"cmp_fm_{f['slug']}_out"
             try:
                 prepare_input(f["consumes"], gt_sources, idir)
-                run_algo(f, idir, odir, args.runner)
+                fm_rt = run_algo(f, idir, odir, args.runner)
                 tf = odir / "totalfield.nii.gz"
                 # A field-mapping method may erode (e.g. Laplacian unwrapping) — carry its valid region.
                 fm_mask = _valid_mask(tf, mask, odir / "validmask.nii.gz")
-                return (f["slug"], tf, fm_mask)
+                return (f["slug"], tf, fm_mask, fm_rt)
             except Exception as e:
                 print(f"  composed  fieldmap {f['slug']} DNF ({e}) — skipping its pipelines")
                 return None
 
         for res in _pmap(fmap, do_fieldmap):
             if res:
-                tf_sources[res[0]] = (res[1], res[2])
+                tf_sources[res[0]] = (res[1], res[2], res[3])
 
         # Stage 2 — bfr: localfield for each (totalfield source, bfr), keyed (tfk, bfr slug).
-        # Each entry caches (localfield, valid-region mask) so the dipole inherits any erosion.
+        # Each entry caches (localfield, valid-region mask, cumulative runtime s) so the dipole
+        # inherits any erosion and the upstream field-mapping + BFR wall-clock time.
         lf_cache: dict[tuple, tuple] = {}
 
         def do_bfr(task):
-            tfk, tfp, tf_mask, b = task
+            tfk, tfp, tf_mask, fm_rt, b = task
             idir, odir = args.work / f"cmp_{tfk}_{b['slug']}_in", args.work / f"cmp_{tfk}_{b['slug']}_out"
             try:
                 # Run within the incoming valid region (not the full mask) so a field-mapping erosion
                 # already narrows the boundary before the BFR erodes further.
                 src = dict(gt_sources); src["totalfield"] = tfp; src["mask"] = tf_mask
                 prepare_input(b["consumes"], src, idir)
-                run_algo(b, idir, odir, args.runner)
+                bfr_rt = run_algo(b, idir, odir, args.runner)
                 lf = odir / "localfield.nii.gz"
                 bfr_mask = _valid_mask(lf, tf_mask, odir / "validmask.nii.gz")
-                return ((tfk, b["slug"]), (lf, bfr_mask))
+                return ((tfk, b["slug"]), (lf, bfr_mask, fm_rt + bfr_rt))
             except Exception as e:
                 print(f"  composed  {tfk}+{b['slug']} bfr DNF ({e})")
                 return None
 
-        bfr_tasks = [(tfk, tfp, tf_mask, b) for tfk, (tfp, tf_mask) in tf_sources.items() for b in bfr
-                     if owns_col(tfk, b["slug"])]  # --shard: only this shard's columns
+        bfr_tasks = [(tfk, tfp, tf_mask, fm_rt, b) for tfk, (tfp, tf_mask, fm_rt) in tf_sources.items()
+                     for b in bfr if owns_col(tfk, b["slug"])]  # --shard: only this shard's columns
         for res in _pmap(bfr_tasks, do_bfr):
             if res:
                 lf_cache[res[0]] = res[1]
@@ -448,16 +451,17 @@ def main() -> None:
             cid = f"{tfk}~{b['slug']}~{d['slug']}-cmp"
             cinfo = {"field_mapping": tfk, "bfr": b["slug"], "dipole": d["slug"]}
             try:
-                lf, bfr_mask = lf_cache[(tfk, b["slug"])]
+                lf, bfr_mask, upstream_rt = lf_cache[(tfk, b["slug"])]
                 # Invert within the BFR's eroded region — not the original full mask — so the dipole
                 # never deconvolves a zero-field rim into a blurry boundary.
                 src = dict(gt_sources); src["localfield"] = lf; src["mask"] = bfr_mask
                 idir, odir = args.work / f"cmp_{cid}_in", args.work / f"cmp_{cid}_out"
                 prepare_input(d["consumes"], src, idir)
                 rt = run_algo(d, idir, odir, args.runner)
+                # runtime_s is the whole pipeline's wall-clock: field-mapping + BFR (upstream_rt) + dipole.
                 meta = {"id": cid, "slug": combo, "name": combo,
                         "stage": "bfr+dipole" if tfk == "gt" else "field-mapping+bfr+dipole",
-                        "mode": "composed", "track": args.track, "runtime": rt, "combo": cinfo}
+                        "mode": "composed", "track": args.track, "runtime": upstream_rt + rt, "combo": cinfo}
                 r = score(odir / "chimap.nii.gz", "chimap", gt, mask,
                           args.work / f"cmp_{cid}.json", meta)
                 m = r["metrics"]

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Parameter sweep for QSM-CI algorithms — optimise isolated xSIM.
+
+Runs each tunable algorithm over a grid of --set overrides in ISOLATED mode (fed the ground-truth
+artifact(s) its stage consumes, exactly like scripts/pipeline.py isolated), scores each output's
+xSIM against ground truth with the same valid-mask logic as the pipeline, and reports the best grid
+point per algorithm against its current default.
+
+  python scripts/sweep.py --dataset data/sim/dev [--only tgv,tkd] [--jobs 4]
+
+Writes results/sweep.json (every grid point) and prints a per-algorithm best-vs-baseline table.
+Only regularisation / threshold knobs are swept — pure convergence knobs (tol, max_iter) are held at
+their defaults, since they change convergence, not the over-/under-regularisation we're tuning for.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import itertools
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+EVAL = ROOT / "eval" / "qsm_eval.py"
+sys.path.insert(0, str(ROOT / "scripts"))
+from pipeline import (  # noqa: E402  reuse the exact isolated-scoring machinery
+    ARTIFACT_FILE, discover_algorithms, prepare_input, _valid_mask,
+)
+
+# Grid of {param: [values]} per slug. itertools.product expands to one run per combination.
+# Baselines (current defaults) are included so the sweep re-measures them under identical scoring.
+GRIDS: dict[str, dict[str, list]] = {
+    # --- dipole stage (fast qsmxt inversions) ---
+    "tkd":      {"threshold": [0.05, 0.08, 0.1, 0.13, 0.16, 0.2, 0.25, 0.3]},
+    "tsvd":     {"threshold": [0.05, 0.08, 0.1, 0.13, 0.16, 0.2, 0.25, 0.3]},
+    "tikhonov": {"lambda": [1e-5, 3e-5, 1e-4, 3e-4, 1e-3, 3e-3, 1e-2]},
+    "medi":     {"lambda": [3e-5, 1e-4, 3e-4, 1e-3, 3e-3, 1e-2]},
+    "tv":       {"lambda": [1e-5, 3e-5, 1e-4, 3e-4, 1e-3, 3e-3]},
+    "nltv":     {"lambda": [1e-5, 3e-5, 1e-4, 3e-4, 1e-3, 3e-3]},
+    "rts":      {"delta": [0.3, 0.6, 1.0, 1.5, 2.0, 3.0], "mu": [1.0]},
+    # --- background-field removal (already scores high; sweep reg/threshold anyway) ---
+    "resharp":  {"radius": [8.0, 12.0, 15.0, 20.0], "tik_reg": [1e-4, 1e-3, 5e-3]},
+    "sharp":    {"threshold": [0.01, 0.02, 0.05, 0.1]},
+    "vsharp":   {"threshold": [0.01, 0.02, 0.05, 0.1]},
+    # --- bfr+dipole single-step spans (the over-regularised ones) ---
+    "tgv":      {"alpha1": [0.0002, 0.0004, 0.0006, 0.001], "alpha0": [0.0008, 0.0015, 0.0025]},
+    "matlab-medi": {"lambda": [100, 300, 600, 1000], "smv_radius": [3, 5]},
+    # --- unwrap+bfr ---
+    "harperella":  {"radius": [3.0, 5.0, 8.0]},
+    "iharperella": {"radius": [3.0, 5.0, 8.0]},
+}
+
+# Round-2 refinement: extend the axes where round-1's best sat on a grid edge, so the true optimum
+# isn't clipped. Only these slugs are re-run (with --refine).
+REFINE: dict[str, dict[str, list]] = {
+    "tgv":     {"alpha1": [0.00003, 0.00006, 0.0001, 0.00015, 0.0002], "alpha0": [0.0015]},
+    "tsvd":    {"threshold": [0.02, 0.03, 0.04, 0.05, 0.06]},
+    "nltv":    {"lambda": [3e-3, 1e-2, 3e-2, 1e-1]},
+    "sharp":   {"threshold": [0.003, 0.005, 0.008, 0.01]},
+    "vsharp":  {"threshold": [0.1, 0.15, 0.2, 0.3]},
+    "harperella": {"radius": [1.0, 2.0, 3.0]},
+    # λ climbs to 0.546 at 450 but diverges hard by 600 — pin the peak in the pre-cliff window.
+    "matlab-medi": {"lambda": [460, 480, 500, 520, 540, 560], "smv_radius": [5]},
+}
+
+_print_lock = threading.Lock()
+RUNNER = "docker"
+
+
+def gt_sources(dataset: Path) -> dict[str, Path]:
+    inputs, gt = dataset / "inputs", dataset / "groundtruth"
+    return {
+        "phase": inputs / "phase.nii.gz", "magnitude": inputs / "magnitude.nii.gz",
+        "mask": inputs / "mask.nii.gz", "params": inputs / "params.json",
+        "totalfield": gt / "totalfield.nii.gz", "localfield": gt / "localfield.nii.gz",
+        "chimap": gt / "chimap.nii.gz",
+    }
+
+
+def combos(grid: dict[str, list]) -> list[dict]:
+    keys = list(grid)
+    return [dict(zip(keys, vals)) for vals in itertools.product(*(grid[k] for k in keys))]
+
+
+def fmt(v) -> str:
+    return f"{v:g}" if isinstance(v, float) else str(v)
+
+
+def score_xsim(recon: Path, artifact: str, gt: Path, mask: Path, work: Path) -> dict:
+    """Valid-mask + qsm_eval, identical to pipeline.score; returns the metrics dict."""
+    kind = {"totalfield": "field", "localfield": "field", "chimap": "chi"}[artifact]
+    sm = _valid_mask(recon, mask, work.with_suffix(".scoremask.nii.gz"))
+    out_json = work.with_suffix(".score.json")
+    cmd = [sys.executable, str(EVAL), "--recon", str(recon),
+           "--truth", str(gt / ARTIFACT_FILE[artifact]), "--kind", kind,
+           "--mask", str(sm), "--artifact", artifact, "--out", str(out_json),
+           "--stage", "sweep", "--name", "sweep", "--track", "sim"]
+    seg = gt / "dseg.nii.gz"
+    if kind == "chi" and seg.exists():
+        cmd += ["--seg", str(seg)]
+    subprocess.run(cmd, check=True, capture_output=True)
+    return json.loads(out_json.read_text())["metrics"]
+
+
+def run_one(algo: dict, override: dict, src: dict, work: Path) -> dict:
+    slug = algo["slug"]
+    tag = "__".join(f"{k}-{fmt(v)}" for k, v in override.items()) or "default"
+    idir = work / f"{slug}__{tag}__in"
+    odir = work / f"{slug}__{tag}__out"
+    produced = algo["produces"][0]
+    prepare_input(algo["consumes"], src, idir)  # stage GT inputs under canonical names
+    argv = ["qsm-ci", "run", str(algo["dir"])]
+    for art in algo["consumes"]:
+        f = idir / ARTIFACT_FILE[art]
+        if art == "magnitude" and not f.exists():
+            continue
+        argv += [f"--{art}", str(f)]
+    for k, v in override.items():
+        argv += ["--set", f"{k}={fmt(v)}"]
+    argv += ["-o", str(odir / ARTIFACT_FILE[produced]), "--runner", RUNNER]
+    rec = {"slug": slug, "stage": algo["stage"], "override": override, "tag": tag}
+    try:
+        odir.mkdir(parents=True, exist_ok=True)
+        t0 = time.time()
+        subprocess.run(argv, check=True, capture_output=True, text=True)
+        m = score_xsim(odir / ARTIFACT_FILE[produced], produced,
+                       Path(src["chimap"]).parent, src["mask"], work / f"{slug}__{tag}")
+        rec.update(status="ok", xsim=m.get("xsim"), nrmse=m.get("nrmse"), runtime=time.time() - t0)
+    except subprocess.CalledProcessError as e:
+        rec.update(status="DNF", error=(e.stderr or "")[-400:])
+    except Exception as e:  # noqa: BLE001
+        rec.update(status="DNF", error=str(e)[-400:])
+    with _print_lock:
+        x = f"xsim={rec['xsim']:.4f}" if rec.get("xsim") is not None else f"DNF"
+        print(f"  {slug:<14} {tag:<28} {x}", flush=True)
+    return rec
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", type=Path, default=ROOT / "data/sim/scoring")
+    ap.add_argument("--only", default=None, help="comma-separated slugs to restrict the sweep")
+    ap.add_argument("--jobs", type=int, default=4)
+    ap.add_argument("--refine", action="store_true", help="use the round-2 REFINE grids")
+    ap.add_argument("--runner", default="docker", help="docker/podman/apptainer/local")
+    ap.add_argument("--work", type=Path, default=ROOT / ".sweep")
+    ap.add_argument("--out", type=Path, default=ROOT / "results/sweep.json")
+    args = ap.parse_args()
+    global RUNNER
+    RUNNER = args.runner
+
+    src = gt_sources(args.dataset)
+    algos = {a["slug"]: a for a in discover_algorithms()}
+    grids = REFINE if args.refine else GRIDS
+    want = args.only.split(",") if args.only else list(grids)
+    want = [s for s in want if s in grids]
+
+    tasks = []
+    for slug in want:
+        a = algos.get(slug)
+        if a is None:
+            print(f"! {slug} not discovered — skipping"); continue
+        tasks.append((a, {}))  # true no-override baseline (the method's built-in default)
+        for ov in combos(grids[slug]):
+            tasks.append((a, ov))
+    print(f"sweeping {len(want)} algorithms, {len(tasks)} runs, jobs={args.jobs}\n")
+    args.work.mkdir(parents=True, exist_ok=True)
+
+    # MATLAB MCR runs are memory-heavy; keep the whole sweep at the given cap (default 4).
+    with cf.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as ex:
+        results = list(ex.map(lambda t: run_one(t[0], t[1], src, args.work), tasks))
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(results, indent=2) + "\n")
+
+    print("\n=== best grid point per algorithm (xSIM) ===")
+    for slug in want:
+        rs = [r for r in results if r["slug"] == slug and r.get("status") == "ok"]
+        if not rs:
+            print(f"{slug:<14} all DNF"); continue
+        rs.sort(key=lambda r: r["xsim"], reverse=True)
+        best, worst = rs[0], rs[-1]
+        print(f"{slug:<14} best xsim={best['xsim']:.4f} @ {best['tag']:<26} "
+              f"(range {worst['xsim']:.4f}–{best['xsim']:.4f} over {len(rs)} pts)")
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sweep_report.py
+++ b/scripts/sweep_report.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Aggregate sweep results into a baseline-vs-best table (optimising xSIM).
+
+Reads every results/sweep_*.json (round 1) and results/sweep_refine_*.json (round 2), and for each
+algorithm reports the no-override baseline xSIM, the best grid point, and the winning override.
+
+  python scripts/sweep_report.py [--dir results]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+
+
+def load(path) -> list:
+    try:
+        return json.load(open(path))
+    except Exception:
+        return []
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dir", default="results")
+    args = ap.parse_args()
+
+    by_slug: dict[str, list] = {}
+    for path in sorted(glob.glob(os.path.join(args.dir, "sweep_*.json"))):
+        for r in load(path):
+            if r.get("status") == "ok" and r.get("xsim") is not None:
+                by_slug.setdefault(r["slug"], []).append(r)
+
+    print(f"{'algorithm':<14} {'baseline':>9} {'best':>9} {'Δ':>8}   best override")
+    print("-" * 72)
+    rows = []
+    for slug in sorted(by_slug):
+        runs = by_slug[slug]
+        base = next((r["xsim"] for r in runs if not r["override"]), None)
+        best = max(runs, key=lambda r: r["xsim"])
+        rows.append((slug, base, best))
+    # sort by improvement, biggest first
+    def delta(row):
+        _, base, best = row
+        return (best["xsim"] - base) if base is not None else -1
+    for slug, base, best in sorted(rows, key=delta, reverse=True):
+        ov = ", ".join(f"{k}={v:g}" if isinstance(v, float) else f"{k}={v}"
+                       for k, v in best["override"].items()) or "(default is best)"
+        b = f"{base:.4f}" if base is not None else "   n/a"
+        d = f"{best['xsim'] - base:+.4f}" if base is not None else "   n/a"
+        print(f"{slug:<14} {b:>9} {best['xsim']:>9.4f} {d:>8}   {ov}")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -139,7 +139,7 @@ const METRICS = {
   xsim:            { label: "XSIM",             unit: "",  better: "higher", dp: 3,
     desc: "Structural-similarity index tuned for QSM (5×5×5 windows). 1 = identical to the ground truth." },
   runtime_s:       { label: "Runtime",          unit: "s", better: "lower",  dp: 1,
-    desc: "Wall-clock time taken by this run." },
+    desc: "Wall-clock time to produce this output — for a combined pipeline, the sum of its field-mapping, background-removal and dipole-inversion stages. Measured on GitHub-hosted runners (≈4 vCPU, 16 GB RAM, no GPU — so learning-based methods run on CPU); treat it as relative speed, not an absolute benchmark." },
 };
 const PREFERRED = ["nrmse", "nrmse_detrend", "nrmse_tissue", "nrmse_blood", "nrmse_dgm",
   "dgm_linearity", "calc_moment_dev", "calc_streak", "correlation", "xsim"];

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -315,7 +315,6 @@ async function loadRun() {
     b.addEventListener("click", () => selectRun(b.dataset.variantId)));
   const bits = [];
   if (run.artifact) bits.push(`scored artifact <code class="text-gray-700 dark:text-gray-300">${run.artifact}</code>`);
-  if (run.runtime_s != null) bits.push(`runtime ${run.runtime_s.toFixed(1)}s`);
   if (run.image) bits.push(`image <code class="text-gray-700 dark:text-gray-300">${run.image}</code>`);
   $("sub-meta").innerHTML = bits.join(" · ");
   renderMethodInfo();
@@ -361,7 +360,7 @@ async function loadRun() {
 // or isolated runs sharing this run's stage). Returns { rank, n, t } where t is 0..1 goodness for
 // colour, or null when there's nothing to compare against.
 function metricRank(k) {
-  const meta = METRICS[k], v = run.metrics?.[k];
+  const meta = METRICS[k], v = val(run, k);   // val() also reaches top-level fields (e.g. runtime_s)
   if (v == null) return null;
   const sameGroup = (r) => (run.combo ? r.mode === "composed" : r.mode === "isolated" && r.stage === run.stage);
   const peers = allRuns.filter((r) => r.status !== "DNF" && sameGroup(r) && val(r, k) != null);
@@ -375,9 +374,10 @@ function metricRank(k) {
 }
 
 function renderMetrics() {
-  const m = run.metrics || {};
   $("metrics-sub").textContent = run.mode === "composed" ? "Final χ map vs. ground truth" : `${run.artifact || "output"} vs. ground truth`;
-  const order = Object.keys(METRICS).filter((k) => m[k] != null);
+  // Include runtime_s (a top-level field, not under run.metrics) via val(), so it's ranked alongside
+  // the accuracy metrics. Object.keys(METRICS) keeps it last, matching its registry order.
+  const order = Object.keys(METRICS).filter((k) => val(run, k) != null);
   const groupLabel = run.combo ? "composed pipelines" : `isolated ${STAGE_LABEL[run.stage] || run.stage} methods`;
   $("metrics-body").innerHTML = order.map((k) => {
     const meta = METRICS[k], arrow = meta.better === "higher" ? "↑" : "↓", hero = k === "xsim" || k === "nrmse";
@@ -387,7 +387,7 @@ function renderMetrics() {
       : `<span class="text-gray-300 dark:text-gray-600">—</span>`;
     return `<tr>
       <td class="py-2.5 text-gray-500 dark:text-gray-400"><span class="has-tip" data-tip="${(meta.desc || "").replace(/"/g, "&quot;")}">${meta.label}</span> <span class="text-gray-300 dark:text-gray-600" title="${meta.better} is better">${arrow}</span></td>
-      <td class="py-2.5 text-right tabular-nums ${hero ? "font-bold text-gray-900 dark:text-gray-100" : "font-medium text-gray-700 dark:text-gray-300"}">${fmt(m[k], k)}</td>
+      <td class="py-2.5 text-right tabular-nums ${hero ? "font-bold text-gray-900 dark:text-gray-100" : "font-medium text-gray-700 dark:text-gray-300"}">${fmt(val(run, k), k)}</td>
       <td class="py-2.5 pl-3 text-right">${rankCell}</td>
     </tr>`;
   }).join("") || `<tr><td class="py-3 text-gray-400">No metrics for this run.</td></tr>`;
@@ -443,7 +443,7 @@ function makeWindowControl(getVol, cmapCfg) {
   const el = document.createElement("div");
   el.innerHTML = `
     <div class="flex items-center gap-2">
-      <div class="dualrange flex-1" title="Scroll to zoom the range · double-click to reset">
+      <div class="dualrange flex-1" title="Scroll to zoom the range · drag to pan when zoomed · double-click to reset">
         <canvas class="hist"></canvas>
         <div class="track"></div><div class="fill"></div>
         <input class="rng-lo" type="range" /><input class="rng-hi" type="range" />
@@ -474,6 +474,7 @@ function makeWindowControl(getVol, cmapCfg) {
   // [dmin,dmax] is the full data range; [vmin,vmax] is the zoomed *view* the slider+histogram span, so
   // scrolling to a narrow view makes each pixel of drag fine. cal_min/cal_max stay the source of truth.
   let dmin = 0, dmax = 1, vmin = 0, vmax = 1, winLo = 0, winHi = 1, hist = null, magnitude = false;
+  let pan = null, panRAF = 0;   // active drag-to-pan state (of the zoomed view) + its rAF handle
   const clampV = (x) => Math.min(vmax, Math.max(vmin, x));  // into the zoom view; thumbs pin, cal_* stay exact
   const pct = (x) => (vmax === vmin ? 0 : ((clampV(x) - vmin) / (vmax - vmin)) * 100);
 
@@ -492,8 +493,9 @@ function makeWindowControl(getVol, cmapCfg) {
     for (const r of [rngLo, rngHi]) { r.min = vmin; r.max = vmax; r.step = step; }
     const zoomed = vmax - vmin < (dmax - dmin) * 0.999;
     hintEl.textContent = zoomed
-      ? `zoomed to ${fmtWin(vmin)} – ${fmtWin(vmax)} · double-click to reset`
+      ? `zoomed to ${fmtWin(vmin)} – ${fmtWin(vmax)} · drag to pan · double-click to reset`
       : "scroll over the bar to zoom in for finer control";
+    dr.style.cursor = pan ? "grabbing" : zoomed ? "grab" : "";  // affordance: grab when there's room to pan
     buildHistogram(getVol());
     apply(winLo, winHi);
   }
@@ -614,6 +616,38 @@ function makeWindowControl(getVol, cmapCfg) {
     zoom(e.deltaY < 0 ? 0.8 : 1.25, frac);
   }, { passive: false });
   dr.addEventListener("dblclick", () => { if (!getVol()) return; vmin = dmin; vmax = dmax; applyView(); });
+  // Drag across the bar to pan the zoomed-in view (scroll zooms; this slides the [vmin,vmax] window
+  // left/right). Ignores drags that begin on a slider thumb or a value bubble — those keep their own
+  // behaviour — and does nothing until the view is actually zoomed in. rAF-coalesced so a fast drag
+  // repaints the histogram at most once per frame.
+  const onThumbOrBubble = (t) => t === rngLo || t === rngHi || !!(t.closest && t.closest(".win-bubble"));
+  dr.addEventListener("pointerdown", (e) => {
+    if (!getVol() || onThumbOrBubble(e.target)) return;
+    if (vmax - vmin >= (dmax - dmin) * 0.999) return;   // not zoomed — nothing to pan
+    pan = { x0: e.clientX, x1: e.clientX, vmin0: vmin, vmax0: vmax, w: dr.getBoundingClientRect().width || 1 };
+    dr.setPointerCapture(e.pointerId); dr.style.cursor = "grabbing"; e.preventDefault();
+  });
+  dr.addEventListener("pointermove", (e) => {
+    if (!pan) return;
+    pan.x1 = e.clientX;
+    if (panRAF) return;
+    panRAF = requestAnimationFrame(() => {
+      panRAF = 0; if (!pan) return;
+      const span = pan.vmax0 - pan.vmin0, dx = ((pan.x1 - pan.x0) / pan.w) * span;  // drag right → view moves left
+      let nmin = pan.vmin0 - dx, nmax = pan.vmax0 - dx;
+      if (nmin < dmin) { nmin = dmin; nmax = dmin + span; }
+      if (nmax > dmax) { nmax = dmax; nmin = dmax - span; }
+      vmin = nmin; vmax = nmax; applyView();
+    });
+  });
+  const endPan = (e) => {
+    if (!pan) return;
+    pan = null; if (panRAF) { cancelAnimationFrame(panRAF); panRAF = 0; }
+    applyView();  // restores the idle grab/none cursor
+    try { dr.releasePointerCapture(e.pointerId); } catch (_) { /* pointer already released */ }
+  };
+  dr.addEventListener("pointerup", endPan);
+  dr.addEventListener("pointercancel", endPan);
 
   const ctl = { el, setup, redraw: () => { draw(); positionBubbles(); }, setMagnitude: (on) => { magnitude = on; }, cmapSelect: cmapSel };
   winControls.push(ctl);

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -339,6 +339,8 @@ async function loadRun() {
       onLocationChange: (d) => { $("intensity").innerHTML = d.string; },
     });
     await nv.attachTo("gl1");
+    nv.addColormap("errpos", ERR_POS_CMAP);   // signed error map: over-estimate (red), under-estimate (blue)
+    nv.addColormap("errneg", ERR_NEG_CMAP);
     nv.setSliceType(nv.sliceTypeMultiplanar);
     wireControls();
   }
@@ -414,11 +416,20 @@ function defaultWindow(vol) {
 const fmtWin = (v) => (Math.abs(v) >= 100 ? v.toFixed(0) : Math.abs(v) >= 1 ? v.toFixed(2) : v.toPrecision(2));
 const fmtNum = (v) => String(+Number(v).toPrecision(4));
 
-// Colormaps for the error overlay. Every option windows on |error| with a transparency floor (so the
-// masked, near-zero background stays clear); "diverging" colours the two signs differently (NiiVue
-// colormapNegative) for a signed red↔blue view, the rest reuse one map for both signs (magnitude only).
+// Signed error-map colormaps: over-estimate (recon>truth) ramps transparent→red→yellow, under-estimate
+// ramps transparent→blue→cyan. Alpha starts at 0 so the inner window bound (cal_min) is a hard
+// transparency floor — errors below it (incl. exact zero + the masked background) don't render at all —
+// and rises to full by the outer bound (cal_max = saturation). Used as colormap / colormapNegative,
+// so the two signs diverge from a fixed, transparent zero: the window changes only the ±inner/±outer
+// thresholds, never the centre.
+const ERR_POS_CMAP = { R: [180, 240, 255], G: [0, 70, 224], B: [0, 30, 40], A: [0, 200, 255], I: [0, 128, 255] };
+const ERR_NEG_CMAP = { R: [0, 20, 120], G: [0, 90, 224], B: [140, 210, 255], A: [0, 200, 255], I: [0, 128, 255] };
+
+// Colormaps for the error overlay. "diverging" is the zero-centered signed view (red = over, blue =
+// under) with a transparency floor at cal_min and saturation at cal_max. The rest window on |error|
+// with a single map for both signs (magnitude only).
 const ERROR_CMAPS = {
-  diverging: { colormap: "warm", colormapNegative: "winter" },  // signed: red = recon>truth, blue = recon<truth
+  diverging: { colormap: "errpos", colormapNegative: "errneg" },  // signed: red = recon>truth, blue = recon<truth
   warm:    { colormap: "warm",    colormapNegative: "warm" },
   hot:     { colormap: "hot",     colormapNegative: "hot" },
   viridis: { colormap: "viridis", colormapNegative: "viridis" },
@@ -479,12 +490,25 @@ function makeWindowControl(getVol, cmapCfg) {
   const pct = (x) => (vmax === vmin ? 0 : ((clampV(x) - vmin) / (vmax - vmin)) * 100);
 
   // Read the volume's current window + data range, reset the zoom to the full range, and sync the UI.
+  // Open the histogram zoomed so the window [winLo, winHi] spans ~half the visible range (context on
+  // both sides) rather than a sliver of the full data range. Preserves the view width when clamped to
+  // the data bounds; leaves the full range when the window is degenerate or already fills it.
+  function frameWindow() {
+    const W = winHi - winLo;
+    if (!(W > 0) || !(dmax > dmin)) { vmin = dmin; vmax = dmax; return; }
+    const span = Math.min(dmax - dmin, W * 2);           // window ≈ 50% of the view
+    const c = (winLo + winHi) / 2;
+    let nmin = c - span / 2, nmax = c + span / 2;
+    if (nmin < dmin) { nmin = dmin; nmax = dmin + span; }
+    if (nmax > dmax) { nmax = dmax; nmin = dmax - span; }
+    vmin = Math.max(dmin, nmin); vmax = Math.min(dmax, nmax);
+  }
   function setup() {
     const v = getVol(); if (!v) return;
     if (magnitude) { dmin = 0; dmax = Math.max(Math.abs(v.global_min), Math.abs(v.global_max)) || 1; }
     else { dmin = v.global_min; dmax = v.global_max; }
-    vmin = dmin; vmax = dmax;
     winLo = v.cal_min; winHi = v.cal_max;
+    frameWindow();   // zoom the initial view so the window takes up ~half the histogram
     applyView();
   }
   // Re-point the slider + histogram at the current zoom view [vmin,vmax] and reposition the window.
@@ -709,6 +733,10 @@ async function refreshView() {
       loadedBase = baseKind; loadedError = false;
       baseCtl.setup();
     }
+    // Reveal the error windowing section BEFORE setErrorColormap() so its canvas has a non-zero size
+    // when the histogram first draws — otherwise it renders blank and the bubbles mis-position until
+    // the next interaction (a hidden `display:none` element reports clientWidth 0).
+    $("win-error-section").classList.toggle("hidden", !showError);
     if (showError && !loadedError) {
       await nv.addVolumeFromUrl({ url: volUrl("error"), opacity: parseFloat($("opacity").value) });
       loadedError = true;
@@ -719,7 +747,6 @@ async function refreshView() {
     }
   } finally { setLoading(false); }
   nv.updateGLVolume();
-  $("win-error-section").classList.toggle("hidden", !showError);
 }
 
 // Apply the chosen error-overlay colormap. The error is always windowed on |error| (magnitude) with a
@@ -731,11 +758,14 @@ function setErrorColormap() {
   const cfg = ERROR_CMAPS[errorCtl.cmapSelect.value] || ERROR_CMAPS.diverging;
   ov.colormap = cfg.colormap;
   ov.colormapNegative = cfg.colormapNegative;
-  if (run.kind === "chi") { ov.cal_min = 0.01; ov.cal_max = 0.1; }
-  else {
-    const m = Math.max(Math.abs(ov.robust_min ?? ov.global_min), Math.abs(ov.robust_max ?? ov.global_max)) || 1;
-    ov.cal_min = 0.02 * m; ov.cal_max = m;
-  }
+  // Window on |error|, mirrored to both signs so zero is a fixed, transparent centre. cal_min = inner
+  // (transparency floor — errors below it, including exact zero, don't render); cal_max = outer
+  // (saturation — beyond it everything shows the top colour). Moving either changes only the ±inner/
+  // ±outer thresholds, never where the two signs diverge.
+  const m = (run.kind === "chi") ? 0.1
+    : (Math.max(Math.abs(ov.robust_min ?? ov.global_min), Math.abs(ov.robust_max ?? ov.global_max)) || 1);
+  ov.cal_min = (run.kind === "chi") ? 0.02 : 0.05 * m;
+  ov.cal_max = m;
   errorCtl.setMagnitude(true);
   errorCtl.setup();
   nv.updateGLVolume();

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -68,7 +68,7 @@
           </div>
           <label class="inline-flex items-center gap-2 text-sm text-gray-600">Colour by
             <select x-model="metric" class="rounded-lg border-gray-300 text-sm py-1.5 pr-8">
-              <template x-for="c in cols.filter(c=>c!=='runtime_s')" :key="c"><option :value="c" :selected="c===metric" x-text="METRICS[c].label"></option></template>
+              <template x-for="c in cols" :key="c"><option :value="c" :selected="c===metric" x-text="METRICS[c].label"></option></template>
             </select>
           </label>
         </div>


### PR DESCRIPTION
Builds on the parameter-tuning work already merged (#77–79). Three commits:

**Rank runtime as a metric; pan histograms; full-pipeline timing** (`7f63c49`)

**web: zero-centered diverging error map + auto-zoomed histograms** (`30de9b8`)
- Error overlay uses a signed diverging colormap (red = over-estimate `recon>truth`, blue = under), windowed on `|error|` with an inner transparency floor and outer saturation mirrored to both signs — so zero is a fixed transparent centre: exact-zero and sub-threshold errors don't render, and moving the window never shifts the divergence point.
- Both histograms open zoomed so the active window spans ~half the bar.
- Fix the error histogram drawing blank / range bubbles mis-positioning on first open (reveal the section before drawing so its canvas has a non-zero size).

**scripts: apptainer runner for the scorer + parameter-sweep tooling** (`abc9829`)
- `pipeline.py --runner apptainer` (HPC scoring, no Docker daemon).
- `scripts/sweep.py` + `sweep_report.py`: the isolated-mode xSIM parameter sweep behind the `algorithm.yml` `tuned:` values, plus a baseline-vs-best report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)