### PR TITLE
ci: cap scorer concurrency to 2 on 16 GB runners (fix OOM-killed shards)

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -101,7 +101,9 @@ jobs:
       matrix:
         task: ${{ fromJson(needs.plan.outputs.tasks) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    # QSM_CI_JOBS=2 (below) halves intra-shard parallelism, so shards run longer — raise the ceiling
+    # so the heaviest shard finishes well within it rather than tripping the limit.
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
 
@@ -123,6 +125,12 @@ jobs:
         run: scripts/fetch_dataset.sh "$TRACK" data/${TRACK}/scoring
 
       - name: Score task ${{ matrix.task.id }}
+        env:
+          # GitHub-hosted ubuntu-latest is a 16 GB runner. pipeline.py defaults to 4 concurrent
+          # containers (tuned for the ~31 GB self-hosted box), which OOM-kills the scorer when a
+          # shard hits several MATLAB MCR / CPU-torch jobs at once. Cap to 2 (~8 GB) per shard; the
+          # 12-way shard matrix still gives ~24-way total parallelism.
+          QSM_CI_JOBS: "2"
         run: |
           DS="data/${TRACK}/scoring"
           ARGS="--dataset $DS --mode both --runner docker --track $TRACK --emit-volumes --runs-out runs-${{ matrix.task.id }}.json"

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -33,9 +33,10 @@ ROOT = Path(__file__).resolve().parent.parent
 EVAL = ROOT / "eval" / "qsm_eval.py"
 
 # Independent submission runs (each a Docker container + a scoring subprocess) are executed
-# concurrently, bounded by QSM_CI_JOBS. The cap is deliberately conservative: MATLAB MCR runs on
-# the 205^3 volume peak at a few GB each, so 4 keeps well under the runner's ~31 GB. Set 1 for
-# fully-serial behaviour. Threads are fine — the actual work is in subprocess.run (GIL released).
+# concurrently, bounded by QSM_CI_JOBS. MATLAB MCR peaks at a few GB each on the 205^3 volume, so
+# the default 4 suits a ~31 GB box; CI (score.yml) runs on 16 GB GitHub-hosted runners and sets
+# QSM_CI_JOBS=2 so a shard of heavy jobs doesn't OOM. Set 1 for fully-serial. Threads are fine —
+# the actual work is in subprocess.run (GIL released).
 JOBS = max(1, int(os.environ.get("QSM_CI_JOBS", "4")))
 
 


### PR DESCRIPTION
### Root cause
`score.yml` runs on 16 GB GitHub-hosted `ubuntu-latest` runners but never sets `QSM_CI_JOBS`, so `pipeline.py` uses its default of **4 concurrent containers** — a value tuned for the ~31 GB self-hosted runner. When a shard happens to run several memory-heavy jobs at once (MATLAB MCR at a few GB each, CPU-torch QSMGAN, …) it blows past 16 GB and the **OOM killer SIGKILLs the scorer**:

```
line 7: 2398 Killed   python scripts/pipeline.py $ARGS
##[error]The runner has received a shutdown signal...
##[error]The operation was canceled.
```

The shard fails and its `runs-sNN.json` never uploads, so the final merge silently drops those results. Because it triggers on the *combination* a shard is running (not elapsed time), it looked like random preemption — shards died at 04:20, 05:00, 05:02, independent of which had run longest.

### Fix
- `QSM_CI_JOBS=2` for the score task (~8 GB peak; 12 shards × 2 still ≈ 24-way parallelism).
- Bump the job timeout 180 → 300 min, since halving intra-shard parallelism lengthens each shard.
- Correct the now-stale ~31 GB rationale comment in `pipeline.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)