### PR TITLE
ci: bump GitHub Actions to current majors (silence Node 20 warnings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     # exercised on a qsm-forward phantom with the container-free `local` runner. Fast, secret-free.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -42,7 +42,7 @@ jobs:
   cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       slugs: ${{ steps.changed.outputs.slugs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with: { fetch-depth: 0 }
       - id: changed
         run: |
@@ -52,7 +52,7 @@ jobs:
       matrix:
         slug: ${{ fromJson(needs.discover.outputs.slugs) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install scorer deps
         # `.` installs the qsm-ci CLI onto PATH — pipeline.py --runner docker delegates each run to
@@ -63,7 +63,7 @@ jobs:
           pip install --no-build-isolation .                       # build the CLI with the upgraded tools
 
       - name: Cache OSF dataset zip
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .osfcache/bids.zip
           key: osf-bids-698ac9aecae88916d1e24f69

--- a/.github/workflows/hf-check.yml
+++ b/.github/workflows/hf-check.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/image-access.yml
+++ b/.github/workflows/image-access.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled   # `docker manifest` is stable on modern docker; belt-and-braces
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with: { fetch-depth: 0 }
 
       - name: Assert each changed submission's image is pullable

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Assemble site (web/ + results/ served alongside)
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
   end-to-end:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v5
         with:
@@ -49,7 +49,7 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Cache OSF dataset zip
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .osfcache/bids.zip
           key: osf-bids-698ac9aecae88916d1e24f69

--- a/.github/workflows/publish-zenodo.yml
+++ b/.github/workflows/publish-zenodo.yml
@@ -33,7 +33,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
       - uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       id-token: write   # required for Trusted Publishing (OIDC)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # setuptools-scm needs the full history + tags to derive the version
 

--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -58,7 +58,7 @@ jobs:
       full: ${{ steps.decide.outputs.full }}
       slugs: ${{ steps.decide.outputs.slugs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with: { fetch-depth: 0 }
       - id: decide
         run: |
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install qsm-ci CLI + scorer deps
         run: |
@@ -116,7 +116,7 @@ jobs:
           pip install --no-build-isolation .
 
       - name: Cache OSF dataset zip
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .osfcache/bids.zip
           key: osf-bids-698ac9aecae88916d1e24f69
@@ -137,7 +137,7 @@ jobs:
           python scripts/pipeline.py $ARGS
           echo "== task ${{ matrix.task.id }} wall-clock: $(( $(date +%s) - t0 ))s =="
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: shard-${{ matrix.task.id }}
           retention-days: 1
@@ -151,8 +151,8 @@ jobs:
     if: ${{ !cancelled() && needs.score.result != 'skipped' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: shard-*
           merge-multiple: true
@@ -203,7 +203,7 @@ jobs:
 
       - name: (dry-run) upload candidate index instead of committing
         if: ${{ github.event.inputs.dry_run == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: index-candidate
           path: results/index.json

--- a/.github/workflows/squash-volumes.yml
+++ b/.github/workflows/squash-volumes.yml
@@ -17,7 +17,7 @@ jobs:
   squash:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
The `@v4` actions are 3+ majors behind and are what emit the noise you saw on score runs:
- `##[warning]Node.js 20 is deprecated … forced to run on Node.js 24` — the v4 actions still declare Node 20.
- `##[warning]The process '/usr/bin/git' failed with exit code 128` — a **benign** `actions/checkout` warning: its internal `git checkout -B main origin/main` fails once and it recovers by checking out the SHA directly (the runs were green).

Neither was failing anything — both are warning-level on passing runs. This just clears the noise by moving to current majors:

| action | from | to |
|---|---|---|
| checkout | v4 | v7 |
| cache | v4 | v6 |
| upload-artifact | v4 | v7 |
| download-artifact | v4 | v8 |

The score merge job relies on `download-artifact` `pattern: shard-*` + `merge-multiple: true` — verified both inputs still exist on v8, so the shard→merge flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)