### PR TITLE
fix: scorer drops 0-indented tuned params (matlab-medi lambda=520)

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -87,7 +87,7 @@ def _tuned_overrides(text: str) -> dict:
     """Extract `{param: tuned_value}` from an algorithm.yml `parameters:` block — the settings we
     optimised on the scoring phantom (each parameter may carry a `tuned:` alongside its `default:`).
     Regex, not YAML, to keep this module dependency-free like the rest of the runner."""
-    m = re.search(r"^parameters:\s*\n(.*?)(?=^\S|\Z)", text, re.M | re.S)
+    m = re.search(r"^parameters:\s*\n(.*?)(?=^[A-Za-z]|\Z)", text, re.M | re.S)
     if not m:
         return {}
     out = {}


### PR DESCRIPTION
pipeline.py._tuned_overrides terminated the parameters block at the first non-space char, so matlab-medi's 0-indented list ended it immediately and its tuned lambda=520 was never scored. Terminate at the next top-level key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)