### PR TITLE
Add 8 QSM submissions: FANSI/NDI/L1-QSM/WH-QSM, HD-QSM, IR2QSM, INR-QSM, MoDIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,16 @@ algorithms/*/sti_support/
 # Dockerfile. Keeping the Dockerfile out of the checkout makes pipeline.build_env pull it.
 # (Dockerfile content is documented in each submission's BUILD.md.)
 algorithms/matlab-*/Dockerfile
+# New compiled-MATLAB submissions (clean names, not matlab-*) + IR2QSM (a baked pretrained checkpoint
+# CI cannot reproduce — the authors' single-file Drive link is quota-blocked). Same rule: CI PULLs
+# the pushed image, so keep their Dockerfiles out of the checkout.
+algorithms/fansi/Dockerfile
+algorithms/ndi/Dockerfile
+algorithms/l1-qsm/Dockerfile
+algorithms/wh-qsm/Dockerfile
+algorithms/hd-qsm/Dockerfile
+algorithms/ir2qsm/Dockerfile
 
 # Large network weights are build-time deps (fetched at build), never committed.
 algorithms/*/*.mat
+algorithms/*/*.pth

--- a/algorithms/fansi/BUILD.md
+++ b/algorithms/fansi/BUILD.md
@@ -1,0 +1,47 @@
+# Building fansi (compiled MATLAB → MATLAB Runtime)
+
+Compile `recon.m` on a machine with **MATLAB + MATLAB Compiler** (R2026a). The result runs
+license-free on the MATLAB Runtime. Same patterns as `matlab-tkd` (bundled NIfTI toolbox, OS
+gzip; see `../matlab-tkd/BUILD.md`), plus Carlos Milovic's **FANSI toolbox**.
+
+Stage: `dipole` — consumes `localfield` (ppm), `mask`, `params`; nonlinear TV/TGV ADMM inversion
+(`nlTV`/`nlTGV`) → `chimap` (ppm).
+
+> **Shared image.** `fansi`, `ndi`, `l1-qsm` and `wh-qsm` are all built from the one FANSI toolbox.
+> They share the image tag `ghcr.io/astewartau/qsm-ci/fansi:v1`. `mcc` bundles the traced FANSI
+> functions into each `recon` binary, so the toolbox is a *build-time* dependency only and does not
+> need to live in the runtime image. If you compile all four, build one image per submission (each
+> COPYs its own `recon`) or bake all four binaries into the single shared image under distinct
+> names and point each `algorithm.yml`'s `run.sh` at the right one.
+
+## 1. Fetch build-time deps (not committed)
+```bash
+cp -r /path/to/NIfTI_20140122               algorithms/fansi/nifti   # Jimmy Shen toolbox
+git clone https://gitlab.com/cmilovic/FANSI-toolbox algorithms/fansi/fansi   # FANSI toolbox
+```
+
+## 2. Compile
+```bash
+cd algorithms/fansi
+matlab -batch "addpath('nifti'); addpath(genpath('fansi')); mcc('-m','recon.m','-o','recon','-d','.')"   # -> ./recon
+```
+`mcc` traces only the FANSI functions `recon.m` actually calls (`nlTV`/`nlTGV`,
+`dipole_kernel_angulated` and their deps); the GUI/metric/script files in `fansi/` are ignored.
+
+## 3. Bake the MCR image and push
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/fansi:v1 .   # FROM matlab-runtime:r2026a + COPY recon
+docker push  ghcr.io/astewartau/qsm-ci/fansi:v1
+```
+Then make the GHCR package public. QSM-CI runs `/opt/qsm-ci/recon /input /output` on the free
+Runtime, offline.
+
+## Units
+`localfield` is ppm; FANSI's *nonlinear* solvers work in radians (they contain a `sin(phi-phase)`
+data term). `recon.m` converts `phase_rad = field * 2*pi*42.58*B0*TE` and divides the output by the
+same `phs_scale` to return ppm — exactly as the toolbox's `script_qsmchallenge.m` does. Any TE
+cancels because the method is (nonlinearly) scale-consistent between input and output; a real
+B0/TE is used only so the radian magnitude sits in the solver's well-conditioned range.
+
+> No MATLAB Compiler license? You can't compile — run raw `.m` on a run-time-licensed MATLAB base
+> instead (Option B in [`docs/matlab.md`](../../docs/matlab.md)). Compiling is strongly preferred.

--- a/algorithms/fansi/README.md
+++ b/algorithms/fansi/README.md
@@ -1,0 +1,43 @@
+# FANSI — Fast Nonlinear Susceptibility Inversion (MATLAB)
+
+**STATUS: scaffold — needs image build (MATLAB Compiler license required).** The source
+(`recon.m`, `run.sh`, `algorithm.yml`, `Dockerfile`) is complete; the compiled `recon` binary and
+the pushed image are the human's job (see `BUILD.md`).
+
+## What it does
+Nonlinear total-variation regularized dipole inversion from Carlos Milovic's **FANSI toolbox**
+(Milovic et al., *MRM* 2018, doi:10.1002/mrm.27073). Solves the QSM dipole-inversion problem with a
+nonlinear (complex-exponential) data-fidelity term and TV (or TGV) regularization via ADMM.
+
+- **Stage:** `dipole` — consumes `localfield` (ppm), `mask`, `params`; produces `chimap` (ppm).
+- **Solver:** `nlTV` by default; set `isTGV=1` to use `nlTGV` (total generalized variation).
+
+## Units handling
+FANSI's *nonlinear* solvers contain a `sin(phi - phase)` data term and therefore require the input
+field in **radians**, not ppm. `recon.m`:
+1. converts the ppm local field to radians: `phase_rad = field * 2*pi * 42.58 * B0 * TE`
+   (42.58 MHz/T absorbs the ppm 1e6 factor),
+2. runs `nlTV`/`nlTGV`,
+3. divides the output by the same `phs_scale` to return **ppm**.
+This exactly mirrors the toolbox's own `script_qsmchallenge.m`.
+
+## Parameters (defaults match FANSI recommendations)
+| name | default | meaning |
+|------|---------|---------|
+| `alpha1` | 3e-4 | gradient L1 (TV) penalty |
+| `mu1` | 3e-2 | gradient-consistency ADMM weight (= 100·alpha1) |
+| `iterations` | 150 | max ADMM outer iterations |
+| `tol_update` | 0.1 | convergence threshold (percent update) |
+| `isTGV` | 0 | 0 = TV (nlTV), 1 = TGV (nlTGV) |
+
+## Assumptions the human must verify
+- **Image is SHARED** with `ndi`, `l1-qsm`, `wh-qsm` (all FANSI): `ghcr.io/astewartau/qsm-ci/fansi:v1`.
+  See `BUILD.md` for how to lay out the shared/multi-binary image.
+- **`alpha1` default (3e-4)** is a literature-typical value from the FANSI challenge script, tuned
+  there for a ppm-normalized brain at ~3 T. The QSM-CI phantom differs; the *real* best value comes
+  from the parameter sweep (do not hard-code a `tuned:` here). Verify it converges on the phantom.
+- **Weighting:** the dipole stage provides no magnitude, so the data-fidelity weight is the binary
+  mask. FANSI normally uses magnitude; mask weighting is the reasonable stage-appropriate choice.
+- **GPU disabled** (`isGPU=false`) — the scoring MATLAB Runtime is CPU-only.
+- **License:** FANSI ships no LICENSE file; README grants "academic and research" use with a
+  BSD-style disclaimer. Recorded as `license: academic use; cite paper`.

--- a/algorithms/fansi/algorithm.yml
+++ b/algorithms/fansi/algorithm.yml
@@ -1,0 +1,42 @@
+name: FANSI (MATLAB)
+slug: fansi
+stage: dipole
+description: Fast Nonlinear Susceptibility Inversion (FANSI) — nonlinear total-variation
+  regularized dipole inversion solved with ADMM, from the FANSI toolbox. Compiled from
+  MATLAB and run on the license-free MATLAB Runtime. Consumes the local field and produces
+  a susceptibility map.
+authors:
+- name: Carlos Milovic
+- name: Berkin Bilgic
+- name: Bo Zhao
+- name: Julio Acosta-Cabronero
+- name: Cristian Tejos
+doi: 10.1002/mrm.27073
+citation: Milovic et al., Magn Reson Med 2018
+code_url: https://gitlab.com/cmilovic/FANSI-toolbox
+# FANSI-toolbox ships no LICENSE file; its README grants use "for academic and research
+# purposes" with a BSD-style warranty disclaimer.
+license: academic use; cite paper
+# Shared image: fansi, ndi, l1-qsm and wh-qsm are all built from the one FANSI toolbox, so
+# they share a single compiled image (each has its own recon.m entry; see BUILD.md).
+image: ghcr.io/astewartau/qsm-ci/fansi:v1
+run: bash run.sh
+matlab:
+  entry: recon.m
+  runtime: r2026a
+parameters:
+- name: alpha1
+  default: 0.0003
+  description: gradient L1 (total-variation) penalty; larger = smoother, more regularized
+- name: mu1
+  default: 0.03
+  description: gradient-consistency ADMM weight (FANSI recommends 100*alpha1)
+- name: iterations
+  default: 150
+  description: maximum number of ADMM outer iterations
+- name: tol_update
+  default: 0.1
+  description: convergence threshold on the normalized solution update (percent)
+- name: isTGV
+  default: 0
+  description: 0 = TV regularization (nlTV), 1 = TGV regularization (nlTGV)

--- a/algorithms/fansi/recon.m
+++ b/algorithms/fansi/recon.m
@@ -1,0 +1,85 @@
+function recon(inp, out)
+% QSM-CI `dipole` stage in MATLAB — FANSI nonlinear Total Variation dipole inversion.
+% Fast Nonlinear Susceptibility Inversion (Milovic et al., MRM 2018, doi:10.1002/mrm.27073).
+% Reads <inp>/localfield.nii.gz (ppm) + mask + params.json, writes <out>/chimap.nii.gz (ppm).
+%
+% Bundled: Jimmy Shen NIfTI toolbox (no Image Processing Toolbox) + FANSI toolbox (installed
+% at /opt/fansi in the image, added to path at build/compile time — see BUILD.md). OS gunzip/gzip
+% (compiled binaries have no JVM). Optional <inp>/config.json overrides {alpha1, mu1, iterations,
+% tol_update, isTGV}.
+%
+% UNITS — CRITICAL. FANSI's nonlinear solvers (nlTV/nlTGV) contain a nonlinear data term
+% sin(phi - phase); their input phase MUST be in RADIANS, not ppm. We convert the ppm local field
+% to radians with the standard scale  phs_scale = 2*pi * gamma * B0 * TE  (gamma = 42.58 MHz/T,
+% so gamma*1e6*1e-6 -> 42.58), run the solver, then divide the susceptibility output by the SAME
+% phs_scale to return to ppm (FANSI's output x is in the same scaled units as its input). This
+% mirrors script_qsmchallenge.m in the FANSI toolbox (phs_scale = TE*gyro*B0, chi = out.x/phs_scale).
+
+    p   = jsondecode(fileread(fullfile(inp, 'params.json')));
+    b0  = p.B0_dir(:)'; b0 = b0 / norm(b0);
+    vox = p.voxel_size(:)';
+    B0T = p.B0;                       % field strength (Tesla)
+    TE  = p.TE(:)';  TE = TE(1);      % first echo time (s); scale is linear so any TE cancels
+
+    % Defaults (FANSI recommended: alpha1 ~ 1e-4..3e-4 gradient L1 penalty; mu1 = 100*alpha1).
+    cfg = struct('alpha1', 3e-4, 'mu1', 3e-2, 'iterations', 150, ...
+                 'tol_update', 0.1, 'isTGV', 0);
+    cf_file = fullfile(inp, 'config.json');
+    if exist(cf_file, 'file')
+        u = jsondecode(fileread(cf_file));
+        for f = fieldnames(u)', cfg.(f{1}) = u.(f{1}); end
+    end
+
+    % --- inputs ---
+    nlf   = read_niigz(fullfile(inp, 'localfield.nii.gz'));
+    field = double(nlf.img);                                     % local field, ppm
+    mask  = double(getfield(read_niigz(fullfile(inp, 'mask.nii.gz')), 'img')) > 0.5;
+
+    N = size(field);
+
+    % ppm -> radians (see UNITS note above)
+    GYRO_MHz = 42.58;                       % gyromagnetic ratio, MHz/T (absorbs the ppm 1e6 factor)
+    phs_scale = 2*pi * GYRO_MHz * B0T * TE;
+    phase_rad = field * phs_scale;
+
+    % Dipole kernel (continuous, angulated for arbitrary B0 direction)
+    kernel = dipole_kernel_angulated(N, vox, b0);
+
+    params = [];
+    params.input        = single(phase_rad);
+    params.K            = single(kernel);
+    params.alpha1       = cfg.alpha1;
+    params.mu1          = cfg.mu1;
+    params.weight       = single(mask);          % no magnitude at dipole stage -> mask weighting
+    params.maxOuterIter = cfg.iterations;
+    params.tolUpdate    = cfg.tol_update;
+    params.isGPU        = false;                 % MATLAB Runtime CPU-only at scoring time
+
+    if cfg.isTGV
+        outs = nlTGV(params);
+    else
+        outs = nlTV(params);
+    end
+
+    chi = double(outs.x) / phs_scale;            % radians -> ppm
+    chi = chi .* mask;
+
+    nlf.img = single(chi);
+    nlf.hdr.dime.datatype = 16;  nlf.hdr.dime.bitpix = 32;
+    nlf.hdr.dime.dim(1) = 3;  nlf.hdr.dime.dim(5) = 1;
+    write_niigz(nlf, fullfile(out, 'chimap.nii.gz'));
+end
+
+function nii = read_niigz(f)
+    t = [tempname '.nii'];
+    system(sprintf('gunzip -c ''%s'' > ''%s''', f, t));
+    nii = load_untouch_nii(t);
+    delete(t);
+end
+
+function write_niigz(nii, f)
+    t = [tempname '.nii'];
+    save_untouch_nii(nii, t);
+    system(sprintf('gzip -c ''%s'' > ''%s''', t, f));
+    delete(t);
+end

--- a/algorithms/fansi/run.sh
+++ b/algorithms/fansi/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary is either baked into the image at /opt/qsm-ci/recon (recommended) or committed
+# alongside this script and mounted at /algo. No network needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/hd-qsm/BUILD.md
+++ b/algorithms/hd-qsm/BUILD.md
@@ -1,0 +1,45 @@
+# Building hd-qsm (compiled MATLAB → MATLAB Runtime)
+
+Compile `recon.m` on a machine with **MATLAB + MATLAB Compiler** (R2026a). Runs license-free on the
+MATLAB Runtime. Same patterns as `matlab-tkd` (bundled NIfTI toolbox, OS gzip), plus the **HD-QSM**
+code (`HDQSM.m`) **and** Carlos Milovic's **FANSI toolbox** — `HDQSM.m` calls FANSI's
+`gradient_calc` and uses a FANSI dipole-kernel function, so FANSI must be on the compile path too.
+
+Stage: `dipole` — consumes `localfield` (ppm), `mask`, `params`; two-stage L1→L2 linear inversion
+(`HDQSM`) → `chimap` (ppm).
+
+> **Own image** (NOT shared with the FANSI family): `ghcr.io/astewartau/qsm-ci/hd-qsm:v1`.
+
+## 1. Fetch build-time deps (not committed)
+```bash
+cp -r /path/to/NIfTI_20140122               algorithms/hd-qsm/nifti   # Jimmy Shen toolbox
+git clone https://github.com/mglambert/HD-QSM  algorithms/hd-qsm/hdqsm  # HD-QSM (HDQSM.m)
+git clone https://gitlab.com/cmilovic/FANSI-toolbox algorithms/hd-qsm/fansi   # FANSI (gradient_calc, kernel)
+```
+> NOTE: the repo is **`mglambert/HD-QSM`** (with a hyphen) — `mglambert/HDQSM` returns 404.
+
+## 2. Compile
+```bash
+cd algorithms/hd-qsm
+matlab -batch "addpath('nifti'); addpath('hdqsm'); addpath(genpath('fansi')); mcc('-m','recon.m','-o','recon','-d','.')"   # -> ./recon
+```
+`mcc` traces `HDQSM`, `gradient_calc`, `dipole_kernel_angulated` and their deps.
+
+## 3. Bake the MCR image and push
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/hd-qsm:v1 .   # FROM matlab-runtime:r2026a + COPY recon
+docker push  ghcr.io/astewartau/qsm-ci/hd-qsm:v1
+```
+Then make the GHCR package public.
+
+## Units
+`localfield` is ppm; HD-QSM is a **linear** inversion (`real(ifftn(kernel.*Fx))`, no `sin`/`exp`),
+so it is scale-linear — output susceptibility is in the same units as the input field. `recon.m`
+feeds the ppm local field directly and writes a ppm `chimap`; **no radian conversion** is needed
+(unlike the FANSI nonlinear methods). `alphaL2` is calibrated to this ppm (B0-normalized) scale,
+matching the `HDQSM.m` example (`params.input = phase_use/phase_scale`).
+
+## License
+HD-QSM ships an **MIT** LICENSE (github.com/mglambert/HD-QSM); recorded in `algorithm.yml`.
+
+> No MATLAB Compiler license? See Option B in [`docs/matlab.md`](../../docs/matlab.md).

--- a/algorithms/hd-qsm/README.md
+++ b/algorithms/hd-qsm/README.md
@@ -1,0 +1,47 @@
+# HD-QSM — Hybrid Data-fidelity QSM (MATLAB)
+
+**STATUS: scaffold — needs image build (MATLAB Compiler license required).** Source is complete;
+the compiled `recon` binary and pushed image are the human's job (see `BUILD.md`).
+
+## What it does
+Hybrid Data-fidelity QSM (Lambert et al., *MRM* 2022, doi:10.1002/mrm.29218). A **two-stage linear**
+dipole inversion: an L1 data-fidelity stage produces a discrepancy map that re-weights a second L2
+stage, combining L1 robustness to phase inconsistencies with L2 smoothness. Code: `HDQSM.m` from
+`github.com/mglambert/HD-QSM`, which builds on the FANSI toolbox.
+
+- **Stage:** `dipole` — consumes `localfield` (ppm), `mask`, `params`; produces `chimap` (ppm).
+
+## Units handling
+HD-QSM is a **linear** inversion (`real(ifftn(kernel.*Fx))`, no `sin`/`exp`), hence scale-linear:
+output susceptibility is in the same units as the input field. `recon.m` feeds the **ppm** local
+field directly and writes a **ppm** chimap — **no radian conversion** (this is the key difference
+from the FANSI *nonlinear* methods fansi/ndi/l1-qsm/wh-qsm). `alphaL2` is calibrated to the ppm
+(B0-normalized) field scale, matching the toolbox example.
+
+## Parameters (defaults from the HDQSM.m example)
+| name | default | meaning |
+|------|---------|---------|
+| `alphaL2` | 1.64e-5 (10^-4.785) | L2-stage TV regularization weight |
+| `mu1L2` | 1.64e-4 | L2-stage gradient-consistency ADMM weight (= 10·alphaL2) |
+| `iterationsL1` | 20 | L1 (discrepancy-estimation) stage iterations |
+| `iterationsL2` | 80 | L2 (final) stage iterations |
+| `tol_update` | 1.0 | L2-stage convergence threshold (percent update) |
+
+(L1-stage `alphaL1`/`mu1L1` default *inside* HDQSM.m to `sqrt(alphaL2)` / `sqrt(mu1L2)`.)
+
+## Assumptions the human must verify
+- **Repo name is `mglambert/HD-QSM`** (hyphen). The task/memo referenced `mglambert/HDQSM`, which
+  returns 404 — corrected here and in `BUILD.md`.
+- **License is MIT** — HD-QSM ships an MIT LICENSE file (contrary to the task's assumption that the
+  repo had none). Recorded as `license: MIT`.
+- **Own image** `ghcr.io/astewartau/qsm-ci/hd-qsm:v1` (NOT shared with the FANSI family), though it
+  still needs FANSI at *compile* time (`gradient_calc`, dipole kernel).
+- **`alphaL2` default (10^-4.785)** is the value hard-coded in the HDQSM.m example, calibrated to a
+  ppm-normalized brain. The QSM-CI phantom differs; the real best value comes from the parameter
+  sweep (no `tuned:` hard-coded here). Verify it converges/behaves on the phantom.
+- **Kernel choice.** `recon.m` uses FANSI's continuous angulated kernel `dipole_kernel_angulated`.
+  The HDQSM example passes a `kernel` the caller builds; the toolbox does not fix which. Confirm the
+  continuous kernel matches the paper's intent (the discrete kernel `dipole_kernel_fansi(...,1)` is
+  an alternative).
+- **Weighting:** binary mask (no magnitude at the dipole stage).
+- **DOI 10.1002/mrm.29218** confirmed via Crossref.

--- a/algorithms/hd-qsm/algorithm.yml
+++ b/algorithms/hd-qsm/algorithm.yml
@@ -1,0 +1,36 @@
+name: HD-QSM (MATLAB)
+slug: hd-qsm
+stage: dipole
+description: Hybrid Data-fidelity QSM (HD-QSM) — a two-stage linear dipole inversion.
+  An L1 data-fidelity stage estimates a discrepancy map that re-weights a second L2 stage,
+  combining robustness to inconsistencies with L2 smoothness. Compiled from MATLAB and run
+  on the license-free MATLAB Runtime. Consumes the local field, produces a susceptibility map.
+authors:
+- name: Mathias Lambert
+- name: Carlos Milovic
+- name: Cristian Tejos
+doi: 10.1002/mrm.29218
+citation: Lambert et al., Magn Reson Med 2022
+code_url: https://github.com/mglambert/HD-QSM
+license: MIT
+image: ghcr.io/astewartau/qsm-ci/hd-qsm:v1
+run: bash run.sh
+matlab:
+  entry: recon.m
+  runtime: r2026a
+parameters:
+- name: alphaL2
+  default: 1.6406e-05
+  description: L2-stage TV regularization weight (10^-4.785; from the HDQSM example)
+- name: mu1L2
+  default: 1.6406e-04
+  description: L2-stage gradient-consistency ADMM weight (recommended 10*alphaL2)
+- name: iterationsL1
+  default: 20
+  description: iterations of the L1 (first / discrepancy-estimation) stage
+- name: iterationsL2
+  default: 80
+  description: iterations of the L2 (second / final) stage
+- name: tol_update
+  default: 1.0
+  description: convergence threshold on the L2-stage normalized solution update (percent)

--- a/algorithms/hd-qsm/recon.m
+++ b/algorithms/hd-qsm/recon.m
@@ -1,0 +1,76 @@
+function recon(inp, out)
+% QSM-CI `dipole` stage in MATLAB — Hybrid Data-fidelity QSM (HD-QSM).
+% Lambert et al., MRM 2022 (doi:10.1002/mrm.29218). Two-stage inversion: an L1 data-fidelity stage
+% estimates a discrepancy map, then an L2 stage re-weighted by it. Repo: github.com/mglambert/HD-QSM.
+% Reads <inp>/localfield.nii.gz (ppm) + mask + params.json, writes <out>/chimap.nii.gz (ppm).
+%
+% Bundled: Jimmy Shen NIfTI toolbox + HD-QSM (HDQSM.m) + FANSI toolbox (HDQSM depends on FANSI's
+% `gradient_calc` and a dipole-kernel function). Installed at /opt/hdqsm and /opt/fansi; added to
+% path at compile time — see BUILD.md. OS gunzip/gzip (compiled binaries have no JVM).
+% Optional <inp>/config.json overrides {alphaL2, mu1L2, tol_update, iterationsL1, iterationsL2}.
+%
+% UNITS. HD-QSM is a LINEAR inversion (real(ifftn(kernel.*Fx)); no sin/exp), so it is scale-linear:
+% output susceptibility is in the same units as the input field. We therefore feed the ppm local
+% field DIRECTLY and get a ppm chimap out — no radian conversion needed (unlike the FANSI nonlinear
+% methods). The regularization weight `alphaL2` is calibrated to this ppm (B0-normalized) field
+% scale, matching the toolbox's own example (params.input = phase_use/phase_scale, which yields the
+% ppm-normalized field).
+
+    p   = jsondecode(fileread(fullfile(inp, 'params.json')));
+    b0  = p.B0_dir(:)'; b0 = b0 / norm(b0);
+    vox = p.voxel_size(:)';
+
+    % Defaults from the HDQSM.m example (alphaL2 = 10^-4.785; mu1L2 = 10*alphaL2). L1-stage params
+    % (alphaL1, mu1L1) default inside HDQSM to sqrt(alphaL2), sqrt(mu1L2). Iterations: L1=20, L2=80.
+    cfg = struct('alphaL2', 10^(-4.785), 'mu1L2', 10*10^(-4.785), ...
+                 'tol_update', 1.0, 'iterationsL1', 20, 'iterationsL2', 80);
+    cf_file = fullfile(inp, 'config.json');
+    if exist(cf_file, 'file')
+        u = jsondecode(fileread(cf_file));
+        for f = fieldnames(u)', cfg.(f{1}) = u.(f{1}); end
+    end
+
+    % --- inputs ---
+    nlf   = read_niigz(fullfile(inp, 'localfield.nii.gz'));
+    field = double(nlf.img);                                     % local field, ppm
+    mask  = double(getfield(read_niigz(fullfile(inp, 'mask.nii.gz')), 'img')) > 0.5;
+
+    N = size(field);
+
+    % Dipole kernel (continuous, angulated for arbitrary B0 direction; from FANSI)
+    kernel = dipole_kernel_angulated(N, vox, b0);
+
+    params = [];
+    params.input          = single(mask .* field);   % ppm local field (linear method -> ppm out)
+    params.kernel         = single(kernel);
+    params.mask           = single(mask);
+    params.weight         = single(mask);             % no magnitude at dipole stage -> mask weighting
+    params.alphaL2        = cfg.alphaL2;
+    params.mu1L2          = cfg.mu1L2;
+    params.tol_update     = cfg.tol_update;
+    params.maxOuterIterL1 = cfg.iterationsL1;
+    params.maxOuterIterL2 = cfg.iterationsL2;
+
+    outs = HDQSM(params);
+
+    chi = double(outs.x) .* mask;                     % already ppm (linear method)
+
+    nlf.img = single(chi);
+    nlf.hdr.dime.datatype = 16;  nlf.hdr.dime.bitpix = 32;
+    nlf.hdr.dime.dim(1) = 3;  nlf.hdr.dime.dim(5) = 1;
+    write_niigz(nlf, fullfile(out, 'chimap.nii.gz'));
+end
+
+function nii = read_niigz(f)
+    t = [tempname '.nii'];
+    system(sprintf('gunzip -c ''%s'' > ''%s''', f, t));
+    nii = load_untouch_nii(t);
+    delete(t);
+end
+
+function write_niigz(nii, f)
+    t = [tempname '.nii'];
+    save_untouch_nii(nii, t);
+    system(sprintf('gzip -c ''%s'' > ''%s''', t, f));
+    delete(t);
+end

--- a/algorithms/hd-qsm/run.sh
+++ b/algorithms/hd-qsm/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary is either baked into the image at /opt/qsm-ci/recon (recommended) or committed
+# alongside this script and mounted at /algo. No network needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/inr-qsm/BUILD.md
+++ b/algorithms/inr-qsm/BUILD.md
@@ -1,0 +1,64 @@
+# BUILD — INR-QSM (`inr-qsm`)
+
+This submission is a **scaffold**. The container image is **not** built or pushed, and the pipeline
+has **not** been run. This file lists exactly what a human must do to finish.
+
+## 1. Build & push the environment image
+
+The run phase has **no network**, so the method source must be baked in at build time. The Dockerfile
+`git clone`s `github.com/AMRI-Lab/INR-QSM` into `/opt/INR-QSM` (the python package is in the repo's
+`inr-qsm/` subdir → `INR_QSM_HOME=/opt/INR-QSM/inr-qsm`) and installs a **CPU** PyTorch wheel.
+
+There are **no recon weights to download** — INR-QSM optimizes per subject. The repo does ship an
+**optional** transfer-learning init (`inr-qsm/transfer_learning/…​.pkl`, ~8 MB, used only to speed up
+convergence); it comes along with the clone.
+
+```bash
+# from the repo root
+docker build -t ghcr.io/astewartau/qsm-ci/inr-qsm:v1 algorithms/inr-qsm
+docker push  ghcr.io/astewartau/qsm-ci/inr-qsm:v1
+```
+
+- For reproducibility, pin the method commit: `--build-arg INR_QSM_REF=<sha>`.
+- QSM-CI also builds this folder's Dockerfile at score-time, so a manual push is not strictly
+  required — but build it once locally to confirm it succeeds.
+
+### GPU variant (optional — see RUNTIME/GPU CAVEAT)
+
+Change the torch install from the CPU index (`.../whl/cpu`) to CUDA (e.g. `.../whl/cu121`), remove
+`ENV CUDA_VISIBLE_DEVICES="-1"` (Dockerfile) and the `export CUDA_VISIBLE_DEVICES=-1` (`run.sh`). Note
+the wrapper runs **float32** (CUDA AMP/fp16 from the reference was dropped for CPU compatibility), so
+a GPU run is heavier than the paper's fp16 pipeline.
+
+## 2. Smoke-test locally (with ground truth)
+
+```bash
+qsm-forward simple bids/          # phantom WITH ground truth
+qsm-ci run inr-qsm \
+  --localfield lf.nii.gz --mask mask.nii.gz --params params.json \
+  --truth chi.nii.gz
+```
+
+Confirm: it produces `chimap.nii.gz`, the scale looks like ppm QSM (~±0.1–0.2 in tissue), and the
+sign/orientation are correct. To iterate fast during testing, cap epochs: `--set epoch=5`.
+
+## 3. Decisions the human must make ⚠️
+
+- **CPU vs. GPU / iteration cap.** Per-subject optimization (default **50 epochs**, wide/deep SIREN,
+  full-volume 3D FFTs) is expensive; the reference used an NVIDIA A6000 (~10 GB VRAM). Time a CPU run
+  first; if it exceeds the CI time limit (2 h → DNF), use a GPU runner or lower
+  `epoch`/`num_layers`/`hidden_dim_num`.
+- **Fidelity deviations** (see README): this wrapper runs a **full-volume** objective rather than the
+  paper's **patch-based non-local phase-compensation** loop, and computes the **WG edge weights in
+  Python** (TKD-seeded) instead of via **STISuite** (proprietary MATLAB, not shipped). Decide whether
+  these approximations are acceptable, or port the patch pipeline for a GPU variant.
+
+## 4. Files in this folder
+
+| File | Role |
+|------|------|
+| `algorithm.yml` | Manifest: stage `dipole`, image, `run: bash run.sh`, parameters (`epoch`, `star_lr`, `end_lr`, `hidden_dim_num`, `num_layers`, `TV_weight`, `gd_weight`). |
+| `Dockerfile` | CPU PyTorch base + `git clone` INR-QSM to `/opt/INR-QSM` (no recon weights). Code is mounted, not COPYed. |
+| `run.sh` | Forces CPU, calls `inr_qsm_infer.py /input /output`. |
+| `inr_qsm_infer.py` | Reuses the repo's SIREN + dipole kernel + TV/GD losses; runs per-subject optimization; writes `chimap.nii.gz` on the input affine. |
+| `README.md` | Method description, units, kernel, deviations, RUNTIME/GPU CAVEAT, assumptions. |

--- a/algorithms/inr-qsm/Dockerfile
+++ b/algorithms/inr-qsm/Dockerfile
@@ -1,0 +1,53 @@
+# INR-QSM environment image — CPU-capable PyTorch, per-subject implicit-neural-representation QSM.
+#
+# INR-QSM (github.com/AMRI-Lab/INR-QSM) is UNSUPERVISED and subject-specific: there are NO pretrained
+# weights for the reconstruction network. A sine-activated coordinate MLP (SIREN) is OPTIMIZED
+# directly on the input local field at inference time, driven by the QSM dipole forward model plus
+# edge-weighted TV / gradient-domain regularizers.
+#
+#   * The repo ships an OPTIONAL transfer-learning init (inr-qsm/transfer_learning/
+#     pre_trained_weight_for_transfer_learning.pkl) used only to SPEED UP convergence — it is not a
+#     trained recon model. We clone it with the repo so it is available offline, but the wrapper does
+#     not require it (INR_QSM_TL_WEIGHTS controls whether it is loaded).
+#   * The repo's MATLAB data-prep (STISuite FastQSM + TVweighting.m) produces the edge-weight matrix
+#     WG. STISuite is proprietary MATLAB; we do NOT ship it. The wrapper reimplements the TV edge
+#     weighting in Python from an in-house initial estimate (see inr_qsm_infer.py). See README.
+#
+# We clone the repo at BUILD time (network ON) into /opt/INR-QSM so the run phase works fully offline
+# (--network none). We do NOT COPY the submission code — run.sh + inr_qsm_infer.py are mounted at
+# /algo at run time (QSM-CI execution model).
+#
+# CPU by default: CPU PyTorch wheel + CUDA forced off at run time. The reference is GPU-oriented
+# (~10 GB VRAM, NVIDIA A6000) and per-subject optimization is expensive; see README "RUNTIME/GPU
+# CAVEAT". A GPU build would swap the torch index-url below.
+#
+# Build & push once (see algorithms/inr-qsm/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/inr-qsm:v1 algorithms/inr-qsm
+#   docker push ghcr.io/astewartau/qsm-ci/inr-qsm:v1
+FROM python:3.10-slim
+
+LABEL description="INR-QSM — CPU-capable per-subject implicit-neural-representation QSM for QSM-CI"
+
+# git to clone the repo; libgomp1 for the PyTorch CPU (OpenMP) runtime; ca-certificates for TLS.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates git libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# CPU PyTorch wheel + NIfTI/array/matlab-io deps. Pin torch to the CPU index (no CUDA runtime).
+RUN pip install --no-cache-dir \
+        "torch>=2.1.0" --index-url https://download.pytorch.org/whl/cpu \
+ && pip install --no-cache-dir \
+        "numpy>=1.23" \
+        "scipy>=1.10" \
+        "nibabel>=5.0"
+
+# Clone INR-QSM (model.py / utils.py are reused by the wrapper; transfer-learning init comes along).
+# Pin a ref for reproducibility (override with --build-arg INR_QSM_REF=<sha>).
+ARG INR_QSM_REF=main
+RUN git clone https://github.com/AMRI-Lab/INR-QSM /opt/INR-QSM \
+ && git -C /opt/INR-QSM checkout "$INR_QSM_REF"
+# The python package lives in the repo's inr-qsm/ subdir (model.py, utils.py, config.py, main.py).
+ENV INR_QSM_HOME="/opt/INR-QSM/inr-qsm"
+
+# Force CPU at run time (override / drop for a GPU variant).
+ENV CUDA_VISIBLE_DEVICES="-1"

--- a/algorithms/inr-qsm/README.md
+++ b/algorithms/inr-qsm/README.md
@@ -1,0 +1,127 @@
+# INR-QSM
+
+Subject-specific **unsupervised** deep-learning **dipole inversion** using an **implicit neural
+representation** (a coordinate MLP optimized per subject — no pretrained recon weights).
+
+> **STATUS: scaffold — needs image build + push (human).** The container image
+> `ghcr.io/astewartau/qsm-ci/inr-qsm:v1` has not been built or pushed yet, and this scaffold has not
+> been run end-to-end. See `BUILD.md` and the checklist below.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [INR-QSM](https://github.com/AMRI-Lab/INR-QSM) — PyTorch SIREN coordinate MLP,
+  per-subject optimization. **CPU by default** here (reference is GPU-oriented — see RUNTIME/GPU
+  CAVEAT).
+- **Reference:** Zhang M., Feng R., Li Z., Feng J., Wu Q., Zhang Z., Ma C., Wu J., Yan F., Liu C.,
+  Zhang Y., Wei H. *A subject-specific unsupervised deep learning method for quantitative
+  susceptibility mapping using implicit neural representation.* Medical Image Analysis 95:103173,
+  2024. DOI: [10.1016/j.media.2024.103173](https://doi.org/10.1016/j.media.2024.103173)
+
+## What it does
+
+INR-QSM represents the susceptibility map as a **continuous function of spatial coordinates**,
+χ(x) = MLP(x), parameterized by a **SIREN** (sine-activated MLP). It loads **no trained recon
+weights**; for each input volume it **optimizes** the MLP so that χ, convolved with the QSM dipole
+kernel, reproduces the input local field, regularized by an **edge-weighted TV** term and a
+**gradient-domain** data-consistency term. This makes it subject-specific and free of the
+generalization concerns of pretrained networks — at the cost of per-volume runtime. An **optional**
+transfer-learning weight init (shipped in the repo) is used only to **accelerate** convergence; it is
+not a trained reconstruction model.
+
+## Why `dipole`
+
+INR-QSM maps a **local (tissue) field** to **susceptibility** through the dipole kernel — purely a
+dipole inversion (no field-mapping / background-field removal). So it consumes `localfield` and
+produces `chimap`: the `dipole` stage. (The repo's `main.py` loads `phi` = tissue field and the
+`data_prep` demo says "the tissue phase ... should be normalized with a unit of ppm".)
+
+## Units & kernel
+
+- **Input/output units.** QSM-CI `localfield` is the local/tissue field already in **ppm**, exactly
+  the repo's `phi`. Fed unchanged. Output susceptibility is **ppm**, written on the input affine.
+- **Dipole kernel.** Built by the repo's `utils.calc_d2_matrix1` from the **B0 direction** and
+  **voxel size**: the k-space kernel `D = 1/3 − (k·B̂0)²/|k|²` (DC set to 0). B0 direction from
+  `params.json` / `QSMCI_B0_DIR`; voxel size from the NIfTI header (fallback `params.json` /
+  `QSMCI_VOXEL_SIZE`). The centered orthonormal FFTs are the repo's `myfftnc`/`myifftnc`.
+
+## Implementation notes & deliberate deviations from the reference
+
+This wrapper **reuses the reference network and operators verbatim** (`model.siren_model`,
+`utils.calc_d2_matrix1`, `utils.build_coordinate_train`, `utils.myfftnc/myifftnc`, `utils.TVLoss`,
+`utils.GradientLoss`). It **deviates** from the reference `main.py` in three documented ways so it
+runs robustly on CPU inside CI:
+
+1. **Full-volume optimization, not the patch-based non-local phase-compensation loop.** The reference
+   tiles the volume into 96×96×48 patches and runs an iterative "phase compensation" to model the
+   non-local field from neighboring patches. Here χ is a **single MLP over the whole volume**, so the
+   forward model `F⁻¹(D·F·χ)` is exact and non-local by construction — no patch stitching /
+   compensation. This optimizes the **same** data-consistency objective but is **not byte-identical**
+   to the paper's patch pipeline and may differ near boundaries. (This is the biggest fidelity
+   caveat; a future version could port the patch/compensation loop for a GPU runner.)
+2. **No CUDA AMP / float16.** The reference uses `torch.cuda.amp` autocast + `GradScaler` + fp16
+   (CUDA-only). We run **float32** on CPU (same math, CPU-safe).
+3. **WG (edge-weight matrix) computed in Python.** The reference builds WG from a **MATLAB STISuite**
+   FastQSM/STAR-QSM initial recon (`data_prep/TVweighting.m`). STISuite is proprietary MATLAB and is
+   **not shipped**. We reimplement `TVweighting.m` in Python (`_tv_weighting`) on an **in-house TKD**
+   initial χ estimate. This **approximates**, and does not reproduce, the STISuite-based WG.
+
+## How QSM-CI runs it
+
+```bash
+bash run.sh                       # -> python inr_qsm_infer.py /input /output
+```
+
+## Parameters (`algorithm.yml`)
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `epoch` | 50 | Per-subject optimization epochs. Main runtime/quality knob. |
+| `star_lr` | 1e-5 | Starting Adam learning rate. |
+| `end_lr` | 2e-7 (0.02e-5) | Final LR (exponential schedule). |
+| `hidden_dim_num` | 512 | SIREN width. |
+| `num_layers` | 10 | SIREN depth. |
+| `TV_weight` | 0.15 | Edge-weighted TV regularizer weight. |
+| `gd_weight` | 1.0 | Gradient-domain data-consistency weight. |
+
+All are legitimate reference **defaults** (from `config.py`), not tuned values. Overrides arrive via
+`/input/config.json` or `QSMCI_SET_*`. Note the shipped transfer-learning init only matches the
+**default** width/depth; changing `hidden_dim_num`/`num_layers` skips it (random init) — controlled by
+`INR_QSM_USE_TL`.
+
+## RUNTIME / GPU CAVEAT  ⚠️
+
+Like all untrained per-subject methods, INR-QSM **trains a network on every input volume**. The
+reference was tested on an **NVIDIA A6000 (~10 GB VRAM)** and uses CUDA AMP. Consequences for QSM-CI:
+
+- **On CPU (the default here), optimization may be slow and can exceed the CI time limit (default 2 h
+  → DNF).** This has **not** been timed on the CI phantom yet.
+- Full-volume 3D FFTs each epoch plus a wide/deep SIREN are memory- and compute-heavy on CPU.
+- Mitigations the human should consider: **(a)** provide a **GPU runner** (drop
+  `CUDA_VISIBLE_DEVICES=-1`, build a CUDA torch wheel — and note AMP/fp16 was dropped here, so a GPU
+  run is float32 and heavier than the paper's); or **(b)** cap cost by lowering `epoch`, `num_layers`
+  and/or `hidden_dim_num`.
+
+## Assumptions to verify
+
+1. **localfield is in ppm** (per `CONTRACT.md` and the repo's `phi`) — no unit rescale.
+2. **WG approximation.** The Python TKD-seeded WG is a stand-in for STISuite FastQSM+TVweighting.
+   Verify it behaves sensibly (edges down-weighted); consider tuning the `(0.5, 0.7)` percentile
+   range and TKD threshold if results look over/under-smoothed.
+3. **Full-volume vs. patch pipeline.** The non-local phase-compensation patch loop is not replicated;
+   confirm this is acceptable, or plan to port it for a GPU runner.
+4. **B0 direction / voxel size** from `params.json` / header — verify against the challenge geometry.
+5. **Coordinate/affine convention.** The repo's `build_coordinate_train` uses a `[-1,1]` normalized,
+   voxel-anisotropy-scaled grid; we write on the input NIfTI affine (orientation preserved). Confirm
+   no axis flip is needed relative to the reference's identity-diagonal affine.
+6. **Referencing.** Output is masked; QSM is defined up to a constant — confirm the scorer's
+   detrend/reference handling is satisfied (no explicit demeaning is applied here).
+7. **CPU feasibility / timeout** — untested; see RUNTIME/GPU CAVEAT.
+
+## Human checklist to finish
+
+- [ ] Build & push the image (see `BUILD.md`; pin `INR_QSM_REF` to a commit SHA).
+- [ ] Run once locally on a `qsm-forward` phantom to confirm plumbing + units + scale + sign.
+- [ ] **Time a CPU run** and decide: GPU runner vs. lower `epoch`/`num_layers`/`hidden_dim_num`.
+- [ ] Decide whether the WG approximation and full-volume (non-patch) objective are acceptable, or
+      port the patch/phase-compensation pipeline for a GPU variant.
+
+_Citations/DOIs are best-effort and should be verified._

--- a/algorithms/inr-qsm/algorithm.yml
+++ b/algorithms/inr-qsm/algorithm.yml
@@ -1,0 +1,55 @@
+name: INR-QSM
+slug: inr-qsm
+stage: dipole
+description: >
+  INR-QSM — a subject-specific UNSUPERVISED deep-learning dipole inversion using an implicit neural
+  representation. No pretrained weights: a sine-activated coordinate MLP (SIREN) is OPTIMIZED
+  per-subject so that the susceptibility it represents, pushed through the QSM dipole forward model,
+  reproduces the input local field, with edge-weighted TV and gradient-domain regularizers. Consumes
+  the local (tissue) field in ppm and produces susceptibility (ppm). The dipole kernel is built from
+  the B0 direction and voxel size. Runs CPU-only by default (the reference is GPU-oriented, ~10 GB
+  VRAM; see RUNTIME/GPU CAVEAT in README). Because it optimizes per input volume with a patch-based
+  non-local phase-compensation scheme, runtime is long.
+authors:
+- name: Zhang M.
+- name: Feng R.
+- name: Li Z.
+- name: Feng J.
+- name: Wu Q.
+- name: Zhang Z.
+- name: Ma C.
+- name: Wu J.
+- name: Yan F.
+- name: Liu C.
+- name: Zhang Y.
+- name: Wei H.
+doi: 10.1016/j.media.2024.103173
+code_url: https://github.com/AMRI-Lab/INR-QSM
+# The INR-QSM repo ships NO LICENSE file. Treat as academic use; cite the paper.
+license: none declared (no LICENSE in repo); academic use, cite the paper
+image: ghcr.io/astewartau/qsm-ci/inr-qsm:v1
+run: bash run.sh
+parameters:
+- name: epoch
+  default: 50
+  description: >
+    Number of per-subject optimization epochs (reference config.py default 50). Main runtime/quality
+    knob; fewer epochs run faster but under-fit.
+- name: star_lr
+  default: 1.0e-5
+  description: Starting Adam learning rate at the first epoch (reference default 1e-5).
+- name: end_lr
+  default: 2.0e-7
+  description: Final learning rate at the last epoch, reached by an exponential schedule (reference default 0.02e-5).
+- name: hidden_dim_num
+  default: 512
+  description: Width (neurons per layer) of the SIREN coordinate MLP (reference default 512).
+- name: num_layers
+  default: 10
+  description: Number of layers in the SIREN MLP (reference default 10).
+- name: TV_weight
+  default: 0.15
+  description: Weight of the edge-weighted total-variation regularizer (reference default 0.15).
+- name: gd_weight
+  default: 1.0
+  description: Weight of the gradient-domain data-consistency regularizer (reference default 1.0).

--- a/algorithms/inr-qsm/inr_qsm_infer.py
+++ b/algorithms/inr-qsm/inr_qsm_infer.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""QSM-CI wrapper for INR-QSM dipole inversion (stage = dipole), CPU by default.
+
+Consumes  /input/localfield.nii.gz, /input/mask.nii.gz, /input/params.json
+Produces  /output/chimap.nii.gz  (susceptibility, ppm)
+
+INR-QSM (Zhang, Feng et al., Medical Image Analysis 2024; github.com/AMRI-Lab/INR-QSM) is an
+UNSUPERVISED, subject-specific deep-learning method. It loads NO pretrained reconstruction weights:
+a sine-activated coordinate MLP (SIREN) is OPTIMIZED per-subject so that the susceptibility it
+represents χ(x) = MLP(coord), pushed through the QSM dipole forward model, reproduces the input local
+field, regularized by an edge-weighted TV term and a gradient-domain data-consistency term.
+
+This wrapper REUSES the reference network + operators verbatim from the cloned repo
+($INR_QSM_HOME = /opt/INR-QSM/inr-qsm):
+  * model.siren_model            — the SIREN coordinate MLP (width/depth/w0 from params)
+  * utils.calc_d2_matrix1        — the k-space dipole kernel D = 1/3 − (k·B̂0)²/|k|²
+  * utils.build_coordinate_train — normalized [-1,1] coordinate grid (voxel-anisotropy aware)
+  * utils.myfftnc / utils.myifftnc — the repo's orthonormal centered FFTs
+  * utils.TVLoss, utils.GradientLoss — the repo's edge-weighted regularizers
+
+DELIBERATE DEVIATIONS from the reference main.py (documented in README, so behavior is explicit):
+  1. FULL-VOLUME optimization, not the patch-based non-local phase-compensation loop. The reference
+     tiles the volume into 96×96×48 patches and runs an iterative "phase compensation" that models
+     the non-local field contribution of neighboring patches. That machinery is GPU/memory-heavy and
+     fragile. Here χ is a single MLP over the whole volume, so the forward model F⁻¹(D·F·χ) is exact
+     and non-local by construction — no patch stitching / compensation is needed. This is a faithful
+     simplification of the SAME data-consistency objective, but is NOT byte-identical to the paper's
+     patch pipeline and may differ near boundaries.
+  2. NO CUDA AMP / float16. The reference uses torch.cuda.amp autocast + GradScaler + fp16 tensors,
+     which are CUDA-only; we run float32 on CPU (or GPU if enabled). Same math, CPU-safe.
+  3. WG (edge-weight matrix) is computed IN PYTHON. The reference generates WG from a MATLAB
+     STISuite FastQSM/STAR-QSM initial recon (data_prep/TVweighting.m). STISuite is proprietary
+     MATLAB and not shipped. We reimplement TVweighting.m in Python on an in-house TKD initial χ
+     estimate (see _tv_weighting). Approximates, does not reproduce, the STISuite-based WG.
+
+Units. QSM-CI's localfield.nii.gz is the tissue/local field already in ppm (the repo's `phi`, likewise
+ppm — see data_prep/demo_use.m "the tissue phase ... should be normalized with a unit of ppm"). Fed
+unchanged; output susceptibility is ppm, written unchanged on the input affine.
+
+B0 direction / voxel size come from params.json / QSMCI_* env vars.
+
+RUNTIME/GPU CAVEAT: per-subject optimization (default 50 epochs) is expensive and the reference is
+GPU-oriented (~10 GB VRAM). On CPU this may be slow or exceed the CI time limit — see README.
+"""
+import json
+import os
+import sys
+
+import numpy as np
+import nibabel as nib
+import torch
+
+INR_HOME = os.environ.get("INR_QSM_HOME", "/opt/INR-QSM/inr-qsm")
+sys.path.insert(0, INR_HOME)
+
+import model as inr_model  # noqa: E402
+import utils as inr_utils  # noqa: E402
+
+
+# --------------------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------------------
+def _load_json(path):
+    if os.path.exists(path):
+        with open(path) as fh:
+            return json.load(fh)
+    return {}
+
+
+def _vec(env_name, key, params, default):
+    env = os.environ.get(env_name)
+    if env:
+        return [float(v) for v in env.split()]
+    if key in params and params[key] is not None:
+        return [float(v) for v in params[key]]
+    return list(default)
+
+
+def _override(name, cfg, default, cast):
+    env = os.environ.get("QSMCI_SET_" + name.upper())
+    if env is not None:
+        return cast(env)
+    if name in cfg and cfg[name] is not None:
+        return cast(cfg[name])
+    return default
+
+
+def _tkd_initial_chi(phi, kernel_np, thresh=0.15):
+    """Truncated k-space division initial χ estimate (numpy), used only to seed the WG edge weights.
+
+    kernel_np is the fftshifted-free centered dipole D from utils.calc_d2_matrix1 (DC at center).
+    We divide in the same centered FFT convention the repo uses (np_myfftnc / np_myifftnc)."""
+    dim = [0, 1, 2]
+    phi_k = inr_utils.np_myfftnc(phi, dim)
+    d = kernel_np.copy()
+    small = np.abs(d) < thresh
+    d_inv = np.where(small, np.sign(d) * thresh, d)
+    d_inv[d_inv == 0] = thresh
+    chi = np.real(inr_utils.np_myifftnc(phi_k / d_inv, dim))
+    return chi
+
+
+def _tv_weighting(x0, mask, tv_range=(0.5, 0.7)):
+    """Python port of data_prep/TVweighting.m: edge-weight matrix from gradient magnitude of x0.
+
+    Returns WG of shape (X, Y, Z, 3), low near strong edges, high in smooth regions, masked."""
+    grad = np.zeros(x0.shape + (3,), dtype=np.float64)
+    grad[..., 0] = np.abs(np.diff(x0, axis=0, append=x0[-1:, :, :]))
+    grad[..., 1] = np.abs(np.diff(x0, axis=1, append=x0[:, -1:, :]))
+    grad[..., 2] = np.abs(np.diff(x0, axis=2, append=x0[:, :, -1:]))
+    m4 = np.repeat(mask[..., None], 3, axis=-1) > 0
+    vals = np.sort(grad[m4])
+    if vals.size == 0:
+        return (np.ones_like(grad) * m4).astype(np.float32)
+    hi = vals[min(int(round(len(vals) * tv_range[1])), len(vals) - 1)]
+    lo = vals[min(int(round(len(vals) * tv_range[0])), len(vals) - 1)]
+    denom = (hi - lo) if (hi - lo) != 0 else 1.0
+    wg = (hi - grad) / denom
+    wg = np.clip(wg, 0.0, 1.0) * m4
+    return wg.astype(np.float32)
+
+
+# --------------------------------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------------------------------
+def main():
+    IN = sys.argv[1] if len(sys.argv) > 1 else "/input"
+    OUT = sys.argv[2] if len(sys.argv) > 2 else "/output"
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    torch.manual_seed(1)
+    np.random.seed(1)
+
+    lfs_img = nib.load(os.path.join(IN, "localfield.nii.gz"))
+    phi = np.asarray(lfs_img.get_fdata(), dtype=np.float64)          # tissue/local field, ppm
+    mask = (np.asarray(nib.load(os.path.join(IN, "mask.nii.gz")).dataobj) > 0).astype(np.float64)
+
+    params = _load_json(os.path.join(IN, "params.json"))
+    cfg = _load_json(os.path.join(IN, "config.json"))
+
+    voxel_size = _vec("QSMCI_VOXEL_SIZE", "voxel_size", params, [1.0, 1.0, 1.0])
+    b0_dir = _vec("QSMCI_B0_DIR", "B0_dir", params, [0.0, 0.0, 1.0])
+    hdr_zooms = [float(z) for z in lfs_img.header.get_zooms()[:3]]
+    if hdr_zooms and all(z > 0 for z in hdr_zooms):
+        voxel_size = hdr_zooms
+
+    # --- reference-default hyperparameters (config.py), with config.json / QSMCI_SET_* overrides ---
+    epoch = _override("epoch", cfg, 50, int)
+    star_lr = _override("star_lr", cfg, 1e-5, float)
+    end_lr = _override("end_lr", cfg, 0.02e-5, float)
+    hidden_dim = _override("hidden_dim_num", cfg, 512, int)
+    num_layers = _override("num_layers", cfg, 10, int)
+    tv_weight = _override("TV_weight", cfg, 0.15, float)
+    gd_weight = _override("gd_weight", cfg, 1.0, float)
+    w0 = 40  # reference default (w0 == w0_hidden == w0_last == 40)
+
+    print(
+        f"INR-QSM: phi {phi.shape}, voxel_size {voxel_size}, B0_dir {b0_dir}, epoch {epoch}, "
+        f"star_lr {star_lr}, hidden_dim {hidden_dim}, num_layers {num_layers}, "
+        f"TV_weight {tv_weight}, gd_weight {gd_weight}, device {device}",
+        flush=True,
+    )
+
+    shape = phi.shape
+
+    # --- dipole kernel (repo's k-space kernel; DC at center) ---
+    kernel_np = inr_utils.calc_d2_matrix1(shape, voxel_size, b0_dir, device="cpu")
+    kernel = torch.tensor(kernel_np, dtype=torch.float32, device=device).unsqueeze(0).unsqueeze(-1)
+
+    # --- edge weights WG from a TKD initial estimate (Python port of the MATLAB data-prep) ---
+    x0 = _tkd_initial_chi(phi * mask, kernel_np) * mask
+    wg_np = _tv_weighting(x0, mask)
+    WG = torch.tensor(wg_np, dtype=torch.float32, device=device).unsqueeze(0)  # (1,X,Y,Z,3)
+
+    # --- normalized coordinate grid + tensors ---
+    coor = inr_utils.build_coordinate_train(shape[0], shape[1], shape[2],
+                                            shape[0], shape[1], shape[2], voxel_size)
+    coor = torch.tensor(coor, dtype=torch.float32, device=device).unsqueeze(0)   # (1,X,Y,Z,3)
+    phi_t = torch.tensor(phi, dtype=torch.float32, device=device).unsqueeze(0).unsqueeze(-1)
+    mask_t = torch.tensor(mask, dtype=torch.float32, device=device).unsqueeze(0).unsqueeze(-1)
+
+    # --- SIREN coordinate MLP (reference model, optional transfer-learning init for speed) ---
+    net = inr_model.siren_model(w0_first=w0, w0_hidden=w0, w0_last=w0,
+                                num_layers=num_layers, input_dim=3,
+                                hidden_dim=hidden_dim, out_dim=1).to(device)
+    tl_path = os.environ.get(
+        "INR_QSM_TL_WEIGHTS",
+        os.path.join(INR_HOME, "transfer_learning",
+                     "pre_trained_weight_for_transfer_learning.pkl"),
+    )
+    if os.environ.get("INR_QSM_USE_TL", "1") == "1" and os.path.exists(tl_path):
+        try:
+            net.load_state_dict(torch.load(tl_path, map_location=device))
+            print("INR-QSM: loaded transfer-learning init (acceleration only)", flush=True)
+        except Exception as e:  # width/depth must match the shipped init; skip if not
+            print(f"INR-QSM: transfer-learning init not applied ({e}); random init", flush=True)
+
+    optimizer = torch.optim.Adam(net.parameters(), lr=star_lr)
+    # exponential decay star_lr -> end_lr over `epoch` epochs (reference schedule form)
+    decay = (end_lr / star_lr) ** (1.0 / max(1, 2 * epoch))
+    scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda e: decay ** e)
+
+    l2 = torch.nn.MSELoss()
+    tv_loss_fn = inr_utils.TVLoss()
+    gd_loss_fn = inr_utils.GradientLoss()
+
+    # --- per-subject optimization: min ||mask·(F⁻¹ D F χ − phi)||² + TV + GD ---
+    net.train()
+    for e in range(epoch):
+        optimizer.zero_grad()
+        chi = net(coor) * mask_t                                   # (1,X,Y,Z,1)
+        chi_k = inr_utils.myfftnc(chi, dim=[1, 2, 3])
+        fwd = inr_utils.myifftnc(chi_k * kernel, dim=[1, 2, 3]).real
+        fwd = fwd * mask_t
+        target = phi_t * mask_t
+
+        mse = l2(fwd, target)
+        tv = tv_weight * tv_loss_fn(chi, "L2", WG)
+        gd = gd_weight * gd_loss_fn(fwd, target, "L2", WG)
+        loss = mse + tv + gd
+
+        loss.backward()
+        optimizer.step()
+        scheduler.step()
+        print(f"INR-QSM epoch [{e + 1}/{epoch}] lr {scheduler.get_last_lr()[0]:.3e} "
+              f"MSE {mse.item():.5f} TV {tv.item():.5f} GD {gd.item():.5f} "
+              f"loss {loss.item():.5f}", flush=True)
+
+    # --- final prediction ---
+    net.eval()
+    with torch.no_grad():
+        chi = (net(coor) * mask_t).squeeze(0).squeeze(-1).cpu().numpy().astype(np.float32)
+
+    os.makedirs(OUT, exist_ok=True)
+    out_path = os.path.join(OUT, "chimap.nii.gz")
+    nib.Nifti1Image(chi, lfs_img.affine, lfs_img.header).to_filename(out_path)
+    print("INR-QSM: wrote", out_path, chi.shape, "ppm", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/inr-qsm/run.sh
+++ b/algorithms/inr-qsm/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# QSM-CI submission — INR-QSM (dipole stage), CPU by default.
+#
+# INR-QSM is an UNSUPERVISED, subject-specific dipole inversion: it loads NO pretrained recon
+# weights. A sine-activated coordinate MLP (SIREN) is OPTIMIZED per-subject at run time so that the
+# susceptibility it represents, pushed through the QSM dipole forward model, reproduces the input
+# local field (with edge-weighted TV + gradient-domain regularizers). Stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units. The QSM-CI localfield is the tissue field already in ppm (normalized by B0), which is the
+# repo's `phi` input (also ppm). Fed unchanged; the output susceptibility (ppm) is written unchanged,
+# on the input affine.
+#
+# The B0 direction (for the dipole kernel) and voxel size are passed through from params.json / env:
+#   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm).
+#
+# RUNTIME/GPU CAVEAT: per-subject optimization (default 50 epochs) is expensive and the reference is
+# GPU-oriented (~10 GB VRAM, NVIDIA A6000). On CPU this may be slow or exceed the CI time limit — see
+# README. Force CPU here for parity with the other subs; a GPU runner or fewer epochs may be needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
+export INR_QSM_HOME="${INR_QSM_HOME:-/opt/INR-QSM/inr-qsm}"
+
+mkdir -p "$OUT"
+
+# inr_qsm_infer.py reuses the repo's SIREN model + dipole kernel + TV/GD losses, runs the per-subject
+# optimization, and writes χ to chimap.nii.gz (ppm).
+python "$(dirname "$0")/inr_qsm_infer.py" "$IN" "$OUT"

--- a/algorithms/ir2qsm/BUILD.md
+++ b/algorithms/ir2qsm/BUILD.md
@@ -1,0 +1,100 @@
+# IR2QSM — build & publish the environment image (human step)
+
+This submission's environment image has **not** been built or pushed (needs network + `ghcr.io`
+registry access). The scaffold is complete; do the following to finish.
+
+## 1. Build the image (bakes code + weights)
+
+The `Dockerfile` clones the IR2QSM repo and downloads the pretrained checkpoint with `gdown` at build
+time (build phase has network; run phase does not).
+
+```bash
+# from the repo root
+docker build -t ghcr.io/astewartau/qsm-ci/ir2qsm:v1 algorithms/ir2qsm
+```
+
+The exact weights-download step baked into the Dockerfile is:
+
+```dockerfile
+ARG IR2QSM_GDRIVE_ID=1EGZGxdgVWI8r0RlyfjP-xQyOL88vLeDf
+RUN gdown "$IR2QSM_GDRIVE_ID" -O /opt/IR2QSM/Evaluate/model_IR2Unet.pth \
+ && test -s /opt/IR2QSM/Evaluate/model_IR2Unet.pth
+```
+
+i.e. it fetches `model_IR2Unet.pth` from Google Drive file id
+`1EGZGxdgVWI8r0RlyfjP-xQyOL88vLeDf`
+(https://drive.google.com/file/d/1EGZGxdgVWI8r0RlyfjP-xQyOL88vLeDf/view). The larger demo bundle
+(id `1S4SkhB-Lqz1D3lf4Q5UHdrpimRo7udbL`) is NOT needed — it only adds demo data.
+
+### If the plain `gdown <id>` fails
+
+Google Drive occasionally blocks the confirm-token flow (quota / "can't scan for viruses"). Fallbacks:
+
+```bash
+# newer gdown syntax
+gdown --id 1EGZGxdgVWI8r0RlyfjP-xQyOL88vLeDf -O model_IR2Unet.pth
+# or the full URL with fuzzy matching
+gdown --fuzzy "https://drive.google.com/file/d/1EGZGxdgVWI8r0RlyfjP-xQyOL88vLeDf/view" -O model_IR2Unet.pth
+```
+
+If Drive rate-limits the CI build entirely, download `model_IR2Unet.pth` once by hand, host it
+somewhere durable (a GitHub Release on a fork, an OSF/HF bucket, etc.), and swap the `gdown` line for
+a `curl -fSL`. This is the single biggest build-reliability risk — Google-Drive downloads are not
+guaranteed reproducible.
+
+## 2. Smoke-test locally before pushing
+
+Generate a phantom with ground truth and run the isolated `dipole` stage:
+
+```bash
+qsm-forward simple /tmp/bids            # writes localfield/chi/mask under derivatives/qsm-forward/
+qsm-ci run ir2qsm \
+  --localfield /tmp/bids/.../localfield.nii.gz \
+  --mask       /tmp/bids/.../mask.nii.gz \
+  --params     /tmp/bids/.../params.json \
+  --truth      /tmp/bids/.../chimap.nii.gz     # scores it with the CI scorer
+```
+
+Check:
+- it produces `chimap.nii.gz` on the input grid/affine,
+- susceptibility magnitudes look physical (roughly ±0.1–0.2 ppm in tissue),
+- no CUDA errors (the `AddNoise` monkeypatch in `ir2qsm_infer.py` must keep everything on CPU).
+
+Also confirm `strict=False` didn't silently drop weights:
+
+```bash
+docker run --rm ghcr.io/astewartau/qsm-ci/ir2qsm:v1 python - <<'PY'
+import os, sys, torch, torch.nn as nn
+sys.path.insert(0, os.environ["IR2QSM_CODE"])
+import IR2Unet
+net = nn.DataParallel(IR2Unet.IR2Unet())
+sd = torch.load(os.environ["IR2QSM_CKPT"], map_location="cpu")
+missing, unexpected = net.load_state_dict(sd, strict=False)
+print("missing:", missing)          # expect [] (or only non-parametric buffers)
+print("unexpected:", unexpected)
+PY
+```
+
+If `missing` lists real conv/bn weights, the checkpoint key layout differs from the current
+`IR2Unet` definition (e.g. repo moved on from the pinned ref) — pin `IR2QSM_REF` to the commit the
+weights were trained against.
+
+## 3. Push
+
+```bash
+docker push ghcr.io/astewartau/qsm-ci/ir2qsm:v1
+```
+
+QSM-CI also builds this folder's Dockerfile at score-time, so a manual push is not strictly required
+for the leaderboard — but pushing avoids re-downloading the weights on every scorer.
+
+## Risks / notes
+
+- **Weights download reliability** — Google Drive confirm-token / quota (see fallbacks above). Biggest risk.
+- **GPU-only op** — upstream `AddNoise` hardcodes `.to("cuda:0")` and runs at inference; the wrapper
+  monkeypatches it to be CPU-safe. If upstream refactors `AddNoise`, re-check the patch still binds.
+- **Non-deterministic output** — that inference-time `AddNoise` is a random draw (gated by
+  `torch.rand(1) > 0.3`), so repeated runs differ slightly. Consider seeding torch or disabling the
+  call; flag with the authors.
+- **Torch drift** — image uses current CPU `torch>=2.1.0` vs the repo's torch 1.13; verify numerics.
+- **1 mm isotropic** — no resampling is done; non-1mm challenge data may degrade results.

--- a/algorithms/ir2qsm/README.md
+++ b/algorithms/ir2qsm/README.md
@@ -1,0 +1,121 @@
+# IR2QSM
+
+A pretrained deep-learning network for quantitative susceptibility mapping by **dipole inversion**,
+using **iterative Reverse Concatenations and Recurrent Modules** (an "IR2U-net").
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [IR2QSM](https://github.com/YangGaoUQ/IR2QSM) — PyTorch, **CPU-only** here (the repo
+  targets Python 3.10+ / PyTorch 1.13+; a current CPU torch runs it fine with `CUDA_VISIBLE_DEVICES=-1`)
+- **Reference:** Li M., Chen C., Xiong Z., Liu Y., Rong P., Shan S., Liu F., Sun H., Gao Y. (2025).
+  *Quantitative susceptibility mapping via deep neural networks with iterative reverse concatenations
+  and recurrent modules.* Medical Physics. (DOI: [10.1002/mp.17747](https://doi.org/10.1002/mp.17747);
+  preprint [arXiv:2406.12300](https://arxiv.org/abs/2406.12300))
+
+> **STATUS: scaffold — needs Docker image build + push to ghcr (human).**
+> This folder is complete but the environment image has **not** been built or pushed, because that
+> requires a network + registry access (Google-Drive weights download + `ghcr.io` push). No part of
+> IR2QSM inference has been run here. See **BUILD.md** for the exact steps, and the "Assumptions to
+> verify" section below for what to confirm on the first real run.
+
+## Why `dipole`
+
+IR2QSM is a single network that maps a **local (tissue) field** directly to **susceptibility** — it
+performs only the dipole inversion, with no field-mapping or background-field-removal step. So it
+consumes `localfield` and produces `chimap`, i.e. the `dipole` stage. (`Evaluate/test.py` loads one
+network, feeds it the local field `lfs1.nii`, and saves the susceptibility output.)
+
+## Units & normalization
+
+The QSM-CI `localfield` is the local/tissue field already **in ppm** (normalized by B0) — the same
+quantity IR2QSM was trained on (their `lfs`, the local field shift in ppm).
+
+Unlike QSMnet / MoDL-QSM, IR2QSM applies **no dataset mean/std normalization**: the reference
+`Evaluate/test_util.py` feeds the local field to the network **directly**, and there is no
+`norm_factor` / `NormFactor` file anywhere in the repo. The output is likewise already in ppm — no
+de-normalization is applied. The wrapper therefore passes the field straight through.
+
+IR2QSM was trained at **1 mm isotropic**; the IR2U-net has `depth=4` (so `depth-1 = 3` max-pool /
+deconv levels), meaning spatial dims must be divisible by **2³ = 8**. The reference zero-pads each
+dimension up to a multiple of 8 (`zero_padding(image, 8)`); the wrapper replicates that centered
+padding and crops back afterwards. The output is masked and written on the input NIfTI's
+affine/header (voxel size + orientation preserved).
+
+## Network output
+
+`model(x)` returns `(latest_out, all_output)`:
+- `latest_out` — the fully integrated final estimate (residual `x_out + input`). **This is what the
+  reference and the wrapper keep.**
+- `all_output[t]` — the per-iteration (T=4) intermediate estimates; the reference explicitly
+  recommends using the final output rather than an intermediate.
+
+## Differences from the reference inference (deliberate)
+
+1. **Mask.** The reference derives a mask from the *padded field's* nonzero voxels (`image != 0`); we
+   use the supplied QSM-CI `mask.nii.gz` (the canonical brain mask for this stage), applied after
+   cropping back to the original grid.
+2. **Affine.** The reference saves with `affine=np.eye(4)`, discarding geometry; we round-trip the
+   input NIfTI's affine so voxel size + orientation carry through unchanged (matching `qsmnet`).
+3. **GPU-only `AddNoise` (important).** `IR2Unet.forward` calls `AddNoise()` in the decoder
+   **unconditionally** — it is *not* gated by `self.training` — and upstream `AddNoise()` hardcodes
+   `.to("cuda:0")`, which raises on a CPU box. The wrapper monkeypatches `AddNoise` to a
+   device-correct version (same additive-noise formula, on the tensor's own device) so CPU inference
+   reproduces the reference behavior. **Note:** because this noise call fires at inference time,
+   IR2QSM's output is **mildly stochastic** (a random draw gated by `torch.rand(1) > 0.3`); this is
+   inherited from the upstream released code, not introduced here. If deterministic output is
+   required, seed torch or disable that call — flag for the authors, as it looks like a leftover from
+   the training-time noise-regularization scheme.
+
+## How QSM-CI runs it
+
+```bash
+bash run.sh                      # -> python ir2qsm_infer.py localfield.nii.gz mask.nii.gz chimap.nii.gz
+```
+
+`ir2qsm_infer.py` drives the repo's `Evaluate/IR2Unet.IR2Unet` with the baked checkpoint
+(`model_IR2Unet.pth`), which was saved from an `nn.DataParallel`-wrapped model (keys carry a
+`module.` prefix), so the wrapper wraps identically and loads with `strict=False` — exactly as the
+reference `test.py` does.
+
+## Weights (baked at build time from Google Drive)
+
+The pretrained checkpoint `model_IR2Unet.pth` lives on the authors' Google Drive (file id
+`1EGZGxdgVWI8r0RlyfjP-xQyOL88vLeDf`). It is fetched with **`gdown`** at **build time** (network is on
+during build, off at scoring) and placed at `/opt/IR2QSM/Evaluate/model_IR2Unet.pth`, so inference
+runs fully offline (`--network none`). `gdown` handles Google Drive's large-file confirm-token. See
+**BUILD.md** for the exact command.
+
+## Parameters
+
+IR2QSM has no runtime tunables — it uses fixed pretrained weights (tuning-free). Voxel size and
+orientation are carried by the input NIfTI affine.
+
+## Assumptions to verify (first real run)
+
+Because nothing was executed here, confirm these when the image is first built and run:
+
+1. **Input units = ppm local field.** Derived from the reference feeding `lfs1.nii` directly with no
+   scaling. If IR2QSM's demo `lfs` turns out to be scaled differently (e.g. Hz, or a fixed ppm
+   scaling), the wrapper would need a matching factor. Sanity-check output susceptibility magnitude
+   (expect roughly ±0.1–0.2 ppm in tissue).
+2. **Padding factor = 8.** Taken from `zero_padding(image, 8)` in `test_util.py`. Verify the net
+   accepts the padded volume without a shape mismatch.
+3. **`latest_out` is the intended product** (vs. `all_output[-1]`). The reference uses `latest_out`.
+4. **`strict=False` load leaves no critical weights unloaded.** The reference uses it because of the
+   `DataParallel` prefix; confirm there are no *unexpectedly* missing keys (which would silently leave
+   parts of the net at init).
+5. **1 mm isotropic.** The network is trained at 1 mm iso; on non-1mm data results may degrade. The
+   QSM-CI challenge grid should be checked; no resampling is done here (matching qsmnet).
+6. **Torch version.** The image installs current CPU `torch>=2.1.0`. Confirm the checkpoint loads and
+   the 3D-conv / ConvTranspose / SRU ops behave numerically as on the authors' torch 1.13.
+7. **Non-determinism** from the inference-time `AddNoise` (see above) — decide whether to seed/disable.
+
+## Building the image
+
+See **BUILD.md**. In short:
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/ir2qsm:v1 algorithms/ir2qsm
+docker push  ghcr.io/astewartau/qsm-ci/ir2qsm:v1
+```
+
+_Citations/DOIs should be verified against the published paper._

--- a/algorithms/ir2qsm/algorithm.yml
+++ b/algorithms/ir2qsm/algorithm.yml
@@ -1,0 +1,28 @@
+name: IR2QSM
+slug: ir2qsm
+stage: dipole
+description: >
+  IR2QSM — a pretrained deep-learning dipole-inversion network (iterative Reverse Concatenations and
+  Recurrent Modules). Consumes the local (tissue) field in ppm and produces susceptibility (ppm). The
+  network is an "IR2U-net": a specially tailored 3D U-net iterated T=4 times, with reverse
+  concatenations between iterations and a recurrent (SRU) middle module. Unlike QSMnet it applies NO
+  dataset mean/std normalization — the local field in ppm is fed to the net directly and the output is
+  already in ppm. Each dimension is zero-padded to a multiple of 8 (the U-net has 3 pool/deconv levels)
+  and cropped back afterwards; trained at 1 mm isotropic. Runs CPU-only with PyTorch (no GPU).
+authors:
+- name: Li M.
+- name: Chen C.
+- name: Xiong Z.
+- name: Liu Y.
+- name: Rong P.
+- name: Shan S.
+- name: Liu F.
+- name: Sun H.
+- name: Gao Y.
+doi: 10.1002/mp.17747
+code_url: https://github.com/YangGaoUQ/IR2QSM
+license: >
+  No LICENSE file in the upstream repository; academic use only — cite the paper
+  (arXiv:2406.12300). Confirm terms with the authors before redistribution.
+image: ghcr.io/astewartau/qsm-ci/ir2qsm:v1
+run: bash run.sh

--- a/algorithms/ir2qsm/ir2qsm_infer.py
+++ b/algorithms/ir2qsm/ir2qsm_infer.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+"""QSM-CI wrapper for IR2QSM dipole inversion (PyTorch, CPU).
+
+Mirrors the reference inference in IR2QSM/Evaluate/test.py + test_util.py, but consuming QSM-CI
+artifacts (localfield.nii.gz + mask.nii.gz) and writing chimap.nii.gz on the INPUT affine.
+
+Pipeline (faithful to the reference test_util.process_nii_file):
+
+  1. Read localfield.nii.gz — the local/tissue field already in ppm. QSM-CI provides this; IR2QSM
+     was trained to map exactly this (their `lfs`, local field shift in ppm) to susceptibility.
+  2. NO normalization. Unlike QSMnet/MoDL-QSM, the IR2QSM reference feeds the local field to the
+     network directly — there is no dataset mean/std scaling and no norm_factor file in the repo.
+     The output is likewise already in ppm (no de-normalization).
+  3. Zero-pad each dim up to a multiple of 8. The IR2U-net has depth=4 with (depth-1)=3 max-pool /
+     deconv levels, so spatial dims must be divisible by 2**3 = 8. The reference calls
+     zero_padding(image, 8); we replicate its centered padding and crop back afterwards.
+  4. Run the frozen IR2U-net (Evaluate/IR2Unet.py). model(x) returns (latest_out, all_output); the
+     reference keeps `latest_out` (the fully integrated final estimate) — so do we. (all_output[t]
+     are the per-iteration intermediates; the reference notes the final output is recommended.)
+  5. Multiply by the brain mask and write chimap.nii.gz on the input affine/header (voxel size +
+     orientation preserved).
+
+Differences from the reference we deliberately make (all documented in README.md):
+  * The reference derives its mask from the padded field's nonzero voxels (`image != 0`); we use the
+    supplied QSM-CI mask.nii.gz instead (the canonical brain mask for this stage), applied after
+    cropping back to the original grid.
+  * The reference saves with affine=np.eye(4), discarding geometry; we round-trip the input NIfTI's
+    affine so voxel size + orientation are carried through unchanged (matching qsmnet_infer.py).
+  * GPU-only AddNoise: the repo's IR2Unet.forward runs an AddNoise() call in the decoder that is NOT
+    gated by self.training, and AddNoise() in IR2UnetBlock.py hardcodes `.to("cuda:0")` — which would
+    crash on CPU. We monkeypatch AddNoise to a device-correct implementation before running so CPU
+    inference reproduces the reference behavior (see _install_cpu_safe_addnoise below).
+"""
+import os
+import sys
+
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")  # force CPU
+
+import numpy as np
+import nibabel as nib
+import torch
+import torch.nn as nn
+
+# The pretrained net is defined in the cloned repo's Evaluate/ package (IR2Unet + the blocks in
+# IR2UnetBlock). IR2QSM_CODE points at that dir in the image.
+IR2QSM_CODE = os.environ.get("IR2QSM_CODE", "/opt/IR2QSM/Evaluate")
+sys.path.insert(0, IR2QSM_CODE)
+
+import IR2UnetBlock  # noqa: E402  (imported before IR2Unet so the monkeypatch below sticks)
+import IR2Unet       # noqa: E402
+
+
+def _install_cpu_safe_addnoise():
+    """Replace the repo's GPU-hardcoded AddNoise with a device-correct equivalent.
+
+    IR2Unet.forward calls AddNoise() in the decoder unconditionally (not gated by self.training), and
+    the upstream AddNoise() does `.to("cuda:0")`, which raises on a CPU-only box. We swap in a version
+    that keeps everything on the input tensor's own device, preserving the reference's numerical
+    behavior (same additive-noise formula) while running on CPU. In eval() + no_grad() the other
+    AddNoise calls are gated out by self.training, so only this decoder call actually fires.
+    """
+    def AddNoise(ins, SNR):
+        sig_power = torch.sum(ins ** 2) / torch.numel(ins)
+        noise_power = sig_power / SNR
+        noise = torch.sqrt(noise_power) * torch.randn(ins.size(), device=ins.device)
+        return ins + noise
+
+    # IR2Unet.py does `from IR2UnetBlock import *`, so AddNoise is resolved in IR2Unet's namespace.
+    IR2Unet.AddNoise = AddNoise
+    IR2UnetBlock.AddNoise = AddNoise
+
+
+def zero_pad_to_multiple(vol, m=8):
+    """Center zero-pad each dim up to the next multiple of m (mirrors repo's zero_padding, factor 8).
+
+    Returns the padded array plus the per-axis (lo, hi) pads so we can crop the prediction back.
+    """
+    shape = np.asarray(vol.shape)
+    target = np.ceil(shape / float(m)).astype(int) * m
+    # Reference uses ceil((up-im)/2) for the low offset; replicate exactly.
+    lo = np.ceil((target - shape) / 2.0).astype(int)
+    hi = target - shape - lo
+    npad = tuple((int(l), int(h)) for l, h in zip(lo, hi))
+    return np.pad(vol, npad, mode="constant", constant_values=0), npad
+
+
+def crop_pad(vol, npad):
+    sl = tuple(slice(lo, vol.shape[i] - hi) for i, (lo, hi) in enumerate(npad))
+    return vol[sl]
+
+
+def main():
+    in_field, in_mask, out_chi = sys.argv[1], sys.argv[2], sys.argv[3]
+    ckpt = os.environ.get("IR2QSM_CKPT", "/opt/IR2QSM/Evaluate/model_IR2Unet.pth")
+
+    _install_cpu_safe_addnoise()
+
+    device = torch.device("cpu")
+
+    # --- read the local field (ppm) + mask ---
+    field_img = nib.load(in_field)
+    field = np.asarray(field_img.get_fdata(), dtype=np.float32)
+    mask = np.asarray(nib.load(in_mask).get_fdata(), dtype=np.float32)
+
+    # pad to /8 (no normalization — IR2QSM consumes ppm local field directly)
+    pfield, npad = zero_pad_to_multiple(field, 8)
+    x = torch.from_numpy(pfield).float()[None, None, ...]  # (1, 1, X, Y, Z)
+    x = x.to(device)
+
+    # --- build + restore the net ---
+    # The checkpoint was saved from an nn.DataParallel-wrapped model, so its keys carry a "module."
+    # prefix; wrap the same way and load with strict=False (exactly as the reference test.py does).
+    net = IR2Unet.IR2Unet()
+    net = nn.DataParallel(net)
+    state = torch.load(ckpt, map_location=device)
+    net.load_state_dict(state, strict=False)
+    net.to(device)
+    net.eval()
+
+    with torch.no_grad():
+        latest_out, _all_out = net(x)
+
+    pred = latest_out.squeeze(0).squeeze(0).to("cpu").numpy()  # (X, Y, Z), padded grid
+
+    # crop back to the original grid, mask, write on the INPUT affine/header
+    chi = crop_pad(pred, npad).astype(np.float32)
+    chi = chi * (mask > 0)
+
+    os.makedirs(os.path.dirname(os.path.abspath(out_chi)), exist_ok=True)
+    nib.save(nib.Nifti1Image(chi, field_img.affine, field_img.header), out_chi)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/ir2qsm/run.sh
+++ b/algorithms/ir2qsm/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# QSM-CI submission — IR2QSM (dipole stage), CPU-only, PyTorch.
+#
+# IR2QSM is a pretrained deep-learning dipole-inversion network (an "IR2U-net": a tailored 3D U-net
+# iterated 4 times with reverse concatenations and a recurrent SRU middle module). It takes the LOCAL
+# (tissue) field and produces susceptibility. Hence stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units: the QSM-CI localfield is the local/tissue field already in ppm (normalized by B0), which is
+# exactly what IR2QSM was trained on (their `lfs`). Unlike QSMnet there is NO dataset mean/std
+# normalization — the field is fed to the net directly and the output is already in ppm. ir2qsm_infer.py
+# only zero-pads each dim to a multiple of 8 (the U-net's 3 pool/deconv levels) and crops back.
+#
+# Orientation/voxel size are carried by the input NIfTI affine (read + written unchanged), so
+# $QSMCI_B0_DIR / $QSMCI_VOXEL_SIZE (see CONTRACT.md) are not consumed by this path. Trained at 1 mm
+# isotropic.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
+
+# The IR2QSM repo (with the baked checkpoint) lives in the image; run.sh + the wrapper are at /algo.
+export IR2QSM_CODE="${IR2QSM_CODE:-/opt/IR2QSM/Evaluate}"
+export IR2QSM_CKPT="${IR2QSM_CKPT:-/opt/IR2QSM/Evaluate/model_IR2Unet.pth}"
+
+mkdir -p "$OUT"
+
+python "$SCRIPT_DIR/ir2qsm_infer.py" \
+  "$IN/localfield.nii.gz" \
+  "$IN/mask.nii.gz" \
+  "$OUT/chimap.nii.gz"

--- a/algorithms/l1-qsm/BUILD.md
+++ b/algorithms/l1-qsm/BUILD.md
@@ -1,0 +1,39 @@
+# Building l1-qsm (compiled MATLAB → MATLAB Runtime)
+
+Compile `recon.m` on a machine with **MATLAB + MATLAB Compiler** (R2026a). Runs license-free on the
+MATLAB Runtime. Same patterns as `matlab-tkd` (bundled NIfTI toolbox, OS gzip), plus Carlos
+Milovic's **FANSI toolbox** (`nlL1TV.m` and its deps).
+
+Stage: `dipole` — consumes `localfield` (ppm), `mask`, `params`; nonlinear L1-fidelity + TV ADMM
+inversion (`nlL1TV`) → `chimap` (ppm).
+
+> **Shared image.** `l1-qsm` shares `ghcr.io/astewartau/qsm-ci/fansi:v1` with `fansi`, `ndi`,
+> `wh-qsm` (all one FANSI toolbox). `mcc` bundles the traced functions into `recon`, so the toolbox
+> is build-time only. Build one image per submission (each COPYs its own `recon`) or bake all four
+> binaries under distinct names into the single shared image. See `../fansi/BUILD.md`.
+
+## 1. Fetch build-time deps (not committed)
+```bash
+cp -r /path/to/NIfTI_20140122               algorithms/l1-qsm/nifti   # Jimmy Shen toolbox
+git clone https://gitlab.com/cmilovic/FANSI-toolbox algorithms/l1-qsm/fansi   # FANSI toolbox
+```
+
+## 2. Compile
+```bash
+cd algorithms/l1-qsm
+matlab -batch "addpath('nifti'); addpath(genpath('fansi')); mcc('-m','recon.m','-o','recon','-d','.')"   # -> ./recon
+```
+
+## 3. Bake the MCR image and push
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/fansi:v1 .
+docker push  ghcr.io/astewartau/qsm-ci/fansi:v1
+```
+Then make the GHCR package public.
+
+## Units
+`localfield` is ppm; `nlL1TV.m` works in radians (it forms `exp(1i*input)`). `recon.m` converts
+`phase_rad = field * 2*pi*42.58*B0*TE` and divides the output by the same `phs_scale` to return ppm.
+The L1 fidelity weight is `lambda*mask`; `lambda<1` rejects more inconsistent voxels (see nlL1TV.m).
+
+> No MATLAB Compiler license? See Option B in [`docs/matlab.md`](../../docs/matlab.md).

--- a/algorithms/l1-qsm/README.md
+++ b/algorithms/l1-qsm/README.md
@@ -1,0 +1,40 @@
+# L1-QSM — L1-norm data-fidelity QSM (MATLAB)
+
+**STATUS: scaffold — needs image build (MATLAB Compiler license required).** Source is complete;
+the compiled `recon` binary and pushed image are the human's job (see `BUILD.md`).
+
+## What it does
+L1-norm data-fidelity QSM, a.k.a. PI-QSM (Milovic et al., *MRM* 2022,
+doi:10.1002/mrm.28957). A nonlinear dipole inversion whose **L1 data-fidelity term** is more robust
+to phase inconsistencies / streaking than the standard L2 (FANSI) term, with TV regularization.
+Implementation is `nlL1TV.m` from Carlos Milovic's **FANSI toolbox**.
+
+- **Stage:** `dipole` — consumes `localfield` (ppm), `mask`, `params`; produces `chimap` (ppm).
+
+## Units handling
+`nlL1TV.m` forms `exp(1i*input)`, so the input must be in **radians**. `recon.m` converts
+`phase_rad = field * 2*pi * 42.58 * B0 * TE`, runs `nlL1TV`, then divides the output by the same
+`phs_scale` to return **ppm**.
+
+## Parameters (defaults track FANSI recommendations)
+| name | default | meaning |
+|------|---------|---------|
+| `alpha1` | 3e-4 | gradient L1 (TV) penalty |
+| `lambda` | 1.0 | L1 data-fidelity strength (scales the fidelity weight); <1 rejects more inconsistent voxels |
+| `mu1` | 3e-2 | gradient-consistency ADMM weight (= 100·alpha1) |
+| `iterations` | 50 | max ADMM outer iterations |
+| `tol_update` | 1.0 | convergence threshold (percent update) |
+
+## Assumptions the human must verify
+- **Image is SHARED** with `fansi`, `ndi`, `wh-qsm`: `ghcr.io/astewartau/qsm-ci/fansi:v1`
+  (see `BUILD.md`).
+- **DOI 10.1002/mrm.28957** — "Streaking artifact suppression of QSM reconstructions via L1-norm
+  data fidelity optimization (L1-QSM)", Milovic et al. Confirmed via Crossref.
+- **`lambda` default = 1.0** (no extra phase rejection). The FANSI docstring recommends `lambda*mask`
+  with the magnitude in [0,1]; at the dipole stage there is no magnitude so the mask is used. The
+  best `alpha1`/`lambda` come from the parameter sweep, not hard-coded here.
+- **`tol_update`/`iterations` defaults** (1.0 / 50) are the `nlL1TV.m` defaults — L1-QSM converges
+  more slowly than L2; the human may want more iterations. Verify on the phantom.
+- **GPU disabled** — scoring Runtime is CPU-only.
+- **License:** FANSI ships no LICENSE file (README: "academic and research", BSD-style disclaimer) →
+  `license: academic use; cite paper`.

--- a/algorithms/l1-qsm/algorithm.yml
+++ b/algorithms/l1-qsm/algorithm.yml
@@ -1,0 +1,41 @@
+name: L1-QSM (MATLAB)
+slug: l1-qsm
+stage: dipole
+description: L1-norm data-fidelity QSM (also called PI-QSM) — nonlinear dipole inversion
+  with an L1 data-fidelity term that is more robust to phase inconsistencies than the
+  standard L2 (FANSI) term, plus TV regularization. Implementation from Carlos Milovic's
+  FANSI toolbox (nlL1TV.m). Compiled from MATLAB and run on the license-free MATLAB Runtime.
+authors:
+- name: Carlos Milovic
+- name: Berkin Bilgic
+- name: Bo Zhao
+- name: Cristian Tejos
+- name: Karin Shmueli
+doi: 10.1002/mrm.28957
+citation: Milovic et al., Magn Reson Med 2022 (L1-QSM)
+code_url: https://gitlab.com/cmilovic/FANSI-toolbox
+# FANSI-toolbox ships no LICENSE file; its README grants use "for academic and research
+# purposes" with a BSD-style warranty disclaimer.
+license: academic use; cite paper
+# Shared image with fansi/ndi/wh-qsm (all one FANSI toolbox); see BUILD.md.
+image: ghcr.io/astewartau/qsm-ci/l1-qsm:v1
+run: bash run.sh
+matlab:
+  entry: recon.m
+  runtime: r2026a
+parameters:
+- name: alpha1
+  default: 0.0003
+  description: gradient L1 (total-variation) penalty; larger = smoother, more regularized
+- name: lambda
+  default: 1.0
+  description: L1 data-fidelity strength (scales the fidelity weight); lambda<1 rejects more inconsistent voxels
+- name: mu1
+  default: 0.03
+  description: gradient-consistency ADMM weight (recommended 100*alpha1)
+- name: iterations
+  default: 50
+  description: maximum number of ADMM outer iterations
+- name: tol_update
+  default: 1.0
+  description: convergence threshold on the normalized solution update (percent)

--- a/algorithms/l1-qsm/recon.m
+++ b/algorithms/l1-qsm/recon.m
@@ -1,0 +1,79 @@
+function recon(inp, out)
+% QSM-CI `dipole` stage in MATLAB — L1-norm data-fidelity QSM (L1-QSM / PI-QSM).
+% Milovic et al., MRM 2022; implementation from Carlos Milovic's FANSI toolbox (nlL1TV.m).
+% Reads <inp>/localfield.nii.gz (ppm) + mask + params.json, writes <out>/chimap.nii.gz (ppm).
+%
+% Bundled: Jimmy Shen NIfTI toolbox + FANSI toolbox (installed at /opt/fansi in the image, added to
+% path at compile time — see BUILD.md). OS gunzip/gzip (compiled binaries have no JVM).
+% Optional <inp>/config.json overrides {alpha1, lambda, mu1, iterations, tol_update}.
+%
+% UNITS — CRITICAL. nlL1TV.m forms IS = exp(1i*params.input); its input MUST be in RADIANS.
+% We convert ppm -> radians with phs_scale = 2*pi * 42.58 * B0 * TE, run the solver, then divide the
+% output by the SAME phs_scale to return ppm (out.x is in radians). See nlL1TV.m header.
+%
+% LAMBDA — the L1 data-fidelity strength. Unlike FANSI, the fidelity weight must be rescaled by a
+% lambda factor: weight = lambda * mask (mask in [0,1]). lambda < 1 rejects more inconsistent voxels.
+
+    p   = jsondecode(fileread(fullfile(inp, 'params.json')));
+    b0  = p.B0_dir(:)'; b0 = b0 / norm(b0);
+    vox = p.voxel_size(:)';
+    B0T = p.B0;                       % field strength (Tesla)
+    TE  = p.TE(:)';  TE = TE(1);      % first echo time (s)
+
+    % Defaults: FANSI-recommended alpha1; lambda=1 (no extra phase rejection); mu1 = 100*alpha1.
+    cfg = struct('alpha1', 3e-4, 'lambda', 1.0, 'mu1', 3e-2, ...
+                 'iterations', 50, 'tol_update', 1.0);
+    cf_file = fullfile(inp, 'config.json');
+    if exist(cf_file, 'file')
+        u = jsondecode(fileread(cf_file));
+        for f = fieldnames(u)', cfg.(f{1}) = u.(f{1}); end
+    end
+
+    % --- inputs ---
+    nlf   = read_niigz(fullfile(inp, 'localfield.nii.gz'));
+    field = double(nlf.img);                                     % local field, ppm
+    mask  = double(getfield(read_niigz(fullfile(inp, 'mask.nii.gz')), 'img')) > 0.5;
+
+    N = size(field);
+
+    % ppm -> radians (see UNITS note above)
+    GYRO_MHz = 42.58;
+    phs_scale = 2*pi * GYRO_MHz * B0T * TE;
+    phase_rad = field * phs_scale;
+
+    kernel = dipole_kernel_angulated(N, vox, b0);
+
+    params = [];
+    params.input        = single(phase_rad);
+    params.K            = single(kernel);
+    params.alpha1       = cfg.alpha1;
+    params.mu1          = cfg.mu1;
+    params.weight       = single(cfg.lambda * mask);  % lambda-scaled mask (no magnitude at dipole)
+    params.maxOuterIter = cfg.iterations;
+    params.tolUpdate    = cfg.tol_update;
+    params.isGPU        = false;                       % MATLAB Runtime CPU-only at scoring time
+
+    outs = nlL1TV(params);
+
+    chi = double(outs.x) / phs_scale;                 % radians -> ppm
+    chi = chi .* mask;
+
+    nlf.img = single(chi);
+    nlf.hdr.dime.datatype = 16;  nlf.hdr.dime.bitpix = 32;
+    nlf.hdr.dime.dim(1) = 3;  nlf.hdr.dime.dim(5) = 1;
+    write_niigz(nlf, fullfile(out, 'chimap.nii.gz'));
+end
+
+function nii = read_niigz(f)
+    t = [tempname '.nii'];
+    system(sprintf('gunzip -c ''%s'' > ''%s''', f, t));
+    nii = load_untouch_nii(t);
+    delete(t);
+end
+
+function write_niigz(nii, f)
+    t = [tempname '.nii'];
+    save_untouch_nii(nii, t);
+    system(sprintf('gzip -c ''%s'' > ''%s''', t, f));
+    delete(t);
+end

--- a/algorithms/l1-qsm/run.sh
+++ b/algorithms/l1-qsm/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary is either baked into the image at /opt/qsm-ci/recon (recommended) or committed
+# alongside this script and mounted at /algo. No network needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/modip/BUILD.md
+++ b/algorithms/modip/BUILD.md
@@ -1,0 +1,61 @@
+# BUILD — MoDIP (`modip`)
+
+This submission is a **scaffold**. The container image is **not** built or pushed, and the pipeline
+has **not** been run. This file lists exactly what a human must do to finish.
+
+## 1. Build & push the environment image
+
+The run phase has **no network**, so the method source must be baked in at build time. The Dockerfile
+`git clone`s `github.com/sunhongfu/MoDIP` into `/opt/MoDIP` and installs a **CPU** PyTorch wheel.
+There are **no weights to download** (MoDIP is untrained — it optimizes per subject).
+
+```bash
+# from the repo root
+docker build -t ghcr.io/astewartau/qsm-ci/modip:v1 algorithms/modip
+docker push  ghcr.io/astewartau/qsm-ci/modip:v1
+```
+
+- For reproducibility, pin the method commit: `--build-arg MODIP_REF=<sha>`.
+- QSM-CI also builds this folder's Dockerfile at score-time, so a manual push is not strictly
+  required for the leaderboard — but build it once locally to confirm it succeeds.
+
+### GPU variant (optional, recommended — see below)
+
+To build a CUDA image, change the torch install in the Dockerfile from the CPU index
+(`https://download.pytorch.org/whl/cpu`) to a CUDA one (e.g. `.../whl/cu121`), remove
+`ENV CUDA_VISIBLE_DEVICES="-1"`, and drop the `export CUDA_VISIBLE_DEVICES=-1` in `run.sh`.
+
+## 2. Smoke-test locally (with ground truth)
+
+```bash
+qsm-forward simple bids/          # phantom WITH ground truth
+# feed the localfield/mask/params + truth from bids/derivatives/qsm-forward/ to:
+qsm-ci run modip \
+  --localfield lf.nii.gz --mask mask.nii.gz --params params.json \
+  --truth chi.nii.gz
+```
+
+Confirm: it produces `chimap.nii.gz`, the scale looks like ppm QSM (roughly ±0.1–0.2 in tissue), and
+the sign is correct.
+
+## 3. Decide the CPU-vs-GPU / iteration-cap question ⚠️
+
+MoDIP **optimizes a network per input volume** (default **500 iterations**). This is the main risk:
+
+- **Time a CPU run first.** If a 500-iteration CPU run exceeds the CI time limit (default 2 h → DNF),
+  either:
+  - provide a **GPU runner** (GPU variant above), or
+  - **cap iterations** via `epoch_num` (e.g. `--set epoch_num=150`) and/or lower `base` — the
+    reference ships 100/200/500-iteration examples showing the trade-off.
+
+Record the chosen `epoch_num` default if you change it from 500.
+
+## 4. Files in this folder
+
+| File | Role |
+|------|------|
+| `algorithm.yml` | Manifest: stage `dipole`, image, `run: bash run.sh`, parameters (`epoch_num`, `lr`, `base`). |
+| `Dockerfile` | CPU PyTorch base + `git clone` MoDIP to `/opt/MoDIP` (no weights). Code is mounted, not COPYed. |
+| `run.sh` | Forces CPU, calls `modip_infer.py /input /output`. |
+| `modip_infer.py` | Loads localfield+mask+params, calls the repo's `inference.run_modip`, masks + writes `chimap.nii.gz` on the input affine. |
+| `README.md` | Method description, units, kernel, RUNTIME/GPU CAVEAT, assumptions. |

--- a/algorithms/modip/Dockerfile
+++ b/algorithms/modip/Dockerfile
@@ -1,0 +1,44 @@
+# MoDIP environment image — CPU-capable PyTorch, per-subject deep-image-prior QSM dipole inversion.
+#
+# MoDIP (github.com/sunhongfu/MoDIP; also mirrored in sunhongfu/deepMRI/MoDIP) is UNSUPERVISED:
+# there are NO pretrained weights to download. A small 3D U-Net (deep image prior) is optimized
+# directly on the input local field at inference time, driven by the QSM dipole forward model. So
+# this image only needs the method source + a PyTorch runtime — no weights step.
+#
+# We clone the repo at BUILD time (network is ON) into /opt/MoDIP so the run phase works fully
+# offline (--network none). We do NOT COPY the submission code — run.sh + modip_infer.py are mounted
+# at /algo at run time (QSM-CI execution model).
+#
+# CPU by default: we install the CPU PyTorch wheel and force CUDA off at run time. The reference is
+# GPU-oriented and per-subject optimization is expensive; see algorithms/modip/README.md
+# "RUNTIME/GPU CAVEAT". A GPU build would swap the torch index-url below.
+#
+# Build & push once (see algorithms/modip/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/modip:v1 algorithms/modip
+#   docker push ghcr.io/astewartau/qsm-ci/modip:v1
+FROM python:3.10-slim
+
+LABEL description="MoDIP — CPU-capable per-subject deep-image-prior QSM dipole inversion for QSM-CI"
+
+# git to clone the repo; libgomp1 for the PyTorch CPU (OpenMP) runtime; ca-certificates for TLS.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates git libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# CPU PyTorch wheel + NIfTI/array deps. Pin torch to the CPU index so no CUDA runtime is pulled in.
+RUN pip install --no-cache-dir \
+        "torch>=2.1.0" --index-url https://download.pytorch.org/whl/cpu \
+ && pip install --no-cache-dir \
+        "numpy>=1.23" \
+        "scipy>=1.10" \
+        "nibabel>=5.0"
+
+# Clone MoDIP (no weights — the network is optimized per subject at run time) into /opt/MoDIP.
+# Pin a ref for reproducibility (override with --build-arg MODIP_REF=<sha>).
+ARG MODIP_REF=master
+RUN git clone https://github.com/sunhongfu/MoDIP /opt/MoDIP \
+ && git -C /opt/MoDIP checkout "$MODIP_REF"
+ENV MODIP_HOME="/opt/MoDIP"
+
+# Force CPU + quiet threads at run time (override MODIP_HOME / device if building a GPU variant).
+ENV CUDA_VISIBLE_DEVICES="-1"

--- a/algorithms/modip/README.md
+++ b/algorithms/modip/README.md
@@ -1,0 +1,102 @@
+# MoDIP
+
+Model-based **deep image prior** for QSM **dipole inversion** — an **unsupervised / untrained**
+deep-learning method that optimizes a network **per subject** at inference time (no pretrained
+weights).
+
+> **STATUS: scaffold — needs image build + push (human).** The container image
+> `ghcr.io/astewartau/qsm-ci/modip:v1` has not been built or pushed yet, and this scaffold has not
+> been run end-to-end. See `BUILD.md` and the checklist below.
+
+- **Stage:** `dipole` (localfield → chimap, ppm)
+- **Engine:** [MoDIP](https://github.com/sunhongfu/MoDIP) — PyTorch, per-subject deep-image-prior
+  optimization. **CPU by default** here (reference is GPU-oriented — see RUNTIME/GPU CAVEAT).
+- **Reference:** Xiong Z., Gao Y., Liu Y., Fazlollahi A., Nestor P., Liu F., Sun H. *Quantitative
+  susceptibility mapping through model-based deep image prior (MoDIP).* NeuroImage 291:120583, 2024.
+  DOI: [10.1016/j.neuroimage.2024.120583](https://doi.org/10.1016/j.neuroimage.2024.120583)
+  (Note: the DOI in the submission brief, …120540, did not resolve to this paper; the verified DOI is
+  …120583.)
+- **Also mirrored in:** `sunhongfu/deepMRI/MoDIP`.
+
+## What it does
+
+MoDIP wraps a small 3D U-Net (a *deep image prior*) inside the QSM **dipole forward model**. It loads
+**no trained weights**; instead, for each input volume it **optimizes** the network so that the
+susceptibility it predicts, convolved with the dipole kernel, reproduces the input local field. A
+gradient-domain (Laplacian/Sobel) term regularizes the fit. After `epoch_num` iterations the final
+susceptibility is de-meaned over the foreground and written out. This makes it **subject-specific**
+and free of the generalization concerns of pretrained networks — at the cost of per-volume runtime.
+
+## Why `dipole`
+
+MoDIP maps a **local (tissue) field** directly to **susceptibility** using the dipole kernel — it is
+purely a dipole inversion (no field-mapping or background-field removal). So it consumes `localfield`
+and produces `chimap`: the `dipole` stage. The repo's `run.py --input_type phi` and
+`inference.run_modip(lfs_nii_path=...)` take exactly the local field map.
+
+## Units & kernel
+
+- **Input/output units.** QSM-CI `localfield` is the local/tissue field already in **ppm** (per
+  `CONTRACT.md`), which is MoDIP's expected local-field input; fed unchanged. Output susceptibility
+  is **ppm**, written unchanged on the input affine.
+- **Dipole kernel.** Built internally by the repo's `utils.handy.generate_dipole` from the **B0
+  direction** (`z_prjs`) and **voxel size** (`vox`) — the standard k-space kernel
+  `1/3 − (k·B̂0)²/|k|²`. We pass B0 direction from `params.json` / `QSMCI_B0_DIR` and voxel size from
+  the NIfTI header (falling back to `params.json` / `QSMCI_VOXEL_SIZE`).
+
+## How QSM-CI runs it
+
+```bash
+bash run.sh                       # -> python modip_infer.py /input /output
+```
+
+`modip_infer.py` calls the repo's `inference.run_modip` (its own optimization loop), then intersects
+the output with the QSM-CI brain mask and writes `chimap.nii.gz` on the input affine.
+
+## Parameters (`algorithm.yml`)
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `epoch_num` | 500 | Per-subject optimization iterations (reference default). Main runtime/quality knob. |
+| `lr` | 5e-4 | Adam learning rate (reference default). |
+| `base` | 32 | DIP U-Net base channel count (reference default). Lower = less memory/compute. |
+
+These are legitimate reference **defaults** (not tuned values). Overrides arrive via
+`/input/config.json` or `QSMCI_SET_*` and fall back to these defaults.
+
+## RUNTIME / GPU CAVEAT  ⚠️
+
+This is the key benchmark-fit risk. Unlike a pretrained network (one forward pass), MoDIP **trains a
+network on every input volume** — the reference default is **500 optimization iterations** over the
+whole 3D volume, each iteration doing FFT-based dipole convolutions and a full U-Net forward/backward
+pass. The reference targets an **NVIDIA GPU**. Consequences for QSM-CI:
+
+- **On CPU (the default here), a full 500-iteration run may be very slow and can exceed the CI time
+  limit (default 2 h wall-clock → DNF).** This has **not** been timed on the CI phantom yet.
+- Mitigations the human should consider: **(a)** provide a **GPU runner** (drop
+  `CUDA_VISIBLE_DEVICES=-1`, build a CUDA torch wheel); or **(b)** cap iterations by lowering
+  `epoch_num` (e.g. 100–200) — the reference README explicitly supports fewer iterations, and ships
+  `result100.nii`/`result200.nii`/`result500.nii` as examples of the quality/iteration trade-off;
+  and/or lower `base` to reduce memory/compute.
+
+## Assumptions to verify
+
+1. **localfield is in ppm** (per `CONTRACT.md`) — no unit rescale applied.
+2. **Mask.** MoDIP derives its own foreground as `(localfield != 0)`; we additionally intersect the
+   result with the provided QSM-CI `mask.nii.gz`. Confirm the local field's zero-background matches
+   the mask closely enough (MoDIP crops the nonzero bounding box for memory).
+3. **B0 direction** taken from `params.json` / `QSMCI_B0_DIR` (default `[0,0,1]`); **voxel size**
+   from the NIfTI header. Verify these agree with the challenge data's true acquisition geometry.
+4. **De-meaning.** MoDIP subtracts the foreground mean from the output (QSM is defined up to a
+   constant). QSM-CI's scorer detrends/compares accordingly, but confirm no additional referencing
+   is expected.
+5. **CPU feasibility / timeout** — untested; see RUNTIME/GPU CAVEAT.
+
+## Human checklist to finish
+
+- [ ] Build & push the image: `docker build -t ghcr.io/astewartau/qsm-ci/modip:v1 algorithms/modip && docker push ...` (pin `MODIP_REF` to a commit SHA for reproducibility).
+- [ ] Run once locally on a `qsm-forward` phantom (`qsm-ci run modip --localfield lf.nii.gz --mask mask.nii.gz --params params.json --truth chi.nii.gz`) to confirm plumbing + units + scale.
+- [ ] **Time a CPU run** and decide: GPU runner vs. lower `epoch_num` (iteration cap) to fit the CI time limit.
+- [ ] Verify output scale/sign against a known-good QSM (de-meaning + ppm).
+
+_Citations/DOIs are best-effort and should be verified._

--- a/algorithms/modip/algorithm.yml
+++ b/algorithms/modip/algorithm.yml
@@ -1,0 +1,41 @@
+name: MoDIP
+slug: modip
+stage: dipole
+description: >
+  MoDIP — model-based deep image prior for QSM dipole inversion. UNSUPERVISED / untrained: no
+  pretrained weights are loaded — a small 3D U-Net (deep image prior) is optimized per-subject at
+  inference time to fit the input local field through the QSM dipole forward model, with a
+  gradient-domain regularizer. Consumes the local (tissue) field in ppm and produces susceptibility
+  (ppm). The dipole kernel is built internally from the B0 direction and voxel size. Runs CPU-only by
+  default (the reference is GPU-oriented; see RUNTIME/GPU CAVEAT in README). Because it optimizes per
+  input volume, runtime is long (hundreds of iterations).
+authors:
+- name: Xiong Z.
+- name: Gao Y.
+- name: Liu Y.
+- name: Fazlollahi A.
+- name: Nestor P.
+- name: Liu F.
+- name: Sun H.
+# DOI verified via PubMed/ScienceDirect: NeuroImage vol. 291, article 120583 (2024). The DOI given in
+# the submission brief (…120540) did not resolve to this paper; using the verified 120583.
+doi: 10.1016/j.neuroimage.2024.120583
+code_url: https://github.com/sunhongfu/MoDIP
+# The MoDIP repo ships NO LICENSE file. Treat as academic use; cite the paper.
+license: none declared (no LICENSE in repo); academic use, cite the paper
+image: ghcr.io/astewartau/qsm-ci/modip:v1
+run: bash run.sh
+parameters:
+- name: epoch_num
+  default: 500
+  description: >
+    Number of per-subject optimization iterations (reference default 500). Fewer iterations run
+    faster but under-fit; this is the main knob for trading runtime against quality on CPU.
+- name: lr
+  default: 0.0005
+  description: Adam learning rate for the deep-image-prior optimization (reference default 5e-4).
+- name: base
+  default: 32
+  description: >
+    Base channel count of the DIP U-Net (reference default 32). Lower reduces memory/compute
+    (the reference README suggests decreasing base and increasing iterations under memory pressure).

--- a/algorithms/modip/modip_infer.py
+++ b/algorithms/modip/modip_infer.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""QSM-CI wrapper for MoDIP dipole inversion (stage = dipole), CPU by default.
+
+Consumes  /input/localfield.nii.gz, /input/mask.nii.gz, /input/params.json
+Produces  /output/chimap.nii.gz  (susceptibility, ppm)
+
+MoDIP (Xiong, Gao, Sun, NeuroImage 2024; github.com/sunhongfu/MoDIP) is an UNSUPERVISED /
+untrained method: it loads NO pretrained weights. A small 3D U-Net (deep image prior) is optimized
+per-subject at inference time so that its output susceptibility, pushed through the QSM dipole
+forward model, matches the input local field (plus a gradient-domain regularizer). Because of this,
+each run performs `epoch_num` optimization iterations and is expensive — see README RUNTIME/GPU
+CAVEAT.
+
+We reuse the repo's own optimization loop, `inference.run_modip`, which:
+  * loads the local field NIfTI (get_fdata),
+  * builds its OWN foreground mask as (data != 0) and crops the zero background bounding box,
+  * builds the dipole kernel internally from `z_prjs` (B0 direction) and `vox` (voxel size) via
+    utils.handy.generate_dipole,
+  * optimizes ModelBasedDIPNet for `epoch_num` iterations (Adam, StepLR),
+  * de-means the final susceptibility over the foreground, and
+  * writes the result on the INPUT NIfTI affine.
+
+Units. QSM-CI's localfield.nii.gz is the tissue/local field already in ppm (normalized by B0), which
+is exactly MoDIP's expected local-field input (its `--input_type phi` / `is_field` local field). It
+is fed unchanged and the output susceptibility is in ppm, written unchanged.
+
+Device. run_modip picks cuda if torch.cuda.is_available() else cpu. run.sh sets
+CUDA_VISIBLE_DEVICES=-1 to force CPU under CI (like the other subs). Set it otherwise for a GPU run.
+
+B0 direction / voxel size come from params.json / QSMCI_* env vars, matching the other submissions.
+
+ASSUMPTIONS (see README):
+  * localfield is in ppm (per CONTRACT.md) — no unit rescale.
+  * MoDIP's internal mask = (localfield != 0). We additionally intersect with the QSM-CI mask when
+    writing, so voxels outside the provided brain mask are zeroed.
+  * B0_dir defaults to [0,0,1] and voxel_size falls back to the NIfTI header zooms.
+"""
+import json
+import os
+import sys
+
+import numpy as np
+import nibabel as nib
+
+IN = sys.argv[1] if len(sys.argv) > 1 else "/input"
+OUT = sys.argv[2] if len(sys.argv) > 2 else "/output"
+
+MODIP_HOME = os.environ.get("MODIP_HOME", "/opt/MoDIP")
+# inference.py imports `from models...` / `from utils...` relative to its own dir; add repo to path.
+sys.path.insert(0, MODIP_HOME)
+
+from inference import run_modip  # noqa: E402  (import after sys.path setup)
+
+
+def _load_params():
+    params = {}
+    ppath = os.path.join(IN, "params.json")
+    if os.path.exists(ppath):
+        with open(ppath) as fh:
+            params = json.load(fh)
+    return params
+
+
+def _vec(env_name, key, params, default):
+    env = os.environ.get(env_name)
+    if env:
+        return [float(v) for v in env.split()]
+    if key in params and params[key] is not None:
+        return [float(v) for v in params[key]]
+    return list(default)
+
+
+def _override(name, params_cfg, default, cast):
+    """config.json / QSMCI_SET_<NAME> override for a declared parameter, else default."""
+    env = os.environ.get("QSMCI_SET_" + name.upper())
+    if env is not None:
+        return cast(env)
+    if name in params_cfg and params_cfg[name] is not None:
+        return cast(params_cfg[name])
+    return default
+
+
+def main():
+    localfield_path = os.path.join(IN, "localfield.nii.gz")
+    mask_path = os.path.join(IN, "mask.nii.gz")
+
+    lfs_img = nib.load(localfield_path)
+    mask = (np.asarray(nib.load(mask_path).dataobj) > 0).astype(np.float32)
+
+    params = _load_params()
+
+    voxel_size = _vec("QSMCI_VOXEL_SIZE", "voxel_size", params, [1.0, 1.0, 1.0])
+    b0_dir = _vec("QSMCI_B0_DIR", "B0_dir", params, [0.0, 0.0, 1.0])
+    # Prefer the affine-derived voxel size when it is well-defined (matches the NIfTI grid).
+    hdr_zooms = [float(z) for z in lfs_img.header.get_zooms()[:3]]
+    if hdr_zooms and all(z > 0 for z in hdr_zooms):
+        voxel_size = hdr_zooms
+
+    # Optional overrides for declared parameters (config.json / QSMCI_SET_*).
+    cfg = {}
+    cfgp = os.path.join(IN, "config.json")
+    if os.path.exists(cfgp):
+        with open(cfgp) as fh:
+            cfg = json.load(fh)
+    epoch_num = _override("epoch_num", cfg, 500, int)
+    lr = _override("lr", cfg, 5e-4, float)
+    base = _override("base", cfg, 32, int)
+
+    print(
+        f"MoDIP: localfield {lfs_img.shape}, voxel_size {voxel_size}, B0_dir {b0_dir}, "
+        f"epoch_num {epoch_num}, lr {lr}, base {base}",
+        flush=True,
+    )
+
+    os.makedirs(OUT, exist_ok=True)
+
+    # run_modip loads the field, builds the dipole from b0_dir+vox, optimizes the DIP for epoch_num
+    # iterations on the available device, and writes <output>/MoDIP.nii.gz on the input affine.
+    qsm_path = run_modip(
+        lfs_nii_path=localfield_path,
+        vox=list(voxel_size),
+        z_prjs=list(b0_dir),
+        epoch_num=epoch_num,
+        lr=lr,
+        base=base,
+        crop_background=True,
+        output_dir=OUT,
+    )
+
+    # Reload MoDIP's output, intersect with the QSM-CI brain mask, and write to the canonical
+    # chimap.nii.gz filename on the INPUT affine/header (voxel size + orientation preserved).
+    chi_img = nib.load(qsm_path)
+    chi = np.asarray(chi_img.get_fdata(), dtype=np.float32)
+    if chi.shape != mask.shape:
+        raise RuntimeError(
+            f"MoDIP output shape {chi.shape} != mask shape {mask.shape}; cannot mask/align."
+        )
+    chi = (chi * mask).astype(np.float32)
+
+    out_path = os.path.join(OUT, "chimap.nii.gz")
+    nib.Nifti1Image(chi, lfs_img.affine, lfs_img.header).to_filename(out_path)
+    print("MoDIP: wrote", out_path, chi.shape, "ppm", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/modip/run.sh
+++ b/algorithms/modip/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# QSM-CI submission — MoDIP (dipole stage), CPU by default.
+#
+# MoDIP is an UNSUPERVISED / untrained model-based deep-image-prior dipole inversion: it loads NO
+# pretrained weights. A small 3D U-Net is OPTIMIZED per-subject at run time to fit the input local
+# field through the QSM dipole forward model. Stage = dipole:
+#   consumes  localfield.nii.gz, mask.nii.gz, params.json   ->   produces  chimap.nii.gz
+#
+# Units. The QSM-CI localfield is the tissue field already in ppm (normalized by B0), which is
+# MoDIP's expected local-field input. It is fed unchanged; the output susceptibility (ppm) is written
+# unchanged, on the input affine.
+#
+# The B0 direction (for the internally-generated dipole kernel) and voxel size are passed through
+# from params.json / env vars:  $QSMCI_B0_DIR  $QSMCI_VOXEL_SIZE (mm).
+#
+# RUNTIME/GPU CAVEAT: per-subject optimization (default 500 iterations) is expensive and the
+# reference is GPU-oriented. On CPU this may be slow or exceed the CI time limit — see README. Force
+# CPU here for parity with the other subs; a GPU runner or a lower epoch_num may be needed to fit CI.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+
+export CUDA_VISIBLE_DEVICES="-1"                         # force CPU
+export MODIP_HOME="${MODIP_HOME:-/opt/MoDIP}"
+
+mkdir -p "$OUT"
+
+# modip_infer.py loads localfield + mask, drives the repo's inference.run_modip optimization loop
+# (dipole built from B0 direction + voxel size), then writes χ to chimap.nii.gz (ppm).
+python "$(dirname "$0")/modip_infer.py" "$IN" "$OUT"

--- a/algorithms/ndi/BUILD.md
+++ b/algorithms/ndi/BUILD.md
@@ -1,0 +1,40 @@
+# Building ndi (compiled MATLAB → MATLAB Runtime)
+
+Compile `recon.m` on a machine with **MATLAB + MATLAB Compiler** (R2026a). Runs license-free on the
+MATLAB Runtime. Same patterns as `matlab-tkd` (bundled NIfTI toolbox, OS gzip), plus Carlos
+Milovic's **FANSI toolbox** (`ndi.m` and its deps).
+
+Stage: `dipole` — consumes `localfield` (ppm), `mask`, `params`; nonlinear gradient-descent
+inversion (`ndi`) → `chimap` (ppm).
+
+> **Shared image.** `ndi` shares `ghcr.io/astewartau/qsm-ci/fansi:v1` with `fansi`, `l1-qsm`,
+> `wh-qsm` (all one FANSI toolbox). `mcc` bundles the traced FANSI functions into `recon`, so the
+> toolbox is build-time only. Either build one image per submission (each COPYs its own `recon`) or
+> bake all four binaries under distinct names into the single shared image. See `../fansi/BUILD.md`.
+
+## 1. Fetch build-time deps (not committed)
+```bash
+cp -r /path/to/NIfTI_20140122               algorithms/ndi/nifti   # Jimmy Shen toolbox
+git clone https://gitlab.com/cmilovic/FANSI-toolbox algorithms/ndi/fansi   # FANSI toolbox
+```
+
+## 2. Compile
+```bash
+cd algorithms/ndi
+matlab -batch "addpath('nifti'); addpath(genpath('fansi')); mcc('-m','recon.m','-o','recon','-d','.')"   # -> ./recon
+```
+`mcc` traces `ndi`, `susc2field`, `dipole_kernel_angulated` and their deps.
+
+## 3. Bake the MCR image and push
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/fansi:v1 .
+docker push  ghcr.io/astewartau/qsm-ci/fansi:v1
+```
+Then make the GHCR package public.
+
+## Units
+`localfield` is ppm; `ndi.m` works in radians (nonlinear `sin` data term). `recon.m` converts
+`phase_rad = field * 2*pi*42.58*B0*TE` and divides the output by the same `phs_scale` to return
+ppm, per the `ndi.m` header ("input/output in radians").
+
+> No MATLAB Compiler license? See Option B in [`docs/matlab.md`](../../docs/matlab.md).

--- a/algorithms/ndi/README.md
+++ b/algorithms/ndi/README.md
@@ -1,0 +1,34 @@
+# NDI — Nonlinear Dipole Inversion (MATLAB)
+
+**STATUS: scaffold — needs image build (MATLAB Compiler license required).** Source is complete;
+the compiled `recon` binary and pushed image are the human's job (see `BUILD.md`).
+
+## What it does
+Nonlinear Dipole Inversion (Polak/Bilgic et al., *NMR Biomed* 2020, doi:10.1002/nbm.4271) — a
+gradient-descent QSM solver with a nonlinear data-fidelity term, promoted as essentially
+**parameter-tuning-free**. Implementation is `ndi.m` from Carlos Milovic's **FANSI toolbox**.
+
+- **Stage:** `dipole` — consumes `localfield` (ppm), `mask`, `params`; produces `chimap` (ppm).
+
+## Units handling
+`ndi.m` uses a `sin(phi - phase)` data term, so the input must be in **radians**. `recon.m` converts
+`phase_rad = field * 2*pi * 42.58 * B0 * TE`, runs `ndi`, then divides the output by the same
+`phs_scale` to return **ppm** (the `ndi.m` header states input and output are both in radians).
+
+## Parameters (defaults = FANSI ndi.m defaults; NDI is designed to be tuning-free)
+| name | default | meaning |
+|------|---------|---------|
+| `tau` | 2.0 | gradient-descent step size |
+| `iterations` | 100 | gradient-descent iterations |
+| `alpha` | 1e-5 | small Tikhonov stabiliser |
+
+## Assumptions the human must verify
+- **Image is SHARED** with `fansi`, `l1-qsm`, `wh-qsm`: `ghcr.io/astewartau/qsm-ci/fansi:v1`
+  (see `BUILD.md`).
+- **DOI 10.1002/nbm.4271** is the NDI paper (Polak et al., *NMR Biomed* 2020); confirm before merge.
+- **`tau=2.0`** is `ndi.m`'s slightly-accelerated default; on the QSM-CI phantom's extreme sources it
+  could diverge. If so, drop `tau` toward 1.0 (the `ndi_auto.m` default) — verify on the phantom.
+- **Weighting:** binary mask (no magnitude at the dipole stage).
+- **GPU disabled** — scoring Runtime is CPU-only.
+- **License:** FANSI ships no LICENSE file (README: "academic and research" use, BSD-style
+  disclaimer) → `license: academic use; cite paper`.

--- a/algorithms/ndi/algorithm.yml
+++ b/algorithms/ndi/algorithm.yml
@@ -1,0 +1,36 @@
+name: NDI (MATLAB)
+slug: ndi
+stage: dipole
+description: Nonlinear Dipole Inversion (NDI) — a parameter-tuning-free gradient-descent
+  QSM solver with a nonlinear data-fidelity term. Implementation from Carlos Milovic's
+  FANSI toolbox (ndi.m). Compiled from MATLAB and run on the license-free MATLAB Runtime.
+  Consumes the local field and produces a susceptibility map.
+authors:
+- name: Daniel Polak
+- name: Itthi Chatnuntawech
+- name: Jaeyeon Yoon
+- name: Siddharth Srinivasan Iyer
+- name: Kawin Setsompop
+- name: Berkin Bilgic
+doi: 10.1002/nbm.4271
+citation: Polak et al., NMR Biomed 2020
+code_url: https://gitlab.com/cmilovic/FANSI-toolbox
+# FANSI-toolbox ships no LICENSE file; its README grants use "for academic and research
+# purposes" with a BSD-style warranty disclaimer.
+license: academic use; cite paper
+# Shared image with fansi/l1-qsm/wh-qsm (all one FANSI toolbox); see BUILD.md.
+image: ghcr.io/astewartau/qsm-ci/ndi:v1
+run: bash run.sh
+matlab:
+  entry: recon.m
+  runtime: r2026a
+parameters:
+- name: tau
+  default: 2.0
+  description: gradient-descent step size; larger converges faster but may diverge
+- name: iterations
+  default: 100
+  description: number of gradient-descent iterations
+- name: alpha
+  default: 0.00001
+  description: small Tikhonov regularization weight for numerical stability

--- a/algorithms/ndi/recon.m
+++ b/algorithms/ndi/recon.m
@@ -1,0 +1,76 @@
+function recon(inp, out)
+% QSM-CI `dipole` stage in MATLAB — Nonlinear Dipole Inversion (NDI).
+% Polak/Bilgic et al., NMR Biomed 2020; implementation from Carlos Milovic's FANSI toolbox (ndi.m).
+% Reads <inp>/localfield.nii.gz (ppm) + mask + params.json, writes <out>/chimap.nii.gz (ppm).
+%
+% Bundled: Jimmy Shen NIfTI toolbox + FANSI toolbox (installed at /opt/fansi in the image, added to
+% path at compile time — see BUILD.md). OS gunzip/gzip (compiled binaries have no JVM).
+% NDI is essentially parameter-tuning-free; optional <inp>/config.json overrides {tau, iterations,
+% alpha} are exposed for experimentation.
+%
+% UNITS — CRITICAL. ndi.m uses a nonlinear data term sin(phix - phase); its input field MUST be in
+% RADIANS. We convert ppm -> radians with phs_scale = 2*pi * 42.58 * B0 * TE (42.58 MHz/T absorbs
+% the ppm 1e6 factor), run the solver, then divide the output by the SAME phs_scale to return ppm
+% (out.x is in radians, i.e. the same scaled units as the input). See ndi.m header.
+
+    p   = jsondecode(fileread(fullfile(inp, 'params.json')));
+    b0  = p.B0_dir(:)'; b0 = b0 / norm(b0);
+    vox = p.voxel_size(:)';
+    B0T = p.B0;                       % field strength (Tesla)
+    TE  = p.TE(:)';  TE = TE(1);      % first echo time (s)
+
+    % NDI is tuning-free; these are the FANSI ndi.m defaults, exposed for override.
+    cfg = struct('tau', 2.0, 'iterations', 100, 'alpha', 1e-5);
+    cf_file = fullfile(inp, 'config.json');
+    if exist(cf_file, 'file')
+        u = jsondecode(fileread(cf_file));
+        for f = fieldnames(u)', cfg.(f{1}) = u.(f{1}); end
+    end
+
+    % --- inputs ---
+    nlf   = read_niigz(fullfile(inp, 'localfield.nii.gz'));
+    field = double(nlf.img);                                     % local field, ppm
+    mask  = double(getfield(read_niigz(fullfile(inp, 'mask.nii.gz')), 'img')) > 0.5;
+
+    N = size(field);
+
+    % ppm -> radians (see UNITS note above)
+    GYRO_MHz = 42.58;
+    phs_scale = 2*pi * GYRO_MHz * B0T * TE;
+    phase_rad = field * phs_scale;
+
+    kernel = dipole_kernel_angulated(N, vox, b0);
+
+    params = [];
+    params.input        = single(phase_rad);
+    params.K            = single(kernel);
+    params.weight       = single(mask);          % no magnitude at dipole stage -> mask weighting
+    params.tau          = cfg.tau;
+    params.alpha        = cfg.alpha;
+    params.maxOuterIter = cfg.iterations;
+    params.isGPU        = false;                  % MATLAB Runtime CPU-only at scoring time
+
+    outs = ndi(params);
+
+    chi = double(outs.x) / phs_scale;             % radians -> ppm
+    chi = chi .* mask;
+
+    nlf.img = single(chi);
+    nlf.hdr.dime.datatype = 16;  nlf.hdr.dime.bitpix = 32;
+    nlf.hdr.dime.dim(1) = 3;  nlf.hdr.dime.dim(5) = 1;
+    write_niigz(nlf, fullfile(out, 'chimap.nii.gz'));
+end
+
+function nii = read_niigz(f)
+    t = [tempname '.nii'];
+    system(sprintf('gunzip -c ''%s'' > ''%s''', f, t));
+    nii = load_untouch_nii(t);
+    delete(t);
+end
+
+function write_niigz(nii, f)
+    t = [tempname '.nii'];
+    save_untouch_nii(nii, t);
+    system(sprintf('gzip -c ''%s'' > ''%s''', t, f));
+    delete(t);
+end

--- a/algorithms/ndi/run.sh
+++ b/algorithms/ndi/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary is either baked into the image at /opt/qsm-ci/recon (recommended) or committed
+# alongside this script and mounted at /algo. No network needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/algorithms/wh-qsm/BUILD.md
+++ b/algorithms/wh-qsm/BUILD.md
@@ -1,0 +1,45 @@
+# Building wh-qsm (compiled MATLAB → MATLAB Runtime)
+
+Compile `recon.m` on a machine with **MATLAB + MATLAB Compiler** (R2026a). Runs license-free on the
+MATLAB Runtime. Same patterns as `matlab-tkd` (bundled NIfTI toolbox, OS gzip), plus Carlos
+Milovic's **FANSI toolbox** (`WH_nlTV.m` and its deps).
+
+Stage: `dipole` — consumes `localfield` (ppm), `mask`, `params`; joint susceptibility + residual
+harmonic-field inversion (`WH_nlTV`) → `chimap` (ppm).
+
+> **Why `dipole`, not `bfr+dipole`.** WH-QSM consumes the **local** field and removes only the
+> *residual/remnant* background field left over after BFR, jointly with the inversion (see the
+> `WH_nlTV.m` header: "remove background field remnants from *local* field maps and calculate the
+> susceptibility of tissues simultaneously"). It is not a full background-field-removal step and
+> does not take the total field, so it belongs at the `dipole` stage.
+
+> **Shared image.** `wh-qsm` shares `ghcr.io/astewartau/qsm-ci/fansi:v1` with `fansi`, `ndi`,
+> `l1-qsm` (all one FANSI toolbox). `mcc` bundles the traced functions into `recon`, so the toolbox
+> is build-time only. Build one image per submission (each COPYs its own `recon`) or bake all four
+> binaries under distinct names into the single shared image. See `../fansi/BUILD.md`.
+
+## 1. Fetch build-time deps (not committed)
+```bash
+cp -r /path/to/NIfTI_20140122               algorithms/wh-qsm/nifti   # Jimmy Shen toolbox
+git clone https://gitlab.com/cmilovic/FANSI-toolbox algorithms/wh-qsm/fansi   # FANSI toolbox
+```
+
+## 2. Compile
+```bash
+cd algorithms/wh-qsm
+matlab -batch "addpath('nifti'); addpath(genpath('fansi')); mcc('-m','recon.m','-o','recon','-d','.')"   # -> ./recon
+```
+
+## 3. Bake the MCR image and push
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/fansi:v1 .
+docker push  ghcr.io/astewartau/qsm-ci/fansi:v1
+```
+Then make the GHCR package public.
+
+## Units
+`localfield` is ppm; `WH_nlTV.m` works in radians (nonlinear `sin` data term). `recon.m` converts
+`phase_rad = field * 2*pi*42.58*B0*TE` and divides the susceptibility output by the same `phs_scale`
+to return ppm.
+
+> No MATLAB Compiler license? See Option B in [`docs/matlab.md`](../../docs/matlab.md).

--- a/algorithms/wh-qsm/README.md
+++ b/algorithms/wh-qsm/README.md
@@ -1,0 +1,51 @@
+# WH-QSM — Weak-Harmonic QSM (MATLAB)
+
+**STATUS: scaffold — needs image build (MATLAB Compiler license required).** Source is complete;
+the compiled `recon` binary and pushed image are the human's job (see `BUILD.md`).
+
+## What it does
+Weak-Harmonic QSM (Milovic et al., *MRM* 2019, doi:10.1002/mrm.27483). A dipole inversion that
+**jointly** estimates the susceptibility map and a residual *harmonic* (background) field that
+survived background-field removal — correcting imperfect BFR during the inversion. TV regularized;
+implementation is `WH_nlTV.m` from Carlos Milovic's **FANSI toolbox**.
+
+## Stage — `dipole` (justification)
+WH-QSM consumes the **local field**, not the total field. Its purpose is to mop up *remnant*
+background field in an already-BFR'd local field map, jointly with inversion. The `WH_nlTV.m` header
+states it "remove[s] background field remnants from *local* field maps and calculate[s] the
+susceptibility of tissues simultaneously." It is therefore a `dipole`-stage method (consumes
+`localfield`, produces `chimap`), **not** a `bfr+dipole` span (which would consume the *total*
+field). Chosen accordingly per `CONTRACT.md`.
+
+## Units handling
+`WH_nlTV.m` uses a `sin(z - phase)` data term → input in **radians**. `recon.m` converts
+`phase_rad = field * 2*pi * 42.58 * B0 * TE`, runs `WH_nlTV`, then divides the susceptibility output
+by the same `phs_scale` to return **ppm**. (WH_nlTV also returns `out.phi`, the harmonic field — not
+used here; only `chimap` is a QSM-CI artifact.)
+
+## Parameters
+| name | default | meaning |
+|------|---------|---------|
+| `alpha1` | 3e-4 | gradient L1 (TV) penalty |
+| `beta` | 150 | weak-harmonic constraint weight (WH_nlTV default) |
+| `mu1` | 3e-2 | gradient-consistency ADMM weight (= 100·alpha1) |
+| `iterations` | 300 | max ADMM outer iterations |
+| `tol_update` | 0.1 | convergence threshold (percent update) |
+
+## Assumptions the human must verify
+- **Stage = `dipole`** (see justification above). If the intent was to test WH-QSM as a
+  background-remnant remover fed the *total* field, that would instead be a `bfr+dipole` span with a
+  different recon; this scaffold implements the local-field (dipole) interpretation, which matches
+  the reference docstring.
+- **Image is SHARED** with `fansi`, `ndi`, `l1-qsm`: `ghcr.io/astewartau/qsm-ci/fansi:v1`
+  (see `BUILD.md`).
+- **`iterations=300`.** The `WH_nlTV.m` header warns the harmonic field needs *hundreds* of
+  iterations to converge (the plain default of 150 is "for testing"). 300 is a compromise; the human
+  should confirm convergence and watch the 2 h time limit on the full-size phantom.
+- **`beta=150`** is the WH_nlTV default; the best value comes from the parameter sweep.
+- **Weighting:** binary mask (no magnitude at the dipole stage); `params.mask` set for the ROI.
+- **GPU disabled** — scoring Runtime is CPU-only.
+- **DOI 10.1002/mrm.27483** — "Weak-harmonic regularization for QSM", Milovic et al. Confirmed via
+  Crossref (the task text said "MRM 2019").
+- **License:** FANSI ships no LICENSE file (README: "academic and research", BSD-style disclaimer) →
+  `license: academic use; cite paper`.

--- a/algorithms/wh-qsm/algorithm.yml
+++ b/algorithms/wh-qsm/algorithm.yml
@@ -1,0 +1,43 @@
+name: WH-QSM (MATLAB)
+slug: wh-qsm
+stage: dipole
+description: Weak-Harmonic QSM (WH-QSM) — dipole inversion that jointly estimates
+  susceptibility and a residual harmonic (background) field remaining in the local field
+  after background-field removal, correcting imperfect BFR during inversion. TV regularized,
+  from Carlos Milovic's FANSI toolbox (WH_nlTV.m). Compiled from MATLAB and run on the
+  license-free MATLAB Runtime.
+authors:
+- name: Carlos Milovic
+- name: Julio Acosta-Cabronero
+- name: José Miguel Pinto
+- name: Hendrik Mattern
+- name: Cristian Tejos
+- name: Karin Shmueli
+doi: 10.1002/mrm.27483
+citation: Milovic et al., Magn Reson Med 2019
+code_url: https://gitlab.com/cmilovic/FANSI-toolbox
+# FANSI-toolbox ships no LICENSE file; its README grants use "for academic and research
+# purposes" with a BSD-style warranty disclaimer.
+license: academic use; cite paper
+# Shared image with fansi/ndi/l1-qsm (all one FANSI toolbox); see BUILD.md.
+image: ghcr.io/astewartau/qsm-ci/wh-qsm:v1
+run: bash run.sh
+matlab:
+  entry: recon.m
+  runtime: r2026a
+parameters:
+- name: alpha1
+  default: 0.0003
+  description: gradient L1 (total-variation) penalty; larger = smoother, more regularized
+- name: beta
+  default: 150
+  description: weak-harmonic constraint weight (strength of the residual background-field model)
+- name: mu1
+  default: 0.03
+  description: gradient-consistency ADMM weight (recommended 100*alpha1)
+- name: iterations
+  default: 300
+  description: max ADMM outer iterations (WH needs many iterations for the harmonic field to converge)
+- name: tol_update
+  default: 0.1
+  description: convergence threshold on the normalized solution update (percent)

--- a/algorithms/wh-qsm/recon.m
+++ b/algorithms/wh-qsm/recon.m
@@ -1,0 +1,86 @@
+function recon(inp, out)
+% QSM-CI `dipole` stage in MATLAB — Weak-Harmonic QSM (WH-QSM).
+% Milovic et al., MRM 2019 (Weak-harmonic regularization, doi:10.1002/mrm.27483);
+% implementation from Carlos Milovic's FANSI toolbox (WH_nlTV.m).
+% Reads <inp>/localfield.nii.gz (ppm) + mask + params.json, writes <out>/chimap.nii.gz (ppm).
+%
+% STAGE = dipole (consumes the LOCAL field, not the total field). WH-QSM jointly estimates
+% susceptibility AND a residual/remnant harmonic (background) field that survived background-field
+% removal. Its own docstring: "used to remove background field remnants from *local* field maps and
+% calculate the susceptibility of tissues simultaneously." So it corrects imperfect BFR at the
+% dipole stage — it is NOT a full background-field-removal step and does NOT consume the total field.
+%
+% Bundled: Jimmy Shen NIfTI toolbox + FANSI toolbox (installed at /opt/fansi; added to path at
+% compile time — see BUILD.md). OS gunzip/gzip (compiled binaries have no JVM).
+% Optional <inp>/config.json overrides {alpha1, beta, mu1, iterations, tol_update}.
+%
+% UNITS — CRITICAL. WH_nlTV.m uses a nonlinear data term sin(z2 - phase); its input MUST be in
+% RADIANS. We convert ppm -> radians with phs_scale = 2*pi * 42.58 * B0 * TE, run the solver, then
+% divide the susceptibility output by the SAME phs_scale to return ppm (out.x is in radians).
+
+    p   = jsondecode(fileread(fullfile(inp, 'params.json')));
+    b0  = p.B0_dir(:)'; b0 = b0 / norm(b0);
+    vox = p.voxel_size(:)';
+    B0T = p.B0;                       % field strength (Tesla)
+    TE  = p.TE(:)';  TE = TE(1);      % first echo time (s)
+
+    % Defaults: FANSI-recommended alpha1; beta=150 (harmonic-constraint weight, WH_nlTV default);
+    % mu1 = 100*alpha1. Hundreds of iterations are recommended for the harmonic field to converge.
+    cfg = struct('alpha1', 3e-4, 'beta', 150, 'mu1', 3e-2, ...
+                 'iterations', 300, 'tol_update', 0.1);
+    cf_file = fullfile(inp, 'config.json');
+    if exist(cf_file, 'file')
+        u = jsondecode(fileread(cf_file));
+        for f = fieldnames(u)', cfg.(f{1}) = u.(f{1}); end
+    end
+
+    % --- inputs ---
+    nlf   = read_niigz(fullfile(inp, 'localfield.nii.gz'));
+    field = double(nlf.img);                                     % local field, ppm
+    mask  = double(getfield(read_niigz(fullfile(inp, 'mask.nii.gz')), 'img')) > 0.5;
+
+    N = size(field);
+
+    % ppm -> radians (see UNITS note above)
+    GYRO_MHz = 42.58;
+    phs_scale = 2*pi * GYRO_MHz * B0T * TE;
+    phase_rad = field * phs_scale;
+
+    kernel = dipole_kernel_angulated(N, vox, b0);
+
+    params = [];
+    params.input        = single(phase_rad);
+    params.K            = single(kernel);
+    params.alpha1       = cfg.alpha1;
+    params.beta         = cfg.beta;
+    params.mu1          = cfg.mu1;
+    params.mask         = single(mask);          % ROI for susceptibility / harmonic estimation
+    params.weight       = single(mask);          % no magnitude at dipole stage -> mask weighting
+    params.maxOuterIter = cfg.iterations;
+    params.tolUpdate    = cfg.tol_update;
+    params.isGPU        = false;                  % MATLAB Runtime CPU-only at scoring time
+
+    outs = WH_nlTV(params);
+
+    chi = double(outs.x) / phs_scale;             % radians -> ppm
+    chi = chi .* mask;
+
+    nlf.img = single(chi);
+    nlf.hdr.dime.datatype = 16;  nlf.hdr.dime.bitpix = 32;
+    nlf.hdr.dime.dim(1) = 3;  nlf.hdr.dime.dim(5) = 1;
+    write_niigz(nlf, fullfile(out, 'chimap.nii.gz'));
+end
+
+function nii = read_niigz(f)
+    t = [tempname '.nii'];
+    system(sprintf('gunzip -c ''%s'' > ''%s''', f, t));
+    nii = load_untouch_nii(t);
+    delete(t);
+end
+
+function write_niigz(nii, f)
+    t = [tempname '.nii'];
+    save_untouch_nii(nii, t);
+    system(sprintf('gzip -c ''%s'' > ''%s''', t, f));
+    delete(t);
+end

--- a/algorithms/wh-qsm/run.sh
+++ b/algorithms/wh-qsm/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary is either baked into the image at /opt/qsm-ci/recon (recommended) or committed
+# alongside this script and mounted at /algo. No network needed.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+# MATLAB Runtime extracts its CTF archive to MCR_CACHE_ROOT; the default ($HOME/.mcrCache*) is
+# not writable when the container runs as a mounted host UID with no home (e.g. GitHub-hosted
+# runners: "Could not access the MATLAB Runtime component cache"). Point it at a writable temp.
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+exec "$BIN" "$IN" "$OUT"    # the MCR wrapper sets LD_LIBRARY_PATH

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -22,6 +22,51 @@
       "parameters": []
     },
     {
+      "slug": "fansi",
+      "name": "FANSI (MATLAB)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "Fast Nonlinear Susceptibility Inversion (FANSI) \u2014 nonlinear total-variation regularized dipole inversion solved with ADMM, from the FANSI toolbox. Compiled from MATLAB and run on the license-free MATLAB Runtime. Consumes the local field and produces a susceptibility map.",
+      "citation": "Milovic et al., Magn Reson Med 2018",
+      "doi": "10.1002/mrm.27073",
+      "code_url": "https://gitlab.com/cmilovic/FANSI-toolbox",
+      "license": "academic use; cite paper",
+      "authors": [
+        "Carlos Milovic",
+        "Berkin Bilgic",
+        "Bo Zhao",
+        "Julio Acosta-Cabronero",
+        "Cristian Tejos"
+      ],
+      "parameters": [
+        {
+          "name": "alpha1",
+          "default": 0.0003,
+          "description": "gradient L1 (total-variation) penalty; larger = smoother, more regularized"
+        },
+        {
+          "name": "mu1",
+          "default": 0.03,
+          "description": "gradient-consistency ADMM weight (FANSI recommends 100*alpha1)"
+        },
+        {
+          "name": "iterations",
+          "default": 150,
+          "description": "maximum number of ADMM outer iterations"
+        },
+        {
+          "name": "tol_update",
+          "default": 0.1,
+          "description": "convergence threshold on the normalized solution update (percent)"
+        },
+        {
+          "name": "isTGV",
+          "default": 0,
+          "description": "0 = TV regularization (nlTV), 1 = TGV regularization (nlTGV)"
+        }
+      ]
+    },
+    {
       "slug": "harperella",
       "name": "HARPERELLA",
       "stage": "unwrap+bfr",
@@ -54,6 +99,49 @@
           "name": "tol",
           "default": "1e-4",
           "description": "tolerance"
+        }
+      ]
+    },
+    {
+      "slug": "hd-qsm",
+      "name": "HD-QSM (MATLAB)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "Hybrid Data-fidelity QSM (HD-QSM) \u2014 a two-stage linear dipole inversion. An L1 data-fidelity stage estimates a discrepancy map that re-weights a second L2 stage, combining robustness to inconsistencies with L2 smoothness. Compiled from MATLAB and run on the license-free MATLAB Runtime. Consumes the local field, produces a susceptibility map.",
+      "citation": "Lambert et al., Magn Reson Med 2022",
+      "doi": "10.1002/mrm.29218",
+      "code_url": "https://github.com/mglambert/HD-QSM",
+      "license": "MIT",
+      "authors": [
+        "Mathias Lambert",
+        "Carlos Milovic",
+        "Cristian Tejos"
+      ],
+      "parameters": [
+        {
+          "name": "alphaL2",
+          "default": 1.6406e-05,
+          "description": "L2-stage TV regularization weight (10^-4.785; from the HDQSM example)"
+        },
+        {
+          "name": "mu1L2",
+          "default": 0.00016406,
+          "description": "L2-stage gradient-consistency ADMM weight (recommended 10*alphaL2)"
+        },
+        {
+          "name": "iterationsL1",
+          "default": 20,
+          "description": "iterations of the L1 (first / discrepancy-estimation) stage"
+        },
+        {
+          "name": "iterationsL2",
+          "default": 80,
+          "description": "iterations of the L2 (second / final) stage"
+        },
+        {
+          "name": "tol_update",
+          "default": 1.0,
+          "description": "convergence threshold on the L2-stage normalized solution update (percent)"
         }
       ]
     },
@@ -127,6 +215,68 @@
       ]
     },
     {
+      "slug": "inr-qsm",
+      "name": "INR-QSM",
+      "stage": "dipole",
+      "engine": null,
+      "description": "INR-QSM \u2014 a subject-specific UNSUPERVISED deep-learning dipole inversion using an implicit neural representation. No pretrained weights: a sine-activated coordinate MLP (SIREN) is OPTIMIZED per-subject so that the susceptibility it represents, pushed through the QSM dipole forward model, reproduces the input local field, with edge-weighted TV and gradient-domain regularizers. Consumes the local (tissue) field in ppm and produces susceptibility (ppm). The dipole kernel is built from the B0 direction and voxel size. Runs CPU-only by default (the reference is GPU-oriented, ~10 GB VRAM; see RUNTIME/GPU CAVEAT in README). Because it optimizes per input volume with a patch-based non-local phase-compensation scheme, runtime is long.",
+      "citation": null,
+      "doi": "10.1016/j.media.2024.103173",
+      "code_url": "https://github.com/AMRI-Lab/INR-QSM",
+      "license": "none declared (no LICENSE in repo); academic use, cite the paper",
+      "authors": [
+        "Zhang M.",
+        "Feng R.",
+        "Li Z.",
+        "Feng J.",
+        "Wu Q.",
+        "Zhang Z.",
+        "Ma C.",
+        "Wu J.",
+        "Yan F.",
+        "Liu C.",
+        "Zhang Y.",
+        "Wei H."
+      ],
+      "parameters": [
+        {
+          "name": "epoch",
+          "default": 50,
+          "description": "Number of per-subject optimization epochs (reference config.py default 50). Main runtime/quality knob; fewer epochs run faster but under-fit.\n"
+        },
+        {
+          "name": "star_lr",
+          "default": 1e-05,
+          "description": "Starting Adam learning rate at the first epoch (reference default 1e-5)."
+        },
+        {
+          "name": "end_lr",
+          "default": 2e-07,
+          "description": "Final learning rate at the last epoch, reached by an exponential schedule (reference default 0.02e-5)."
+        },
+        {
+          "name": "hidden_dim_num",
+          "default": 512,
+          "description": "Width (neurons per layer) of the SIREN coordinate MLP (reference default 512)."
+        },
+        {
+          "name": "num_layers",
+          "default": 10,
+          "description": "Number of layers in the SIREN MLP (reference default 10)."
+        },
+        {
+          "name": "TV_weight",
+          "default": 0.15,
+          "description": "Weight of the edge-weighted total-variation regularizer (reference default 0.15)."
+        },
+        {
+          "name": "gd_weight",
+          "default": 1.0,
+          "description": "Weight of the gradient-domain data-consistency regularizer (reference default 1.0)."
+        }
+      ]
+    },
+    {
       "slug": "iqsm",
       "name": "iQSM",
       "stage": "end-to-end",
@@ -176,6 +326,29 @@
       "parameters": []
     },
     {
+      "slug": "ir2qsm",
+      "name": "IR2QSM",
+      "stage": "dipole",
+      "engine": null,
+      "description": "IR2QSM \u2014 a pretrained deep-learning dipole-inversion network (iterative Reverse Concatenations and Recurrent Modules). Consumes the local (tissue) field in ppm and produces susceptibility (ppm). The network is an \"IR2U-net\": a specially tailored 3D U-net iterated T=4 times, with reverse concatenations between iterations and a recurrent (SRU) middle module. Unlike QSMnet it applies NO dataset mean/std normalization \u2014 the local field in ppm is fed to the net directly and the output is already in ppm. Each dimension is zero-padded to a multiple of 8 (the U-net has 3 pool/deconv levels) and cropped back afterwards; trained at 1 mm isotropic. Runs CPU-only with PyTorch (no GPU).",
+      "citation": null,
+      "doi": "10.1002/mp.17747",
+      "code_url": "https://github.com/YangGaoUQ/IR2QSM",
+      "license": "No LICENSE file in the upstream repository; academic use only \u2014 cite the paper (arXiv:2406.12300). Confirm terms with the authors before redistribution.\n",
+      "authors": [
+        "Li M.",
+        "Chen C.",
+        "Xiong Z.",
+        "Liu Y.",
+        "Rong P.",
+        "Shan S.",
+        "Liu F.",
+        "Sun H.",
+        "Gao Y."
+      ],
+      "parameters": []
+    },
+    {
       "slug": "ismv",
       "name": "iSMV",
       "stage": "bfr",
@@ -207,6 +380,51 @@
           "name": "radius_factor",
           "default": 2.0,
           "description": "\u00d7 max voxel size"
+        }
+      ]
+    },
+    {
+      "slug": "l1-qsm",
+      "name": "L1-QSM (MATLAB)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "L1-norm data-fidelity QSM (also called PI-QSM) \u2014 nonlinear dipole inversion with an L1 data-fidelity term that is more robust to phase inconsistencies than the standard L2 (FANSI) term, plus TV regularization. Implementation from Carlos Milovic's FANSI toolbox (nlL1TV.m). Compiled from MATLAB and run on the license-free MATLAB Runtime.",
+      "citation": "Milovic et al., Magn Reson Med 2022 (L1-QSM)",
+      "doi": "10.1002/mrm.28957",
+      "code_url": "https://gitlab.com/cmilovic/FANSI-toolbox",
+      "license": "academic use; cite paper",
+      "authors": [
+        "Carlos Milovic",
+        "Berkin Bilgic",
+        "Bo Zhao",
+        "Cristian Tejos",
+        "Karin Shmueli"
+      ],
+      "parameters": [
+        {
+          "name": "alpha1",
+          "default": 0.0003,
+          "description": "gradient L1 (total-variation) penalty; larger = smoother, more regularized"
+        },
+        {
+          "name": "lambda",
+          "default": 1.0,
+          "description": "L1 data-fidelity strength (scales the fidelity weight); lambda<1 rejects more inconsistent voxels"
+        },
+        {
+          "name": "mu1",
+          "default": 0.03,
+          "description": "gradient-consistency ADMM weight (recommended 100*alpha1)"
+        },
+        {
+          "name": "iterations",
+          "default": 50,
+          "description": "maximum number of ADMM outer iterations"
+        },
+        {
+          "name": "tol_update",
+          "default": 1.0,
+          "description": "convergence threshold on the normalized solution update (percent)"
         }
       ]
     },
@@ -486,6 +704,43 @@
       ]
     },
     {
+      "slug": "modip",
+      "name": "MoDIP",
+      "stage": "dipole",
+      "engine": null,
+      "description": "MoDIP \u2014 model-based deep image prior for QSM dipole inversion. UNSUPERVISED / untrained: no pretrained weights are loaded \u2014 a small 3D U-Net (deep image prior) is optimized per-subject at inference time to fit the input local field through the QSM dipole forward model, with a gradient-domain regularizer. Consumes the local (tissue) field in ppm and produces susceptibility (ppm). The dipole kernel is built internally from the B0 direction and voxel size. Runs CPU-only by default (the reference is GPU-oriented; see RUNTIME/GPU CAVEAT in README). Because it optimizes per input volume, runtime is long (hundreds of iterations).",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2024.120583",
+      "code_url": "https://github.com/sunhongfu/MoDIP",
+      "license": "none declared (no LICENSE in repo); academic use, cite the paper",
+      "authors": [
+        "Xiong Z.",
+        "Gao Y.",
+        "Liu Y.",
+        "Fazlollahi A.",
+        "Nestor P.",
+        "Liu F.",
+        "Sun H."
+      ],
+      "parameters": [
+        {
+          "name": "epoch_num",
+          "default": 500,
+          "description": "Number of per-subject optimization iterations (reference default 500). Fewer iterations run faster but under-fit; this is the main knob for trading runtime against quality on CPU.\n"
+        },
+        {
+          "name": "lr",
+          "default": 0.0005,
+          "description": "Adam learning rate for the deep-image-prior optimization (reference default 5e-4)."
+        },
+        {
+          "name": "base",
+          "default": 32,
+          "description": "Base channel count of the DIP U-Net (reference default 32). Lower reduces memory/compute (the reference README suggests decreasing base and increasing iterations under memory pressure).\n"
+        }
+      ]
+    },
+    {
       "slug": "modl-qsm",
       "name": "MoDL-QSM",
       "stage": "dipole",
@@ -509,6 +764,42 @@
         "Wei H."
       ],
       "parameters": []
+    },
+    {
+      "slug": "ndi",
+      "name": "NDI (MATLAB)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "Nonlinear Dipole Inversion (NDI) \u2014 a parameter-tuning-free gradient-descent QSM solver with a nonlinear data-fidelity term. Implementation from Carlos Milovic's FANSI toolbox (ndi.m). Compiled from MATLAB and run on the license-free MATLAB Runtime. Consumes the local field and produces a susceptibility map.",
+      "citation": "Polak et al., NMR Biomed 2020",
+      "doi": "10.1002/nbm.4271",
+      "code_url": "https://gitlab.com/cmilovic/FANSI-toolbox",
+      "license": "academic use; cite paper",
+      "authors": [
+        "Daniel Polak",
+        "Itthi Chatnuntawech",
+        "Jaeyeon Yoon",
+        "Siddharth Srinivasan Iyer",
+        "Kawin Setsompop",
+        "Berkin Bilgic"
+      ],
+      "parameters": [
+        {
+          "name": "tau",
+          "default": 2.0,
+          "description": "gradient-descent step size; larger converges faster but may diverge"
+        },
+        {
+          "name": "iterations",
+          "default": 100,
+          "description": "number of gradient-descent iterations"
+        },
+        {
+          "name": "alpha",
+          "default": 1e-05,
+          "description": "small Tikhonov regularization weight for numerical stability"
+        }
+      ]
     },
     {
       "slug": "nextqsm",
@@ -976,6 +1267,52 @@
           "name": "min_radius_factor",
           "default": 0.0,
           "description": "\u00d7 max voxel size"
+        }
+      ]
+    },
+    {
+      "slug": "wh-qsm",
+      "name": "WH-QSM (MATLAB)",
+      "stage": "dipole",
+      "engine": null,
+      "description": "Weak-Harmonic QSM (WH-QSM) \u2014 dipole inversion that jointly estimates susceptibility and a residual harmonic (background) field remaining in the local field after background-field removal, correcting imperfect BFR during inversion. TV regularized, from Carlos Milovic's FANSI toolbox (WH_nlTV.m). Compiled from MATLAB and run on the license-free MATLAB Runtime.",
+      "citation": "Milovic et al., Magn Reson Med 2019",
+      "doi": "10.1002/mrm.27483",
+      "code_url": "https://gitlab.com/cmilovic/FANSI-toolbox",
+      "license": "academic use; cite paper",
+      "authors": [
+        "Carlos Milovic",
+        "Julio Acosta-Cabronero",
+        "Jos\u00e9 Miguel Pinto",
+        "Hendrik Mattern",
+        "Cristian Tejos",
+        "Karin Shmueli"
+      ],
+      "parameters": [
+        {
+          "name": "alpha1",
+          "default": 0.0003,
+          "description": "gradient L1 (total-variation) penalty; larger = smoother, more regularized"
+        },
+        {
+          "name": "beta",
+          "default": 150,
+          "description": "weak-harmonic constraint weight (strength of the residual background-field model)"
+        },
+        {
+          "name": "mu1",
+          "default": 0.03,
+          "description": "gradient-consistency ADMM weight (recommended 100*alpha1)"
+        },
+        {
+          "name": "iterations",
+          "default": 300,
+          "description": "max ADMM outer iterations (WH needs many iterations for the harmonic field to converge)"
+        },
+        {
+          "name": "tol_update",
+          "default": 0.1,
+          "description": "convergence threshold on the normalized solution update (percent)"
         }
       ]
     },


### PR DESCRIPTION
Adds 8 dipole-inversion submissions. Images are built and pushed to `ghcr.io/astewartau/qsm-ci/<slug>:v1` (all packages public) and smoke-tested offline on `data/sim/dev`.

## Methods (all `stage: dipole`)
| slug | method | image | corr (dev smoke) |
|---|---|---|---|
| fansi | FANSI nonlinear TV/TGV (Milovic 2018) | compiled MATLAB | 0.9986 |
| ndi | Nonlinear Dipole Inversion (Polak/Bilgic 2020) | compiled MATLAB | 0.9685 |
| l1-qsm | L1-QSM (Milovic 2022) | compiled MATLAB | — |
| wh-qsm | Weak-Harmonic QSM (Milovic 2019) | compiled MATLAB | — |
| hd-qsm | Hybrid Data-fidelity QSM (Lambert 2022) | compiled MATLAB | 0.9854 |
| ir2qsm | IR2QSM pretrained net (Li/Gao 2025) | PyTorch (CPU) | 0.9913 |
| inr-qsm | INR-QSM, per-subject INR (Zhang 2024) | PyTorch (CPU) | — |
| modip | MoDIP, untrained deep image prior (Xiong 2024) | PyTorch (CPU) | — |

## Notes
- Compiled-MATLAB (`fansi`/`ndi`/`l1-qsm`/`wh-qsm`/`hd-qsm`) + `ir2qsm` Dockerfiles are gitignored so CI **pulls** the pushed image (mcc binary / pretrained weights ship in the image, not git; IR2QSM's single-file Drive link is quota-blocked so weights are baked from the demo bundle). `inr-qsm`/`modip` Dockerfiles are tracked (CI-reproducible).
- `web/algorithms.json` regenerated (45 methods).
- Merging triggers a focused rescore of these 8 (isolated + composed combos).
- `inr-qsm`/`modip` are per-subject optimization; on CPU they may approach the 180 min/shard budget — will cap iterations if a shard times out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)