### PR TITLE
CI notes + self-hosted runner routing + fansi high-field fix

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -87,19 +87,50 @@ jobs:
     outputs:
       tasks: ${{ steps.gen.outputs.tasks }}
     steps:
+      - uses: actions/checkout@v7   # need algorithm.yml to read each method's `runner:` routing
       - id: gen
-        # slugs/full come in as env vars (not inlined) — the slugs JSON contains double quotes that
-        # would otherwise break the python -c "..." string in the focused branch.
         env:
           FULL: ${{ needs.scope.outputs.full }}
           SLUGS: ${{ needs.scope.outputs.slugs }}
           N: ${{ github.event.inputs.shards || '12' }}
         run: |
-          if [ "$FULL" = "true" ]; then
-            TASKS=$(python3 -c "import json,os;N=int(os.environ['N']);print(json.dumps([{'id':'s%02d'%i,'shard':'%d/%d'%(i,N)} for i in range(N)]))")
-          else
-            TASKS=$(python3 -c "import json,os;s=json.loads(os.environ['SLUGS']);print(json.dumps([{'id':'f-'+x,'focus':x} for x in s]))")
-          fi
+          TASKS=$(python3 - <<'PY'
+          import json, os, re, glob
+          full = os.environ['FULL'] == 'true'
+          # Per-task runner routing. A method may set `runner: self-hosted` in its algorithm.yml to run
+          # on QSM-CI's 31 GB private runners (more RAM, no 180-min hosted cap, 4 concurrent containers)
+          # instead of ubuntu-latest — needed by heavy DL/optimization methods. Only the two self-hosted
+          # runners run in parallel, so keep the self-hosted set small.
+          HOSTED     = {'runs_on': 'ubuntu-latest', 'timeout': 180, 'jobs': 2}
+          SELFHOSTED = {'runs_on': ['self-hosted', 'Linux', 'X64'], 'timeout': 360, 'jobs': 4}
+          def is_self_hosted(text):
+              m = re.search(r'^runner:[ \t]*(\S+)', text, re.M)
+              return bool(m and m.group(1) == 'self-hosted')
+          def route(slug):
+              try: t = open(f'algorithms/{slug}/algorithm.yml').read()
+              except FileNotFoundError: return HOSTED
+              return SELFHOSTED if is_self_hosted(t) else HOSTED
+          def all_self_hosted():
+              out = []
+              for p in sorted(glob.glob('algorithms/*/algorithm.yml')):
+                  slug = p.split('/')[1]
+                  if not slug.startswith('_') and is_self_hosted(open(p).read()):
+                      out.append(slug)
+              return out
+          if full:
+              # Full re-run: hosted shards score the whole matrix MINUS the self-hosted methods
+              # (pipeline.py --exclude), and each self-hosted method runs as its own focused job on the
+              # private runner (--focus). Union = the full matrix, every method on the right runner.
+              N = int(os.environ['N'])
+              sh = all_self_hosted()
+              excl = ','.join(sh)
+              tasks = [{'id': 's%02d' % i, 'shard': '%d/%d' % (i, N), 'exclude': excl, **HOSTED} for i in range(N)]
+              tasks += [{'id': 'f-' + s, 'focus': s, **SELFHOSTED} for s in sh]
+          else:
+              tasks = [{'id': 'f-' + s, 'focus': s, **route(s)} for s in json.loads(os.environ['SLUGS'])]
+          print(json.dumps(tasks))
+          PY
+          )
           echo "tasks=$TASKS" >>"$GITHUB_OUTPUT"
           echo "planned tasks: $TASKS"
 
@@ -109,8 +140,13 @@ jobs:
       fail-fast: false
       matrix:
         task: ${{ fromJson(needs.plan.outputs.tasks) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 180
+    # Runner, wall-clock budget and intra-job container parallelism are chosen per task by the plan
+    # job (ubuntu-latest/180/2 by default; the 31 GB self-hosted runners/360/4 for `runner: self-hosted`
+    # methods). QSM_CI_JOBS here overrides the workflow-level cap of 2 for self-hosted jobs.
+    runs-on: ${{ matrix.task.runs_on }}
+    timeout-minutes: ${{ matrix.task.timeout }}
+    env:
+      QSM_CI_JOBS: ${{ matrix.task.jobs }}
     steps:
       - uses: actions/checkout@v7
 
@@ -137,6 +173,7 @@ jobs:
           ARGS="--dataset $DS --mode both --runner docker --track $TRACK --emit-volumes --runs-out runs-${{ matrix.task.id }}.json"
           [ -n "${{ matrix.task.shard }}" ] && ARGS="$ARGS --shard ${{ matrix.task.shard }}"
           [ -n "${{ matrix.task.focus }}" ] && ARGS="$ARGS --focus ${{ matrix.task.focus }}"
+          [ -n "${{ matrix.task.exclude }}" ] && ARGS="$ARGS --exclude ${{ matrix.task.exclude }}"
           echo "== task ${{ matrix.task.id }}: pipeline.py $ARGS =="
           t0=$(date +%s)
           python scripts/pipeline.py $ARGS

--- a/algorithms/fansi/algorithm.yml
+++ b/algorithms/fansi/algorithm.yml
@@ -21,6 +21,12 @@ license: academic use; cite paper
 # they share a single compiled image (each has its own recon.m entry; see BUILD.md).
 image: ghcr.io/astewartau/qsm-ci/fansi:v1
 run: bash run.sh
+# Notes on how QSM-CI runs this method vs. its reference (shown on the submission page).
+ci_notes:
+- >
+  On high-field data with large field outliers, the ppm-to-radians phase scale is capped so FANSI's
+  nonlinear solver stays numerically stable (at the physical 7 T scale it otherwise diverges to NaN).
+  Well-behaved fields use the standard physical scale unchanged, so the inversion is unaffected there.
 matlab:
   entry: recon.m
   runtime: r2026a

--- a/algorithms/fansi/recon.m
+++ b/algorithms/fansi/recon.m
@@ -37,10 +37,17 @@ function recon(inp, out)
 
     N = size(field);
 
-    % ppm -> radians (see UNITS note above)
-    GYRO_MHz = 42.58;                       % gyromagnetic ratio, MHz/T (absorbs the ppm 1e6 factor)
-    phs_scale = 2*pi * GYRO_MHz * B0T * TE;
-    phase_rad = field * phs_scale;
+    % ppm -> radians (see UNITS note above). nlTV's nonlinear sin() data term diverges to NaN once
+    % |phase| approaches pi: the fixed physical scale 2*pi*gamma*B0*TE overflows at 7 T on fields with
+    % large outliers (the scoring phantom reaches ~0.8 ppm -> ~6 rad -> NaN by iter 3). Cap the scale
+    % so the max in-brain phase stays ~1.5 rad. FANSI is scale-consistent (chi = x/phs_scale), so on
+    % well-behaved fields the physical scale is used unchanged (e.g. the 3 T dev phantom, |field|<0.1
+    % ppm) and the inversion is identical; the cap only tames the pathological high-field case.
+    GYRO_MHz   = 42.58;                      % gyromagnetic ratio, MHz/T (absorbs the ppm 1e6 factor)
+    phys_scale = 2*pi * GYRO_MHz * B0T * TE;
+    fmax       = max(abs(field(mask)));      % largest in-brain |field| — drives the phase magnitude
+    phs_scale  = min(phys_scale, 1.5 / max(fmax, eps));
+    phase_rad  = field * phs_scale;
 
     % Dipole kernel (continuous, angulated for arbitrary B0 direction)
     kernel = dipole_kernel_angulated(N, vox, b0);

--- a/algorithms/inr-qsm/algorithm.yml
+++ b/algorithms/inr-qsm/algorithm.yml
@@ -29,6 +29,14 @@ code_url: https://github.com/AMRI-Lab/INR-QSM
 license: none declared (no LICENSE in repo); academic use, cite the paper
 image: ghcr.io/astewartau/qsm-ci/inr-qsm:v1
 run: bash run.sh
+# Route to QSM-CI's 31 GB self-hosted runner: the full-size CPU optimization OOMs GitHub's 16 GB
+# hosted box and needs more than the hosted 180-min budget. Only 2 self-hosted jobs run at once.
+runner: self-hosted
+# Notes on how QSM-CI runs this method vs. its reference (shown on the submission page).
+ci_notes:
+- >
+  Executed CPU-only. The reference optimizes per subject on an NVIDIA GPU with mixed precision, so
+  runtime here is substantially longer and not comparable to GPU timings.
 parameters:
 - name: epoch
   default: 50

--- a/algorithms/ir2qsm/algorithm.yml
+++ b/algorithms/ir2qsm/algorithm.yml
@@ -26,3 +26,11 @@ license: >
   (arXiv:2406.12300). Confirm terms with the authors before redistribution.
 image: ghcr.io/astewartau/qsm-ci/ir2qsm:v1
 run: bash run.sh
+# Notes on how QSM-CI runs this method vs. its reference (shown on the submission page).
+ci_notes:
+- >
+  Executed CPU-only on QSM-CI's runners (no GPU). IR2QSM is a GPU-oriented network, so wall-clock
+  runtime here is far longer than a GPU deployment and should not be read as the method's native speed.
+- >
+  The reference injects noise at inference through a CUDA-only operation; QSM-CI patches it to run on
+  CPU, so reconstructions are mildly stochastic and can vary slightly between runs.

--- a/algorithms/modip/algorithm.yml
+++ b/algorithms/modip/algorithm.yml
@@ -25,6 +25,14 @@ code_url: https://github.com/sunhongfu/MoDIP
 license: none declared (no LICENSE in repo); academic use, cite the paper
 image: ghcr.io/astewartau/qsm-ci/modip:v1
 run: bash run.sh
+# Route to QSM-CI's 31 GB self-hosted runner: the per-subject optimization exceeds the hosted
+# 180-min budget. Only 2 self-hosted jobs run at once.
+runner: self-hosted
+# Notes on how QSM-CI runs this method vs. its reference (shown on the submission page).
+ci_notes:
+- >
+  Executed CPU-only. The reference optimizes per subject on a GPU, so runtime here is substantially
+  longer and not comparable to GPU timings.
 parameters:
 - name: epoch_num
   default: 500

--- a/algorithms/wh-qsm/algorithm.yml
+++ b/algorithms/wh-qsm/algorithm.yml
@@ -22,6 +22,9 @@ license: academic use; cite paper
 # Shared image with fansi/ndi/l1-qsm (all one FANSI toolbox); see BUILD.md.
 image: ghcr.io/astewartau/qsm-ci/wh-qsm:v1
 run: bash run.sh
+# Route to QSM-CI's 31 GB self-hosted runner: the 300-iteration weak-harmonic solve exceeds the
+# hosted 180-min budget across its composed combos. Only 2 self-hosted jobs run at once.
+runner: self-hosted
 matlab:
   entry: recon.m
   runtime: r2026a

--- a/scripts/combo_sweep.py
+++ b/scripts/combo_sweep.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Combination (joint) parameter sweep for QSM-CI — does a method's ISOLATED-tuned value stay
+optimal once it's CHAINED behind another method?
+
+scripts/sweep.py tunes each method alone (fed ground-truth inputs). But in the composed matrix a
+dipole method inverts the *output field of a BFR method*, not the ground-truth local field — so its
+optimal regularisation may shift depending on which BFR feeds it. This script measures that: for each
+(bfr -> dipole) cell it runs the BFR once, then sweeps the downstream dipole's grid over that BFR's
+actual localfield and scores the final chimap's xSIM against ground truth.
+
+  python scripts/combo_sweep.py --dataset data/sim/dev [--bfr sharp,resharp] [--dipole tv,nltv]
+  python scripts/combo_sweep.py --dataset data/sim/dev --sweep-bfr   # also vary the BFR's own param
+
+Default strategy = "downstream" (hold the BFR at its default, sweep only the dipole): this is the
+cheap ~264-run probe that answers "does the dipole optimum move with the upstream BFR?". Pass
+--sweep-bfr to additionally vary a tunable BFR's parameter (recomputing its localfield per value) —
+the fuller joint grid. Results go to results/combo_sweep.json; scripts/combo_sweep_report.py reads
+them and prints, per cell, whether the isolated-tuned point coincides with the in-combination best.
+
+Field-mapping is held at the ground-truth totalfield ("gt" source) — neither field-map submission
+declares a tunable knob, so there is nothing to sweep on that axis. Spans (tgv, matlab-medi) are
+single-step and have no combination to tune; their isolated sweep already covers them.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as cf
+import itertools
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+EVAL = ROOT / "eval" / "qsm_eval.py"
+sys.path.insert(0, str(ROOT / "scripts"))
+from pipeline import (  # noqa: E402  reuse the exact composed-chain machinery
+    ARTIFACT_FILE, discover_algorithms, prepare_input, run_algo, _valid_mask,
+)
+from sweep import GRIDS, REFINE, combos, fmt, gt_sources  # noqa: E402  one grid definition, shared
+
+# Which stages each swept slug belongs to is decided from discover_algorithms(), not hardcoded — so
+# the split below is derived at runtime. GRIDS/REFINE already list every method with a tunable knob.
+
+_print_lock = threading.Lock()
+RUNNER = "docker"
+
+
+def score_chi_xsim(recon: Path, gt_dir: Path, mask: Path, work: Path) -> dict:
+    """Score a composed chimap's xSIM vs ground truth — same valid-mask + qsm_eval path as
+    pipeline.score / sweep.score_xsim, so combo numbers are comparable to the leaderboard's."""
+    sm = _valid_mask(recon, mask, work.with_suffix(".scoremask.nii.gz"))
+    out_json = work.with_suffix(".score.json")
+    cmd = [sys.executable, str(EVAL), "--recon", str(recon),
+           "--truth", str(gt_dir / ARTIFACT_FILE["chimap"]), "--kind", "chi",
+           "--mask", str(sm), "--artifact", "chimap", "--out", str(out_json),
+           "--stage", "combo-sweep", "--name", "combo-sweep", "--track", "sim"]
+    seg = gt_dir / "dseg.nii.gz"
+    if seg.exists():
+        cmd += ["--seg", str(seg)]
+    subprocess.run(cmd, check=True, capture_output=True)
+    return json.loads(out_json.read_text())["metrics"]
+
+
+def run_bfr(bfr: dict, override: dict, src: dict, work: Path) -> "tuple | None":
+    """Run one BFR (at `override`, {} = default) on the gt totalfield; return (localfield, valid
+    mask, runtime) or None on DNF. Mirrors pipeline.do_bfr: run within the incoming mask, then narrow
+    the mask to the BFR's non-zero support so the dipole never inverts a zero-field rim."""
+    tag = "__".join(f"{k}-{fmt(v)}" for k, v in override.items()) or "default"
+    idir, odir = work / f"bfr_{bfr['slug']}__{tag}__in", work / f"bfr_{bfr['slug']}__{tag}__out"
+    try:
+        prepare_input(bfr["consumes"], src, idir)
+        rt = run_algo(bfr, idir, odir, RUNNER, override or None)
+        lf = odir / ARTIFACT_FILE["localfield"]
+        lf_mask = _valid_mask(lf, src["mask"], odir / "validmask.nii.gz")
+        return (lf, lf_mask, rt)
+    except Exception as e:  # noqa: BLE001
+        with _print_lock:
+            print(f"  bfr  {bfr['slug']:<14} {tag:<24} DNF ({str(e)[-120:]})", flush=True)
+        return None
+
+
+def run_dipole(dipole: dict, override: dict, src: dict, work: Path) -> dict:
+    """Invert a cached localfield with one dipole grid point; score the final chimap's xSIM."""
+    tag = "__".join(f"{k}-{fmt(v)}" for k, v in override.items()) or "default"
+    idir, odir = work / f"{work.name}_dip_{dipole['slug']}__{tag}__in", \
+        work / f"{work.name}_dip_{dipole['slug']}__{tag}__out"
+    rec = {"dipole": dipole["slug"], "override": override, "tag": tag}
+    try:
+        prepare_input(dipole["consumes"], src, idir)
+        t0 = time.time()
+        run_algo(dipole, idir, odir, RUNNER, override or None)
+        m = score_chi_xsim(odir / ARTIFACT_FILE["chimap"], Path(src["chimap"]).parent,
+                           src["mask"], work / f"dip_{dipole['slug']}__{tag}")
+        rec.update(status="ok", xsim=m.get("xsim"), nrmse=m.get("nrmse"), runtime=time.time() - t0)
+    except subprocess.CalledProcessError as e:
+        rec.update(status="DNF", error=(e.stderr or "")[-300:])
+    except Exception as e:  # noqa: BLE001
+        rec.update(status="DNF", error=str(e)[-300:])
+    return rec
+
+
+def _tuned_point(algo: dict) -> "dict | None":
+    """The method's isolated-tuned override (from algorithm.yml `tuned:`), coerced onto its grid's
+    keys, or None if it declares no tuned value for a swept param. Used to guarantee the joint sweep
+    always measures the isolated optimum so the report can compare it to the joint best."""
+    tuned = algo.get("tuned") or {}
+    grid = GRIDS.get(algo["slug"], {})
+    pt = {k: tuned[k] for k in grid if k in tuned}
+    return pt or None
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", type=Path, default=ROOT / "data/sim/dev",
+                    help="tune on dev; confirm winners on data/sim/scoring separately (dev avoids "
+                         "overfitting the scored phantom any harder than isolated tuning already does)")
+    ap.add_argument("--bfr", default=None, help="comma-separated BFR slugs (default: all localfield producers)")
+    ap.add_argument("--dipole", default=None, help="comma-separated dipole slugs (default: all tunable dipoles)")
+    ap.add_argument("--sweep-bfr", action="store_true",
+                    help="also vary each tunable BFR's own parameter, recomputing its localfield per "
+                         "value (the fuller joint grid). Default holds the BFR at its built-in default.")
+    ap.add_argument("--refine", action="store_true", help="use the round-2 REFINE grids where defined")
+    ap.add_argument("--jobs", type=int, default=4, help="MATLAB MCR runs are memory-heavy; keep modest")
+    ap.add_argument("--runner", default="docker", help="docker/podman/apptainer/local")
+    ap.add_argument("--work", type=Path, default=ROOT / ".combo_sweep")
+    ap.add_argument("--out", type=Path, default=ROOT / "results/combo_sweep.json")
+    args = ap.parse_args()
+    global RUNNER
+    RUNNER = args.runner
+    grids = REFINE if args.refine else GRIDS
+
+    src0 = gt_sources(args.dataset)  # "gt" field-map source = ground-truth totalfield
+    algos = {a["slug"]: a for a in discover_algorithms()}
+
+    bfrs = [a for a in algos.values() if "localfield" in a["produces"]]
+    dipoles = [a for a in algos.values() if a["stage"] == "dipole" and a["slug"] in grids]
+    if args.bfr:
+        want = set(args.bfr.split(","));  bfrs = [b for b in bfrs if b["slug"] in want]
+    if args.dipole:
+        want = set(args.dipole.split(","));  dipoles = [d for d in dipoles if d["slug"] in want]
+    if not bfrs or not dipoles:
+        raise SystemExit("nothing to sweep — check --bfr/--dipole against the tunable methods")
+
+    # BFR variants: default only, unless --sweep-bfr and the BFR has a grid.
+    def bfr_variants(b):
+        vs = [{}]
+        if args.sweep_bfr and b["slug"] in grids:
+            vs += [ov for ov in combos(grids[b["slug"]]) if ov]
+        return vs
+
+    n_bfr_runs = sum(len(bfr_variants(b)) for b in bfrs)
+    n_dip_pts = sum(len(combos(grids[d["slug"]])) + 1 for d in dipoles)  # +1 for true default
+    print(f"combo sweep: {len(bfrs)} BFR x {len(dipoles)} dipole on {args.dataset.name}")
+    print(f"  ~{n_bfr_runs} BFR localfield runs, up to ~{n_bfr_runs * n_dip_pts} dipole runs, "
+          f"jobs={args.jobs}, strategy={'joint (BFR swept)' if args.sweep_bfr else 'downstream'}\n")
+    args.work.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1 — compute every needed localfield once, keyed (bfr_slug, bfr_tag). Keying by the BFR's
+    # override (not just its slug) is essential: pipeline.py's lf_cache omits the param dimension, so
+    # a naive reuse would silently hand a dipole the wrong (default-param) field under --sweep-bfr.
+    bfr_tasks = [(b, ov) for b in bfrs for ov in bfr_variants(b)]
+    lf_cache: dict[tuple, tuple] = {}
+
+    def do_bfr(task):
+        b, ov = task
+        tag = "__".join(f"{k}-{fmt(v)}" for k, v in ov.items()) or "default"
+        res = run_bfr(b, ov, src0, args.work)
+        if res:
+            with _print_lock:
+                print(f"  bfr  {b['slug']:<14} {tag:<24} ok ({res[2]:.0f}s)", flush=True)
+        return ((b["slug"], tag), res)
+
+    with cf.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as ex:
+        for key, res in ex.map(do_bfr, bfr_tasks):
+            if res:
+                lf_cache[key] = res
+
+    # Stage 2 — for each cached localfield, sweep every dipole's grid (plus the true default and the
+    # dipole's isolated-tuned point, so the report can always compare isolated-vs-joint).
+    dip_tasks = []
+    for (bfr_slug, bfr_tag), (lf, lf_mask, up_rt) in lf_cache.items():
+        cell_src = dict(src0); cell_src["localfield"] = lf; cell_src["mask"] = lf_mask
+        cell_work = args.work / f"cell_{bfr_slug}__{bfr_tag}"
+        cell_work.mkdir(parents=True, exist_ok=True)
+        for d in dipoles:
+            pts = [{}] + combos(grids[d["slug"]])           # {} = the method's built-in default
+            tp = _tuned_point(d)
+            if tp and tp not in pts:
+                pts.append(tp)                               # ensure isolated-tuned is measured
+            seen = set()
+            for ov in pts:
+                k = tuple(sorted((kk, fmt(vv)) for kk, vv in ov.items()))
+                if k in seen:
+                    continue
+                seen.add(k)
+                dip_tasks.append((bfr_slug, bfr_tag, up_rt, d, ov, cell_src, cell_work))
+
+    results = []
+
+    def do_dip(task):
+        bfr_slug, bfr_tag, up_rt, d, ov, cell_src, cell_work = task
+        rec = run_dipole(d, ov, cell_src, cell_work)
+        rec.update(bfr=bfr_slug, bfr_tag=bfr_tag, upstream_runtime=up_rt,
+                   fieldmap="gt", dataset=args.dataset.name,
+                   isolated_tuned=_tuned_point(d) or {})
+        with _print_lock:
+            x = f"xsim={rec['xsim']:.4f}" if rec.get("xsim") is not None else "DNF"
+            print(f"  {bfr_slug}+{d['slug']:<12} {rec['tag']:<24} {x}", flush=True)
+        return rec
+
+    with cf.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as ex:
+        results = list(ex.map(do_dip, dip_tasks))
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(results, indent=2) + "\n")
+    print(f"\nwrote {args.out}  ({len(results)} dipole runs across {len(lf_cache)} localfields)")
+    print("run  scripts/combo_sweep_report.py  to see isolated-tuned vs in-combination best")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/combo_sweep_report.py
+++ b/scripts/combo_sweep_report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Read a combination sweep and answer: does each dipole's ISOLATED-tuned value stay optimal once
+it's chained behind a specific BFR?
+
+For every (bfr -> dipole) cell it prints the xSIM at the dipole's isolated-tuned override, the best
+grid point found in-combination, the gap between them, and whether the winning override differs from
+the isolated one. A cell flagged "MOVED" is direct evidence that per-combination tuning would help —
+the cells that move are exactly the ones worth a proper joint sweep (and worth storing separately in
+tuning/combinations.yml).
+
+  python scripts/combo_sweep_report.py [--in results/combo_sweep.json] [--min-delta 0.002]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+
+
+def ov_str(ov: dict) -> str:
+    return ", ".join(f"{k}={v:g}" if isinstance(v, float) else f"{k}={v}"
+                     for k, v in ov.items()) or "(default)"
+
+
+def key(ov: dict) -> tuple:
+    return tuple(sorted((k, f"{v:g}" if isinstance(v, float) else str(v)) for k, v in ov.items()))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="path", default="results/combo_sweep.json")
+    ap.add_argument("--min-delta", type=float, default=0.002,
+                    help="xSIM gain over the isolated-tuned point needed to flag a cell as MOVED")
+    args = ap.parse_args()
+
+    runs = [r for r in json.load(open(args.path)) if r.get("status") == "ok" and r.get("xsim") is not None]
+    if not runs:
+        raise SystemExit(f"no scored runs in {args.path}")
+
+    # group by (bfr, bfr_tag, dipole)
+    cells: dict[tuple, list] = defaultdict(list)
+    for r in runs:
+        cells[(r["bfr"], r.get("bfr_tag", "default"), r["dipole"])].append(r)
+
+    print(f"{'bfr':<14} {'dipole':<12} {'iso-tuned':>9} {'best':>9} {'Δ':>8}   best override  [iso override]")
+    print("-" * 96)
+    moved, checked = 0, 0
+    dipole_moves: dict[str, int] = defaultdict(int)
+    dipole_seen: dict[str, int] = defaultdict(int)
+
+    for (bfr, bfr_tag, dipole) in sorted(cells):
+        rs = cells[(bfr, bfr_tag, dipole)]
+        iso_ov = rs[0].get("isolated_tuned") or {}
+        best = max(rs, key=lambda r: r["xsim"])
+        iso_run = next((r for r in rs if key(r["override"]) == key(iso_ov)), None) if iso_ov else None
+        # fall back to the method's built-in default point when no isolated-tuned value is declared
+        base_run = iso_run or next((r for r in rs if not r["override"]), None)
+        base = base_run["xsim"] if base_run else None
+        d = best["xsim"] - base if base is not None else None
+        tag = bfr if bfr_tag == "default" else f"{bfr}[{bfr_tag}]"
+        dipole_seen[dipole] += 1
+        flag = ""
+        if base is not None:
+            checked += 1
+            if d >= args.min_delta and key(best["override"]) != key(base_run["override"]):
+                flag = "  <- MOVED"; moved += 1; dipole_moves[dipole] += 1
+        bs = f"{base:.4f}" if base is not None else "   n/a"
+        ds = f"{d:+.4f}" if d is not None else "   n/a"
+        print(f"{tag:<14} {dipole:<12} {bs:>9} {best['xsim']:>9.4f} {ds:>8}   "
+              f"{ov_str(best['override'])}  [{ov_str(iso_ov)}]{flag}")
+
+    print("-" * 96)
+    print(f"{moved}/{checked} cells improved by >= {args.min_delta} xSIM when tuned in combination.")
+    if moved:
+        print("dipoles whose optimum shifts most (cells moved / cells seen):")
+        for dip in sorted(dipole_moves, key=dipole_moves.get, reverse=True):
+            print(f"  {dip:<12} {dipole_moves[dip]}/{dipole_seen[dip]}")
+        print("\n=> per-combination tuning is justified for the MOVED cells; store their winning "
+              "overrides in tuning/combinations.yml keyed by (bfr, dipole).")
+    else:
+        print("=> isolated-tuned values hold up in combination; combination tuning is NOT justified "
+              "on this dataset. (Re-check on data/sim/scoring before concluding.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_manifest.py
+++ b/scripts/gen_manifest.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Build web/algorithms.json from every algorithms/<slug>/algorithm.yml.
 
-The site (Methods page + submission page) fetches this manifest to show what each algorithm is —
-description, parameters, citation/DOI, source — alongside the scores.
+The submission page fetches this manifest to show what each algorithm is — description, parameters,
+citation/DOI, source, and any `ci_notes` — and the leaderboard uses it to badge methods that carry
+notes on how QSM-CI runs them.
 """
 from __future__ import annotations
 
@@ -31,6 +32,9 @@ def entry(meta: dict) -> dict:
         # `parameters:` is the canonical key; tolerate a stray `params:` so a mistyped
         # submission still shows its parameter rows instead of silently dropping them.
         "parameters": meta.get("parameters") or meta.get("params") or [],
+        # Optional notes on how QSM-CI runs this method vs. its reference (e.g. CPU-only execution of
+        # a GPU method, model complexity reduced to fit the runner) — shown on the submission page.
+        "ci_notes": meta.get("ci_notes") or [],
     }
 
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures as _cf
 import json
+import math
 import os
 import re
 import shutil
@@ -202,6 +203,16 @@ def _valid_mask(volume: Path, base_mask: Path, out: Path) -> Path:
     return out
 
 
+def _finite(v) -> bool:
+    """True if v is a real, finite number — a usable metric, not None/NaN/inf."""
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
+
+
+def _fmt(v, spec: str = ".4f") -> str:
+    """Format a metric, or 'n/a' when it's missing/non-finite — so a NaN output can't crash a print."""
+    return format(v, spec) if _finite(v) else "n/a"
+
+
 def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, meta: dict) -> dict:
     kind = ARTIFACT_KIND[artifact]
     raw_mask = mask  # the full brain mask, before erosion — used to mask the viewer's error map
@@ -219,7 +230,15 @@ def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, 
         cmd += ["--seg", str(seg)]
     subprocess.run(cmd, check=True)
     result = json.loads(out_json.read_text())
-    result["status"] = "ok"
+    # A scorable recon yields finite metrics; an all-NaN / empty output makes the scorer emit
+    # null/NaN. Record that as a clear DNF (not a metric-less "ok" row, and without crashing the
+    # caller's formatted print) so the failure is legible instead of a cryptic format-string error.
+    primary = (result.get("metrics") or {}).get("xsim" if kind == "chi" else "nrmse")
+    if _finite(primary):
+        result["status"] = "ok"
+    else:
+        result["status"] = "DNF"
+        result["dnf_reason"] = "non-finite output (unscorable)"
     result.update({k: meta[k] for k in ("id", "slug", "mode", "variant", "params") if k in meta})
     if "combo" in meta:
         result["combo"] = meta["combo"]
@@ -259,6 +278,10 @@ def main() -> None:
                     help="incremental: isolated for this slug, and every composed combo that includes "
                          "it (its own stage is pinned to it; complementary stages stay full)")
     ap.add_argument("--include", default=None, help="comma-separated slugs to restrict the run to")
+    ap.add_argument("--exclude", default=None,
+                    help="comma-separated slugs to DROP from the run (isolated + composed). Used by "
+                         "score.yml's full re-run so the hosted shards skip methods pinned to the "
+                         "self-hosted runner; those run as separate --focus jobs on that runner.")
     ap.add_argument("--shard", default=None, metavar="i/n",
                     help="run only shard i of n disjoint shards (0-indexed), for parallel scoring "
                          "across jobs. Composed work is split by (field-map, bfr) COLUMN so each "
@@ -304,6 +327,9 @@ def main() -> None:
     if args.include:
         keep = set(args.include.split(","))
         algos = [a for a in algos if a["slug"] in keep]
+    if args.exclude:
+        drop = set(args.exclude.split(","))
+        algos = [a for a in algos if a["slug"] not in drop]
     print(f"discovered {len(algos)} submissions:",
           ", ".join(f"{a['slug']}[{a['stage']}]" for a in algos))
     runs: list[dict] = []
@@ -346,8 +372,11 @@ def main() -> None:
                               args.work / f"iso_{a['slug']}{sfx}.json", meta)
                     out.append(r)
                     m = r["metrics"]
-                    print(f"  isolated  {a['slug']:<16} {variant:<8} {art:<11} "
-                          f"xsim={m.get('xsim'):.4f} nrmse={m.get('nrmse'):.2f}%")
+                    if r.get("status") == "DNF":
+                        print(f"  isolated  {a['slug']:<16} {variant:<8} {art:<11} DNF ({r.get('dnf_reason','')})")
+                    else:
+                        print(f"  isolated  {a['slug']:<16} {variant:<8} {art:<11} "
+                              f"xsim={_fmt(m.get('xsim'))} nrmse={_fmt(m.get('nrmse'), '.2f')}%")
                 return out
             except Exception as e:  # DNF — record and continue
                 print(f"  isolated  {a['slug']:<16} {variant:<8} DNF ({e})")
@@ -467,8 +496,11 @@ def main() -> None:
                 r = score(odir / "chimap.nii.gz", "chimap", gt, mask,
                           args.work / f"cmp_{cid}.json", meta)
                 m = r["metrics"]
-                print(f"  composed  {combo:<34} chimap xsim={m.get('xsim'):.4f} "
-                      f"nrmse_dt={m.get('nrmse_detrend'):.2f}%")
+                if r.get("status") == "DNF":
+                    print(f"  composed  {combo:<34} DNF ({r.get('dnf_reason','')})")
+                else:
+                    print(f"  composed  {combo:<34} chimap xsim={_fmt(m.get('xsim'))} "
+                          f"nrmse_dt={_fmt(m.get('nrmse_detrend'), '.2f')}%")
                 return r
             except Exception as e:
                 print(f"  composed  {combo:<34} DNF ({e})")

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -19,7 +19,8 @@
         "Yeom K.W.",
         "Liu C."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "fansi",
@@ -64,6 +65,9 @@
           "default": 0,
           "description": "0 = TV regularization (nlTV), 1 = TGV regularization (nlTGV)"
         }
+      ],
+      "ci_notes": [
+        "On high-field data with large field outliers, the ppm-to-radians phase scale is capped so FANSI's nonlinear solver stays numerically stable (at the physical 7 T scale it otherwise diverges to NaN). Well-behaved fields use the standard physical scale unchanged, so the inversion is unaffected there.\n"
       ]
     },
     {
@@ -100,7 +104,8 @@
           "default": "1e-4",
           "description": "tolerance"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "hd-qsm",
@@ -143,7 +148,8 @@
           "default": 1.0,
           "description": "convergence threshold on the L2-stage normalized solution update (percent)"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "iharperella",
@@ -178,7 +184,8 @@
           "default": "1e-4",
           "description": "tolerance"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "ilsqr",
@@ -212,7 +219,8 @@
           "default": 1000,
           "description": "iterations"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "inr-qsm",
@@ -274,6 +282,9 @@
           "default": 1.0,
           "description": "Weight of the gradient-domain data-consistency regularizer (reference default 1.0)."
         }
+      ],
+      "ci_notes": [
+        "Executed CPU-only. The reference optimizes per subject on an NVIDIA GPU with mixed precision, so runtime here is substantially longer and not comparable to GPU timings.\n"
       ]
     },
     {
@@ -299,7 +310,8 @@
         "Liu F.",
         "Sun H."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "iqsm-plus",
@@ -323,7 +335,8 @@
         "Liu F.",
         "Sun H."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "ir2qsm",
@@ -346,7 +359,11 @@
         "Sun H.",
         "Gao Y."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": [
+        "Executed CPU-only on QSM-CI's runners (no GPU). IR2QSM is a GPU-oriented network, so wall-clock runtime here is far longer than a GPU deployment and should not be read as the method's native speed.\n",
+        "The reference injects noise at inference through a CUDA-only operation; QSM-CI patches it to run on CPU, so reconstructions are mildly stochastic and can vary slightly between runs.\n"
+      ]
     },
     {
       "slug": "ismv",
@@ -381,7 +398,8 @@
           "default": 2.0,
           "description": "\u00d7 max voxel size"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "l1-qsm",
@@ -426,7 +444,8 @@
           "default": 1.0,
           "description": "convergence threshold on the normalized solution update (percent)"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "laplacian-fieldmap",
@@ -441,7 +460,8 @@
       "authors": [
         "QSM-CI"
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "lbv",
@@ -465,7 +485,8 @@
           "default": "1e-4",
           "description": "convergence tolerance"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "lpcnn",
@@ -484,7 +505,8 @@
         "Li X.",
         "Sulam J."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "matlab-bfrnet",
@@ -499,7 +521,8 @@
       "authors": [
         "Xuanyu Zhu, Yang Gao, Feng Liu, Stuart Crozier, Hongfu Sun"
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "matlab-medi",
@@ -546,7 +569,8 @@
           "default": 0,
           "description": "model-error reduction (iterative reweighting); 1 enables"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "matlab-sti-iharperella",
@@ -576,7 +600,8 @@
           "default": 12,
           "description": "zero-pad size (voxels, isotropic) for numerical accuracy"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "matlab-sti-ilsqr",
@@ -605,7 +630,8 @@
           "default": 12,
           "description": "zero-pad size (voxels, isotropic) to improve numerical accuracy of the inversion"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "matlab-sti-star",
@@ -626,7 +652,8 @@
           "default": 12,
           "description": "zero-pad size (voxels, isotropic) to improve numerical accuracy of the inversion"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "matlab-sti-vsharp",
@@ -650,7 +677,8 @@
           "default": 12,
           "description": "maximum spherical-mean-value kernel size (voxels) for the SMV deconvolution"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "matlab-tkd",
@@ -670,7 +698,8 @@
         "Stephen J. Dodd",
         "Jeff H. Duyn"
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "medi",
@@ -701,7 +730,8 @@
           "default": "1e-4",
           "description": "regularization"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "modip",
@@ -738,6 +768,9 @@
           "default": 32,
           "description": "Base channel count of the DIP U-Net (reference default 32). Lower reduces memory/compute (the reference README suggests decreasing base and increasing iterations under memory pressure).\n"
         }
+      ],
+      "ci_notes": [
+        "Executed CPU-only. The reference optimizes per subject on a GPU, so runtime here is substantially longer and not comparable to GPU timings.\n"
       ]
     },
     {
@@ -763,7 +796,8 @@
         "Zhuang J.",
         "Wei H."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "ndi",
@@ -799,7 +833,8 @@
           "default": 1e-05,
           "description": "small Tikhonov regularization weight for numerical stability"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "nextqsm",
@@ -820,7 +855,8 @@
         "Barth M.",
         "Bollmann S."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "nltv",
@@ -849,7 +885,8 @@
           "default": 1000,
           "description": "iterations"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "pdf",
@@ -876,7 +913,8 @@
           "default": "1e-4",
           "description": "convergence tolerance"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "qsmart",
@@ -902,7 +940,8 @@
         "Scott Kolbe",
         "Leigh A. Johnston"
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "qsmgan",
@@ -921,7 +960,8 @@
         "Hess C.P.",
         "Lupo J.M."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "qsmnet",
@@ -948,7 +988,8 @@
         "Pauly J.",
         "Lee J."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "qsmnet-plus",
@@ -970,7 +1011,8 @@
         "Kim E.Y.",
         "Lee J."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "resharp",
@@ -998,7 +1040,8 @@
           "default": "1e-3",
           "description": "Tikhonov regularization"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "romeo-fieldmap",
@@ -1013,7 +1056,8 @@
       "authors": [
         "Dymerska and Eckstein et al."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     },
     {
       "slug": "rts",
@@ -1046,7 +1090,8 @@
           "default": 1000,
           "description": "iterations"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "sharp",
@@ -1076,7 +1121,8 @@
           "default": 0.5,
           "description": "\u00d7 min voxel size"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "tgv",
@@ -1117,7 +1163,8 @@
           "default": 0.0015,
           "description": "second-order weight"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "tikhonov",
@@ -1145,7 +1192,8 @@
           "tuned": "3e-3",
           "description": "L2 regularization"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "tkd",
@@ -1171,7 +1219,8 @@
           "default": 0.1,
           "description": "k-space threshold"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "tsvd",
@@ -1195,7 +1244,8 @@
           "tuned": 0.05,
           "description": "singular-value threshold"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "tv",
@@ -1234,7 +1284,8 @@
           "default": 1000,
           "description": "iterations"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "vsharp",
@@ -1268,7 +1319,8 @@
           "default": 0.0,
           "description": "\u00d7 max voxel size"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "wh-qsm",
@@ -1314,7 +1366,8 @@
           "default": 0.1,
           "description": "convergence threshold on the normalized solution update (percent)"
         }
-      ]
+      ],
+      "ci_notes": []
     },
     {
       "slug": "xqsm",
@@ -1337,7 +1390,8 @@
         "Liu F.",
         "Sun H."
       ],
-      "parameters": []
+      "parameters": [],
+      "ci_notes": []
     }
   ]
 }

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -263,6 +263,10 @@ function methodCard(a) {
       <span class="text-xs text-gray-400">${a.stage ? (STAGE_LABEL[a.stage] || a.stage) : ""}</span>
     </div>
     <p class="mt-0.5 text-sm text-gray-600 dark:text-gray-400">${a.description || ""}</p>
+    ${(a.ci_notes && a.ci_notes.length) ? `<div class="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+      <div class="flex items-center gap-1.5 font-semibold"><span aria-hidden="true">⚠</span> How QSM-CI runs this</div>
+      <ul class="mt-1 list-disc space-y-0.5 pl-4 marker:text-amber-400">${a.ci_notes.map((n) => `<li>${n}</li>`).join("")}</ul>
+    </div>` : ""}
     ${params ? `<table class="mt-2 w-full text-xs">${paramHead}<tbody>${params}</tbody></table>` : ""}
     ${(a.citation || links.length) ? `<p class="mt-1.5 text-xs text-gray-400 dark:text-gray-500">${a.citation || ""} ${links.length ? "· " + links.join(" · ") : ""}</p>` : ""}
   </div>`;

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -86,9 +86,11 @@
                 <template x-if="g.t==='cell'">
                   <button @click="go(g.run)"
                     :title="g.run.combo.bfr+' + '+g.run.combo.dipole+' — '+METRICS[metric].label+': '+fmt(val(g.run,metric),metric)"
-                    class="group relative h-14 w-full rounded-xl text-white font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none ring-1 ring-black/5"
-                    :style="'background:'+heat(norm(val(g.run,metric)))">
+                    class="heat-cell group relative h-14 w-full rounded-xl font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none"
+                    :class="g.run.variant==='tuned' ? 'ring-2 ring-emerald-600 ring-offset-2' : 'ring-1 ring-black/5'"
+                    :style="'--heat:'+heat(norm(val(g.run,metric)))">
                     <span x-text="fmt(val(g.run, metric), metric)"></span>
+                    <span x-show="g.run.variant==='tuned'" class="absolute -right-1.5 -top-1.5 grid h-4 w-4 place-items-center rounded-full bg-emerald-600 text-[9px] shadow" title="tuned parameters">⚙</span>
                   </button>
                 </template>
                 <template x-if="g.t==='empty'">
@@ -115,10 +117,12 @@
                       <div class="flex items-center gap-3">
                         <div class="w-36 shrink-0 truncate pr-1 text-right text-xs font-semibold text-gray-500" x-text="r.name"></div>
                         <button @click="go(r)"
-                          :title="r.name+' — '+METRICS[metric].label+': '+fmt(val(r,metric),metric)"
-                          class="group relative h-14 w-40 shrink-0 rounded-xl text-white font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none ring-1 ring-black/5"
-                          :style="'background:'+heat(norm(val(r,metric)))">
+                          :title="r.name+' — '+METRICS[metric].label+': '+fmt(val(r,metric),metric)+(r.variant==='tuned' ? ' (tuned parameters)' : '')"
+                          class="heat-cell group relative h-14 w-40 shrink-0 rounded-xl font-semibold text-sm shadow-sm transition hover:z-10 hover:scale-[1.06] hover:shadow-md focus:outline-none"
+                          :class="r.variant==='tuned' ? 'ring-2 ring-emerald-600 ring-offset-2' : 'ring-1 ring-black/5'"
+                          :style="'--heat:'+heat(norm(val(r,metric)))">
                           <span x-text="fmt(val(r, metric), metric)"></span>
+                          <span x-show="r.variant==='tuned'" class="absolute -right-1.5 -top-1.5 grid h-4 w-4 place-items-center rounded-full bg-emerald-600 text-[9px] shadow" title="tuned parameters">⚙</span>
                         </button>
                       </div>
                     </template>
@@ -132,7 +136,7 @@
         <!-- legend -->
         <div class="mt-5 flex items-center gap-3 text-xs text-gray-500">
           <span x-text="(METRICS[metric].better==='higher'?'worse':'better')"></span>
-          <div class="h-2.5 w-40 rounded-full" style="background:linear-gradient(90deg,#be6b6b,#c49e60,#6ea886)"></div>
+          <div class="heat-legend h-2.5 w-40 rounded-full ring-1 ring-inset ring-black/5"></div>
           <span x-text="(METRICS[metric].better==='higher'?'better':'worse')"></span>
           <span class="ml-2 tabular-nums" x-text="'range '+fmt(matrix.lo,metric)+' – '+fmt(matrix.hi,metric)"></span>
         </div>
@@ -179,7 +183,7 @@
           </thead>
           <tbody class="divide-y divide-gray-100">
             <template x-for="(r, i) in rows" :key="r.id">
-              <tr @click="go(r)" class="group cursor-pointer" :class="r.status==='DNF' ? 'opacity-50' : ''">
+              <tr @click="go(r)" class="group cursor-pointer" :class="(r.status==='DNF' ? 'opacity-50 ' : '') + (r.variant==='tuned' ? 'tuned-row' : '')">
                 <td class="px-5 py-3 text-left font-medium text-gray-900 sticky left-0 bg-white group-hover:bg-emerald-50/40">
                   <span class="mr-1.5 inline-block w-5 text-center" x-text="medal(i)"></span>
                   <span x-text="r.name"></span>
@@ -189,6 +193,8 @@
                        :title="'Submission DOI (Zenodo v' + doi(r).version + ')'">DOI</a>
                   </template>
                   <span x-show="r.status==='DNF'" class="ml-2 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500">DNF</span>
+                  <span x-show="r.variant==='tuned'" class="ml-2 rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 ring-1 ring-inset ring-emerald-600/25" title="Parameters tuned on the scoring phantom">⚙ tuned</span>
+                  <span x-show="ciNotes(r.slug).length" class="ml-2 cursor-help rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 ring-1 ring-inset ring-amber-500/30 dark:bg-amber-500/10 dark:text-amber-300" :data-tip="ciNotes(r.slug).join('  •  ')">⚠ note</span>
                 </td>
                 <template x-for="c in displayCols" :key="c">
                   <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="c===sortKey ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt(val(r,c), c)"></td>
@@ -210,7 +216,29 @@
   </main>
 
   <footer id="site-footer"></footer>
-  <style>[x-cloak]{display:none!important}</style>
+  <style>
+    [x-cloak]{display:none!important}
+    /* Tuned rows: faint emerald tint + left accent bar, styled per-cell — a tr outline paints
+       under the sticky first cell and doubles up between adjacent tuned rows. The sticky cell
+       gets the same tint as an opaque colour so columns scrolling beneath it don't show through;
+       Tailwind's group-hover classes still win on hover (higher specificity). */
+    tr.tuned-row td{background:rgb(236 253 245/.55)}
+    tr.tuned-row td:first-child{background:rgb(245 254 249);box-shadow:inset 3px 0 0 rgb(5 150 105/.6)}
+    /* Dark counterparts (site themes via html.dark overrides in app.js, and the light values above
+       outrank them — so restate both cells here). Sticky cell = emerald tint pre-blended into the
+       dark table bg (#111827), kept opaque for the same see-through reason. */
+    html.dark tr.tuned-row td{background:rgb(16 185 129/.08)}
+    html.dark tr.tuned-row td:first-child{background:rgb(17 37 40);box-shadow:inset 3px 0 0 rgb(52 211 153/.55)}
+    /* Combination-matrix cells. heat() supplies the dark-first muted colour in --heat; in light
+       mode render it as a pastel wash with dark tinted text (solid mid-tones + white text read
+       murky on the white card), in dark mode use it as-is. CSS-only so the theme toggle switches
+       cells without an Alpine re-render. */
+    .heat-cell{background:color-mix(in srgb,var(--heat) 38%,#fff);color:color-mix(in srgb,var(--heat) 55%,#1f2937)}
+    .heat-legend{background:linear-gradient(90deg,
+      color-mix(in srgb,#be6b6b 38%,#fff),color-mix(in srgb,#c49e60 38%,#fff),color-mix(in srgb,#6ea886 38%,#fff))}
+    html.dark .heat-cell{background:var(--heat);color:#fff}
+    html.dark .heat-legend{background:linear-gradient(90deg,#be6b6b,#c49e60,#6ea886)}
+  </style>
 
   <script>
     function board() {
@@ -240,16 +268,26 @@
       };
       return {
         METRICS, STAGE_LABEL, MEDALS, fmt, val,
-        runs: [], registry: {}, view: "composed", stage: "dipole", fmap: "gt",
+        runs: [], registry: {}, algos: [], view: "composed", stage: "dipole", fmap: "gt",
         variant: "default",
         metric: "xsim", sortKey: "xsim", sortDir: "desc", filter: "",
         colMenu: false, selectedCols: ["nrmse", "correlation", "xsim", "runtime_s"],
         loading: true,
+        // ci_notes: per-method infrastructure caveats (algorithms.json), surfaced as a ⚠ badge that
+        // tooltips the notes; clicking the row opens the method's submission page with the full text.
+        ciNotes(slug) { const a = this.algos.find((x) => x.slug === slug); return (a && a.ci_notes) || []; },
         async init() {
+          // Deep-link support: leaderboard.html?view=isolated&stage=dipole&variant=tuned
+          const q = new URLSearchParams(location.search);
+          if (["composed", "isolated"].includes(q.get("view"))) this.view = q.get("view");
+          if (q.get("variant") === "tuned") this.variant = "tuned";
           try {
             this.runs = await loadRuns();
             this.registry = await loadRegistry();
-            const st = this.stages(); if (!st.includes(this.stage)) this.stage = st[0] || "dipole";
+            this.algos = await loadAlgos();
+            const st = this.stages();
+            if (st.includes(q.get("stage"))) this.stage = q.get("stage");
+            else if (!st.includes(this.stage)) this.stage = st[0] || "dipole";
             if (!this.runs.some((r) => r.mode === "composed")) this.view = "isolated";
           } finally {
             this.loading = false;   // only reveal the empty-state once the fetch has actually resolved


### PR DESCRIPTION
Bundles the follow-ups to the 8 new submissions (#88).

## Fixes
- **fansi** DNF'd on the 7 T scoring phantom — its `nlTV` solver diverged to NaN on large field outliers. Capped the phase scale so it stays numerically stable; verified **xSIM 0.704 / corr 0.949** (was DNF), dev unchanged at 0.9986. Image rebuilt + pushed.
- **pipeline.py**: a non-finite (all-NaN) recon now records a clear **DNF ("non-finite output")** instead of crashing with `unsupported format string passed to NoneType.__format__`.

## Self-hosted runner routing
- `runner: self-hosted` in `algorithm.yml` → the `plan` job routes that method to the 31 GB private runners (360-min budget, 4 containers) in **both** focused and full re-runs. Full runs use `pipeline.py --exclude` on the hosted shards + a `--focus` job per self-hosted method.
- Tagged **inr-qsm** (was OOMing 16 GB), **modip**, **wh-qsm** (were hitting the 180-min hosted wall).

## CI notes
- `algorithm.yml` `ci_notes:` list → amber callout on the submission page + a ⚠ badge on the leaderboard (documents CPU-only-vs-GPU, ir2qsm's stochastic patch, fansi's phase cap).

## Also
- Leaderboard tuned-parameter disclosure UI polish; `combo_sweep` tooling for joint parameter tuning.

Merging touches `pipeline.py`, so it triggers a **full rescore** — which validates the new full-mode routing and re-scores everything cleanly (fansi valid, the 3 heavy methods on the private runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)