### PR TITLE
fix(score): publish partial results when a leg is cancelled; drop stage-count stat

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -190,7 +190,14 @@ jobs:
 
   merge:
     needs: [scope, score]
-    if: ${{ !cancelled() && needs.score.result != 'skipped' }}
+    # Publish whatever finished scoring — even if a leg failed or a flaky self-hosted DL job (e.g.
+    # modip) was cancelled/timed out. `merge` downloads the shard artifacts that exist and merges
+    # them into results/index.json by run-id, so a leg that uploaded nothing is simply absent and
+    # keeps its previous score. We need always() here: without it, one cancelled leg skips merge and
+    # blocks the ENTIRE leaderboard publish, including all the hosted results (this is what DNF'd the
+    # BFRnet/resource-graph publish). Still skip when scope failed (nothing was planned) or scoring
+    # was skipped (nothing changed).
+    if: ${{ always() && needs.scope.result == 'success' && needs.score.result != 'skipped' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/web/index.html
+++ b/web/index.html
@@ -157,12 +157,10 @@
         async init() {
           this.runs = await loadRuns();
           const methods = new Set(this.runs.filter(r => r.mode === "isolated").map(r => r.slug));
-          const stages = new Set(this.runs.filter(r => r.mode === "isolated").map(r => r.stage));
           const composed = this.runs.filter(r => r.mode === "composed" && r.status !== "DNF");
           const bestX = Math.max(...composed.map(r => val(r, "xsim")).filter(v => v != null), 0);
           this.statCards = [
             { label: "Methods", value: methods.size },
-            { label: "Stages", value: stages.size },
             { label: "Pipelines evaluated", value: composed.length },
             { label: "Best XSIM", value: bestX.toFixed(3) },
           ];


### PR DESCRIPTION
Two fixes.

### 1. Score publish no longer blocked by a flaky self-hosted leg
The `merge` job (which commits `results/index.json` and updates the leaderboard) was gated on `if: !cancelled() && …`. When a single score leg is cancelled or times out — in practice the self-hosted deep-learning methods, especially **modip** (ran ~3h51m then cancelled) — GitHub skips `merge`, so **nothing publishes**: all the hosted results, BFRnet's composed scores, and the new resource-graph traces get dropped. The last several scheduled score runs DNF'd this way.

Fix: `if: always() && needs.scope.result == 'success' && needs.score.result != 'skipped'`. `merge` now runs regardless of individual-leg status, downloads whatever `shard-*` artifacts exist, and merges them into `index.json` **by run-id**. A cancelled leg uploaded no artifact, so it's simply absent from the merge and **keeps its previous score** — one hung `modip` no longer blocks the entire leaderboard.

### 2. Drop the "Stages" stat card
The homepage stat card showing the number of stages (e.g. "6") isn't meaningful to users and is more confusing than useful. Removed. The functional per-stage filter, nav toggle, and graph stage-bands are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)