### PR TITLE
refactor(scoring): extract shared scoring primitives into qsm_ci/scoring.py

### DIFF
--- a/qsm_ci/scoring.py
+++ b/qsm_ci/scoring.py
@@ -1,0 +1,126 @@
+"""Shared scoring/sweep primitives — one home for the helpers that scripts/pipeline.py,
+scripts/sweep.py and scripts/combo_sweep.py used to each keep their own copy of.
+
+These are the pure-ish building blocks around *running* a submission and *scoring* its artifact:
+
+  - `cli_run_argv(...)`   — build the exact `qsm-ci run …` argv for an isolated container run.
+  - `gt_sources(dataset)` — map each canonical artifact to its ground-truth-backed source path.
+  - `parse_shard(spec)` / `shard_owns(...)` / `shard_partition(...)` — the `--shard i/n` round-robin
+    partition logic (deterministic, order-preserving, no overlap and no gaps across the n shards).
+  - `eval_argv(...)`      — build the `python qsm_eval.py …` argv the scorer invokes.
+
+Kept importable without heavy deps at module top: nothing here imports numpy/nibabel/subprocess at
+import time (matching the standalone-script style — a bare `python scripts/pipeline.py` must work from
+a checkout without the scientific stack installed just to build an argv or parse a shard spec).
+
+The artifact→file map lives in qsm_ci.stages (ARTIFACT_FILE); callers pass it in so this module has no
+import cycle with stages and no opinion on where the table lives.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+
+def cli_run_argv(algo: dict, input_dir: Path, output_dir: Path, artifact_file: dict,
+                 runner: str = "docker", overrides: "dict | None" = None,
+                 fmt: "Callable | None" = None) -> list[str]:
+    """Build the `qsm-ci run …` argv that reproduces this submission's isolated container run.
+
+    Each consumed artifact becomes a `--<artifact> <input_dir>/<file>` flag (magnitude is optional —
+    only passed when present); the produced artifact is written with `-o <output_dir>/<file>`. Any
+    `overrides` become `--set NAME=VALUE` (the tuned pass). The CLI owns image resolution, mounting
+    run.sh, and injecting the QSMCI_* acquisition env vars — so the scorer no longer duplicates
+    (and drifts from) that logic.
+
+    `artifact_file` is the canonical artifact→filename map (qsm_ci.stages.ARTIFACT_FILE). `fmt`, if
+    given, formats each override VALUE before it goes into the `--set` string — sweep.py passes its
+    grid-value formatter here so a swept float like 8.0 renders as `8` (its long-standing behaviour);
+    the default `str(v)` matches pipeline.py / run_algo, so both callers keep their exact output.
+    """
+    fmt = fmt or str
+    produced = algo["produces"][0]
+    argv = ["qsm-ci", "run", str(algo["dir"])]
+    for art in algo["consumes"]:
+        f = input_dir / artifact_file[art]
+        if art == "magnitude" and not f.exists():
+            continue  # optional — only some methods use it
+        argv += [f"--{art}", str(f)]
+    for k, v in (overrides or {}).items():
+        argv += ["--set", f"{k}={fmt(v)}"]
+    argv += ["-o", str(output_dir / artifact_file[produced]), "--runner", runner]
+    return argv
+
+
+def gt_sources(dataset: Path) -> dict[str, Path]:
+    """Map each canonical artifact to its ground-truth-backed source path for a dataset dir.
+
+    Raw acquisition artifacts (phase/magnitude/mask/params) come from `<dataset>/inputs`; the stage
+    boundaries (totalfield/localfield/chimap) come from `<dataset>/groundtruth`, so an isolated run is
+    fed the exact GT artifact its stage consumes.
+    """
+    inputs, gt = dataset / "inputs", dataset / "groundtruth"
+    return {
+        "phase": inputs / "phase.nii.gz", "magnitude": inputs / "magnitude.nii.gz",
+        "mask": inputs / "mask.nii.gz", "params": inputs / "params.json",
+        "totalfield": gt / "totalfield.nii.gz", "localfield": gt / "localfield.nii.gz",
+        "chimap": gt / "chimap.nii.gz",
+    }
+
+
+def parse_shard(spec: "str | None") -> "tuple[int | None, int | None]":
+    """Parse a `--shard i/n` spec into (i, n), or (None, None) when unset. Raises SystemExit with the
+    same message pipeline.py used for an out-of-range spec (0 <= i < n)."""
+    if not spec:
+        return (None, None)
+    i, n = (int(x) for x in spec.split("/"))
+    if not (0 <= i < n):
+        raise SystemExit(f"--shard i/n needs 0 <= i < n, got {spec}")
+    return (i, n)
+
+
+def shard_owns(index: int, shard_i: "int | None", shard_n: "int | None") -> bool:
+    """Deterministic round-robin ownership: does shard `shard_i` of `shard_n` own this 0-based index?
+
+    Sharding-off (shard_n is None) owns everything. Otherwise `index % shard_n == shard_i`, so the n
+    shards partition a stable ordering with no overlap and no gaps (union of all n == the full set).
+    """
+    return shard_n is None or index % shard_n == shard_i
+
+
+def shard_partition(items: "list", spec: "str | None") -> "list":
+    """Return the sublist of `items` owned by shard `spec` (`"i/n"`), preserving order.
+
+    A round-robin over `items` by position: shard i keeps items at indices i, i+n, i+2n, … The n
+    shards partition `items` exactly (every item in one shard, none in two). `spec` None/"" → all
+    items. Handles n > len(items) (some shards get []), 1/1 (all items), etc.
+    """
+    shard_i, shard_n = parse_shard(spec)
+    if shard_n is None:
+        return list(items)
+    return [x for idx, x in enumerate(items) if shard_owns(idx, shard_i, shard_n)]
+
+
+def eval_argv(python: str, eval_path: Path, recon: Path, truth: Path, kind: str, mask: Path,
+              artifact: str, out_json: Path, *, stage: str, name: str, track: str,
+              runtime=None, seg: "Path | None" = None) -> list[str]:
+    """Build the `python qsm_eval.py …` argv the scorer subprocess runs.
+
+    This is the flag-assembly the three scoring wrappers (pipeline.score, sweep.score_xsim,
+    combo_sweep.score_chi_xsim) all shared, factored out so the exact flags/order can't drift between
+    them. Callers still own the mask build (nibabel), the subprocess.run call and what they do with
+    the result — those genuinely differ (pipeline records status/meta/volumes; the sweeps only pull
+    the metrics dict, run capture_output, and label the run differently), so they stay in-caller.
+
+    `runtime` is only appended when not None; `--seg` only when a seg path is given (the pipeline gates
+    this on kind == 'chi' AND the file existing — it passes seg=None otherwise, matching that gate).
+    """
+    cmd = [python, str(eval_path), "--recon", str(recon), "--truth", str(truth), "--kind", kind,
+           "--mask", str(mask), "--artifact", artifact, "--out", str(out_json),
+           "--stage", stage, "--name", name, "--track", track]
+    if runtime is not None:
+        cmd += ["--runtime", str(runtime)]
+    if seg is not None:
+        cmd += ["--seg", str(seg)]
+    return cmd

--- a/scripts/combo_sweep.py
+++ b/scripts/combo_sweep.py
@@ -35,11 +35,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 EVAL = ROOT / "eval" / "qsm_eval.py"
+# Repo root on sys.path so `qsm_ci` resolves from a bare checkout (same pattern as pipeline.py);
+# scripts/ for the pipeline chain machinery we still reuse.
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "scripts"))
+from qsm_ci.scoring import gt_sources, eval_argv  # noqa: E402  shared primitives
 from pipeline import (  # noqa: E402  reuse the exact composed-chain machinery
     ARTIFACT_FILE, discover_algorithms, prepare_input, run_algo, _valid_mask,
 )
-from sweep import GRIDS, REFINE, combos, fmt, gt_sources  # noqa: E402  one grid definition, shared
+from sweep import GRIDS, REFINE, combos, fmt  # noqa: E402  one grid definition, shared
 
 # Which stages each swept slug belongs to is decided from discover_algorithms(), not hardcoded — so
 # the split below is derived at runtime. GRIDS/REFINE already list every method with a tunable knob.
@@ -53,13 +57,10 @@ def score_chi_xsim(recon: Path, gt_dir: Path, mask: Path, work: Path) -> dict:
     pipeline.score / sweep.score_xsim, so combo numbers are comparable to the leaderboard's."""
     sm = _valid_mask(recon, mask, work.with_suffix(".scoremask.nii.gz"))
     out_json = work.with_suffix(".score.json")
-    cmd = [sys.executable, str(EVAL), "--recon", str(recon),
-           "--truth", str(gt_dir / ARTIFACT_FILE["chimap"]), "--kind", "chi",
-           "--mask", str(sm), "--artifact", "chimap", "--out", str(out_json),
-           "--stage", "combo-sweep", "--name", "combo-sweep", "--track", "sim"]
     seg = gt_dir / "dseg.nii.gz"
-    if seg.exists():
-        cmd += ["--seg", str(seg)]
+    cmd = eval_argv(sys.executable, EVAL, recon, gt_dir / ARTIFACT_FILE["chimap"], "chi", sm,
+                    "chimap", out_json, stage="combo-sweep", name="combo-sweep", track="sim",
+                    seg=seg if seg.exists() else None)
     subprocess.run(cmd, check=True, capture_output=True)
     return json.loads(out_json.read_text())["metrics"]
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -40,6 +40,12 @@ EVAL = ROOT / "eval" / "qsm_eval.py"
 # not). qsm_ci.stages is pure literals — no yaml/heavy deps.
 sys.path.insert(0, str(ROOT))
 from qsm_ci.stages import STAGES, ARTIFACT_FILE, ARTIFACT_KIND  # noqa: E402
+# Shared scoring/sweep primitives (also used by scripts/sweep.py + combo_sweep.py) — one home for the
+# `qsm-ci run` argv builder, the GT source map, the --shard partition, and the qsm_eval argv, so the
+# scorer and the sweeps can't drift. Pure literals/argv assembly — no heavy deps at import.
+from qsm_ci.scoring import (  # noqa: E402
+    cli_run_argv, gt_sources as _gt_sources, parse_shard, shard_owns, shard_partition, eval_argv,
+)
 
 # Independent submission runs (each a Docker container + a scoring subprocess) are executed
 # concurrently, bounded by QSM_CI_JOBS. The cap is deliberately conservative: MATLAB MCR runs on
@@ -241,28 +247,6 @@ def prepare_input(consumes: list[str], sources: dict[str, Path], dest: Path) -> 
         shutil.copy(src, dest / ARTIFACT_FILE[art])
 
 
-def _cli_run_argv(algo: dict, input_dir: Path, output_dir: Path,
-                  runner: str = "docker", overrides: "dict | None" = None) -> list[str]:
-    """Build the `qsm-ci run …` argv that reproduces this submission's isolated container run.
-
-    Each consumed artifact becomes a `--<artifact> <input_dir>/<file>` flag (magnitude is optional —
-    only passed when present); the produced artifact is written with `-o <output_dir>/<file>`. Any
-    `overrides` become `--set NAME=VALUE` (the tuned pass). The CLI owns image resolution, mounting
-    run.sh, and injecting the QSMCI_* acquisition env vars — so the scorer no longer duplicates
-    (and drifts from) that logic."""
-    produced = algo["produces"][0]
-    argv = ["qsm-ci", "run", str(algo["dir"])]
-    for art in algo["consumes"]:
-        f = input_dir / ARTIFACT_FILE[art]
-        if art == "magnitude" and not f.exists():
-            continue  # optional — only some methods use it
-        argv += [f"--{art}", str(f)]
-    for k, v in (overrides or {}).items():
-        argv += ["--set", f"{k}={v}"]
-    argv += ["-o", str(output_dir / ARTIFACT_FILE[produced]), "--runner", runner]
-    return argv
-
-
 def run_algo(algo: dict, input_dir: Path, output_dir: Path, runner: str = "local",
              overrides: "dict | None" = None) -> float:
     if output_dir.exists():
@@ -277,7 +261,7 @@ def run_algo(algo: dict, input_dir: Path, output_dir: Path, runner: str = "local
         # Ask the CLI's container runner to trace this run's memory/CPU over time into the output dir
         # (resources.json); score()/emit_volumes() later copy it next to the viewer volumes.
         env = {**os.environ, "QSMCI_RESOURCES_OUT": str(output_dir / "resources.json")}
-        subprocess.run(_cli_run_argv(algo, input_dir, output_dir, runner, overrides),
+        subprocess.run(cli_run_argv(algo, input_dir, output_dir, ARTIFACT_FILE, runner, overrides),
                        check=True, env=env)
     else:
         if overrides:  # run.sh reads overrides from $IN/config.json (mirrors `qsm-ci run --set`)
@@ -323,15 +307,11 @@ def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, 
     # Score only where the method actually produced a value (its non-zero support), so an eroded
     # rim isn't penalised as error — consistent with masking that rim out of the pipeline.
     mask = _valid_mask(recon, mask, out_json.parent / (out_json.stem + "_scoremask.nii.gz"))
-    cmd = [sys.executable, str(EVAL), "--recon", str(recon),
-           "--truth", str(gt_dir / ARTIFACT_FILE[artifact]), "--kind", kind,
-           "--mask", str(mask), "--artifact", artifact, "--out", str(out_json),
-           "--stage", meta["stage"], "--name", meta["name"], "--track", meta["track"]]
-    if meta.get("runtime") is not None:
-        cmd += ["--runtime", str(meta["runtime"])]
     seg = gt_dir / "dseg.nii.gz"
-    if kind == "chi" and seg.exists():
-        cmd += ["--seg", str(seg)]
+    cmd = eval_argv(sys.executable, EVAL, recon, gt_dir / ARTIFACT_FILE[artifact], kind, mask,
+                    artifact, out_json, stage=meta["stage"], name=meta["name"], track=meta["track"],
+                    runtime=meta.get("runtime"),
+                    seg=seg if (kind == "chi" and seg.exists()) else None)
     subprocess.run(cmd, check=True)
     result = json.loads(out_json.read_text())
     # A scorable recon yields finite metrics; an all-NaN / empty output makes the scorer emit
@@ -414,23 +394,14 @@ def main() -> None:
 
     # --shard i/n : this job runs shard i of n. `_owns(index)` is a deterministic round-robin over a
     # stable ordering, so the n shards partition the work with no overlap and no gaps.
-    shard_i, shard_n = (None, None)
-    if args.shard:
-        shard_i, shard_n = (int(x) for x in args.shard.split("/"))
-        if not (0 <= shard_i < shard_n):
-            raise SystemExit(f"--shard i/n needs 0 <= i < n, got {args.shard}")
+    shard_i, shard_n = parse_shard(args.shard)
     def _owns(index):
-        return shard_n is None or index % shard_n == shard_i
+        return shard_owns(index, shard_i, shard_n)
 
     inputs, gt = args.dataset / "inputs", args.dataset / "groundtruth"
     mask, params = inputs / "mask.nii.gz", inputs / "params.json"
-    # GT-backed source map: inputs for raw artifacts, groundtruth for stage boundaries.
-    gt_sources = {
-        "phase": inputs / "phase.nii.gz", "magnitude": inputs / "magnitude.nii.gz",
-        "mask": mask, "params": params,
-        "totalfield": gt / "totalfield.nii.gz", "localfield": gt / "localfield.nii.gz",
-        "chimap": gt / "chimap.nii.gz",
-    }
+    # GT-backed source map: inputs for raw artifacts, groundtruth for stage boundaries (shared helper).
+    gt_sources = _gt_sources(args.dataset)
     algos = discover_algorithms()
     if args.include:
         keep = set(args.include.split(","))
@@ -492,7 +463,7 @@ def main() -> None:
                             args.track, variant=variant)]
 
         iso_tasks = [t for a in iso_algos for t in iso_variants(a)]
-        iso_tasks = [t for idx, t in enumerate(iso_tasks) if _owns(idx)]  # --shard: round-robin
+        iso_tasks = shard_partition(iso_tasks, args.shard)  # --shard: round-robin over a stable order
         for out in _pmap(iso_tasks, do_isolated):
             runs.extend(out)
         if not args.runs_out:
@@ -530,7 +501,7 @@ def main() -> None:
         if shard_n is not None:
             needed_fm = {tfk for (tfk, bs) in col_owner if tfk != "gt" and owns_col(tfk, bs)}
             fmap = [f for f in fmap if f["slug"] in needed_fm]
-            spans = [s for idx, s in enumerate(sorted(spans, key=lambda x: x["slug"])) if _owns(idx)]
+            spans = shard_partition(sorted(spans, key=lambda x: x["slug"]), args.shard)
 
         # Stage 1 — totalfield sources: the ground-truth field ("gt") plus each field-mapping
         # submission's output (run on raw inputs), so the matrix can start from raw phase.

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -26,7 +26,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 EVAL = ROOT / "eval" / "qsm_eval.py"
+# Put the repo root on sys.path so `qsm_ci` resolves straight from a bare checkout (same pattern as
+# pipeline.py). scripts/ is on the path too for the pipeline helpers we still reuse (run_algo etc.).
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "scripts"))
+from qsm_ci.scoring import cli_run_argv, gt_sources, eval_argv  # noqa: E402  shared primitives
 from pipeline import (  # noqa: E402  reuse the exact isolated-scoring machinery
     ARTIFACT_FILE, discover_algorithms, prepare_input, _valid_mask,
 )
@@ -71,16 +75,6 @@ _print_lock = threading.Lock()
 RUNNER = "docker"
 
 
-def gt_sources(dataset: Path) -> dict[str, Path]:
-    inputs, gt = dataset / "inputs", dataset / "groundtruth"
-    return {
-        "phase": inputs / "phase.nii.gz", "magnitude": inputs / "magnitude.nii.gz",
-        "mask": inputs / "mask.nii.gz", "params": inputs / "params.json",
-        "totalfield": gt / "totalfield.nii.gz", "localfield": gt / "localfield.nii.gz",
-        "chimap": gt / "chimap.nii.gz",
-    }
-
-
 def combos(grid: dict[str, list]) -> list[dict]:
     keys = list(grid)
     return [dict(zip(keys, vals)) for vals in itertools.product(*(grid[k] for k in keys))]
@@ -95,13 +89,10 @@ def score_xsim(recon: Path, artifact: str, gt: Path, mask: Path, work: Path) -> 
     kind = {"totalfield": "field", "localfield": "field", "chimap": "chi"}[artifact]
     sm = _valid_mask(recon, mask, work.with_suffix(".scoremask.nii.gz"))
     out_json = work.with_suffix(".score.json")
-    cmd = [sys.executable, str(EVAL), "--recon", str(recon),
-           "--truth", str(gt / ARTIFACT_FILE[artifact]), "--kind", kind,
-           "--mask", str(sm), "--artifact", artifact, "--out", str(out_json),
-           "--stage", "sweep", "--name", "sweep", "--track", "sim"]
     seg = gt / "dseg.nii.gz"
-    if kind == "chi" and seg.exists():
-        cmd += ["--seg", str(seg)]
+    cmd = eval_argv(sys.executable, EVAL, recon, gt / ARTIFACT_FILE[artifact], kind, sm,
+                    artifact, out_json, stage="sweep", name="sweep", track="sim",
+                    seg=seg if (kind == "chi" and seg.exists()) else None)
     subprocess.run(cmd, check=True, capture_output=True)
     return json.loads(out_json.read_text())["metrics"]
 
@@ -113,15 +104,9 @@ def run_one(algo: dict, override: dict, src: dict, work: Path) -> dict:
     odir = work / f"{slug}__{tag}__out"
     produced = algo["produces"][0]
     prepare_input(algo["consumes"], src, idir)  # stage GT inputs under canonical names
-    argv = ["qsm-ci", "run", str(algo["dir"])]
-    for art in algo["consumes"]:
-        f = idir / ARTIFACT_FILE[art]
-        if art == "magnitude" and not f.exists():
-            continue
-        argv += [f"--{art}", str(f)]
-    for k, v in override.items():
-        argv += ["--set", f"{k}={fmt(v)}"]
-    argv += ["-o", str(odir / ARTIFACT_FILE[produced]), "--runner", RUNNER]
+    # Shared argv builder — `fmt=fmt` reproduces the sweep's grid-value formatting (a swept float like
+    # 8.0 renders as `8`, this script's long-standing behaviour), so the emitted argv is unchanged.
+    argv = cli_run_argv(algo, idir, odir, ARTIFACT_FILE, RUNNER, override, fmt=fmt)
     rec = {"slug": slug, "stage": algo["stage"], "override": override, "tag": tag}
     try:
         odir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,216 @@
+"""Unit tests for the shared scoring/sweep primitives in qsm_ci.scoring.
+
+These cover the PURE helpers only — no Docker, no dataset, no scientific stack. They pin the exact
+argv/mapping/partition behaviour the three scripts (pipeline.py, sweep.py, combo_sweep.py) used to
+each keep an inline copy of, so a future edit that changes what the scorer runs fails here loudly.
+"""
+from pathlib import Path
+
+import pytest
+
+from qsm_ci.scoring import (
+    cli_run_argv, eval_argv, gt_sources, parse_shard, shard_owns, shard_partition,
+)
+from qsm_ci.stages import ARTIFACT_FILE as AF
+
+
+# ---------------------------------------------------------------- cli_run_argv
+
+
+def _algo(stage, consumes, produces, dir="/algos/x"):
+    return {"stage": stage, "consumes": consumes, "produces": produces, "dir": Path(dir)}
+
+
+def test_cli_run_argv_dipole_no_overrides():
+    algo = _algo("dipole", ["localfield", "mask", "params"], ["chimap"], "/algos/tkd")
+    argv = cli_run_argv(algo, Path("/in"), Path("/out"), AF)
+    assert argv == [
+        "qsm-ci", "run", "/algos/tkd",
+        "--localfield", "/in/localfield.nii.gz",
+        "--mask", "/in/mask.nii.gz",
+        "--params", "/in/params.json",
+        "-o", "/out/chimap.nii.gz", "--runner", "docker",
+    ]
+
+
+def test_cli_run_argv_bfr_and_fieldmapping():
+    bfr = _algo("bfr", ["totalfield", "mask", "params"], ["localfield"], "/algos/sharp")
+    assert cli_run_argv(bfr, Path("/in"), Path("/out"), AF) == [
+        "qsm-ci", "run", "/algos/sharp",
+        "--totalfield", "/in/totalfield.nii.gz",
+        "--mask", "/in/mask.nii.gz", "--params", "/in/params.json",
+        "-o", "/out/localfield.nii.gz", "--runner", "docker",
+    ]
+    fm = _algo("field-mapping", ["phase", "magnitude", "mask", "params"], ["totalfield"], "/algos/romeo")
+    argv = cli_run_argv(fm, Path("/in"), Path("/out"), AF)
+    # magnitude IS in consumes; without a real file on disk it is optional-skipped
+    assert "--magnitude" not in argv
+    assert argv[:5] == ["qsm-ci", "run", "/algos/romeo", "--phase", "/in/phase.nii.gz"]
+    assert argv[-4:] == ["-o", "/out/totalfield.nii.gz", "--runner", "docker"]
+
+
+def test_cli_run_argv_magnitude_optional_present(tmp_path):
+    """magnitude in consumes is emitted only when the file exists (the optional-input rule)."""
+    algo = _algo("bfr+dipole", ["totalfield", "mask", "params", "magnitude"], ["chimap"], "/algos/medi")
+    for fn in ("totalfield.nii.gz", "mask.nii.gz", "params.json"):
+        (tmp_path / fn).write_text("x")
+    # missing magnitude -> skipped
+    argv_missing = cli_run_argv(algo, tmp_path, Path("/out"), AF)
+    assert "--magnitude" not in argv_missing
+    # present magnitude -> included, in consumes order (last)
+    (tmp_path / "magnitude.nii.gz").write_text("x")
+    argv_present = cli_run_argv(algo, tmp_path, Path("/out"), AF)
+    assert ["--magnitude", str(tmp_path / "magnitude.nii.gz")] == argv_present[-6:-4]
+
+
+def test_cli_run_argv_overrides_default_str_format():
+    """Default value formatting is str(v) — the pipeline / run_algo (tuned pass) behaviour."""
+    algo = _algo("bfr", ["totalfield", "mask", "params"], ["localfield"], "/algos/resharp")
+    argv = cli_run_argv(algo, Path("/in"), Path("/out"), AF, "apptainer",
+                        {"radius": "15", "tik_reg": "0.001"})
+    assert "--runner" in argv and argv[argv.index("--runner") + 1] == "apptainer"
+    assert ["--set", "radius=15", "--set", "tik_reg=0.001"] == argv[-8:-4]
+
+
+def test_cli_run_argv_overrides_fmt_callable():
+    """sweep.py passes fmt so a swept float 8.0 renders as `8` (its long-standing behaviour)."""
+    def fmt(v):
+        return f"{v:g}" if isinstance(v, float) else str(v)
+
+    algo = _algo("bfr", ["totalfield", "mask", "params"], ["localfield"], "/algos/resharp")
+    argv = cli_run_argv(algo, Path("/in"), Path("/out"), AF, "docker",
+                        {"radius": 8.0, "tik_reg": 1e-3, "n": 5}, fmt=fmt)
+    sets = [argv[i + 1] for i, a in enumerate(argv) if a == "--set"]
+    assert sets == ["radius=8", "tik_reg=0.001", "n=5"]
+    # default (str) would instead give 8.0
+    argv_str = cli_run_argv(algo, Path("/in"), Path("/out"), AF, "docker", {"radius": 8.0})
+    assert "radius=8.0" in argv_str
+
+
+# ------------------------------------------------------------------ gt_sources
+
+
+def test_gt_sources_mapping():
+    ds = Path("/data/sim/dev")
+    src = gt_sources(ds)
+    assert src == {
+        "phase": ds / "inputs" / "phase.nii.gz",
+        "magnitude": ds / "inputs" / "magnitude.nii.gz",
+        "mask": ds / "inputs" / "mask.nii.gz",
+        "params": ds / "inputs" / "params.json",
+        "totalfield": ds / "groundtruth" / "totalfield.nii.gz",
+        "localfield": ds / "groundtruth" / "localfield.nii.gz",
+        "chimap": ds / "groundtruth" / "chimap.nii.gz",
+    }
+
+
+def test_gt_sources_raw_vs_boundary_split():
+    """Raw acquisition artifacts come from inputs/; stage boundaries from groundtruth/."""
+    src = gt_sources(Path("/d"))
+    assert "inputs" in src["phase"].parts and "inputs" in src["mask"].parts
+    for boundary in ("totalfield", "localfield", "chimap"):
+        assert "groundtruth" in src[boundary].parts
+
+
+# ------------------------------------------------------------ shard partition
+
+
+def test_parse_shard():
+    assert parse_shard(None) == (None, None)
+    assert parse_shard("") == (None, None)
+    assert parse_shard("0/1") == (0, 1)
+    assert parse_shard("2/5") == (2, 5)
+
+
+@pytest.mark.parametrize("spec", ["3/3", "5/3", "-1/3"])
+def test_parse_shard_out_of_range_raises(spec):
+    with pytest.raises(SystemExit):
+        parse_shard(spec)
+
+
+def test_shard_owns():
+    assert shard_owns(0, None, None) is True  # sharding off -> owns everything
+    assert shard_owns(7, None, None) is True
+    assert shard_owns(0, 0, 3) is True
+    assert shard_owns(3, 0, 3) is True
+    assert shard_owns(1, 0, 3) is False
+
+
+def test_shard_partition_none_returns_all():
+    items = list(range(10))
+    assert shard_partition(items, None) == items
+    assert shard_partition(items, "") == items
+    # returns a copy, not the same list object
+    assert shard_partition(items, None) is not items
+
+
+def test_shard_partition_preserves_order():
+    items = ["a", "b", "c", "d", "e", "f", "g"]
+    part = shard_partition(items, "0/2")
+    assert part == ["a", "c", "e", "g"]  # order preserved, round-robin stride
+    assert part == [x for x in items if x in part]
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 5, 7, 10, 13])
+def test_shard_partition_exact_cover(n):
+    """Union of all n shards == the input exactly once each; shards are disjoint."""
+    items = list(range(23))
+    union = []
+    for i in range(n):
+        part = shard_partition(items, f"{i}/{n}")
+        assert part == sorted(part)  # order preserved (ints ascending here)
+        union += part
+    assert sorted(union) == items
+    assert len(union) == len(items)  # no item counted twice
+
+
+def test_shard_partition_n_greater_than_len():
+    items = [10, 20, 30]
+    # 5 shards over 3 items: shards 0..2 get one each, 3 and 4 get nothing
+    parts = [shard_partition(items, f"{i}/5") for i in range(5)]
+    assert parts == [[10], [20], [30], [], []]
+    assert sorted(x for p in parts for x in p) == items
+
+
+def test_shard_partition_one_of_one():
+    items = list(range(6))
+    assert shard_partition(items, "0/1") == items
+
+
+# --------------------------------------------------------------------- eval_argv
+
+
+def test_eval_argv_pipeline_chi_with_runtime_and_seg():
+    argv = eval_argv("py", Path("/eval.py"), Path("/r.nii.gz"), Path("/gt/chimap.nii.gz"), "chi",
+                     Path("/m.nii.gz"), "chimap", Path("/o.json"),
+                     stage="bfr+dipole", name="medi", track="sim",
+                     runtime=12.5, seg=Path("/gt/dseg.nii.gz"))
+    assert argv == [
+        "py", "/eval.py", "--recon", "/r.nii.gz", "--truth", "/gt/chimap.nii.gz",
+        "--kind", "chi", "--mask", "/m.nii.gz", "--artifact", "chimap", "--out", "/o.json",
+        "--stage", "bfr+dipole", "--name", "medi", "--track", "sim",
+        "--runtime", "12.5", "--seg", "/gt/dseg.nii.gz",
+    ]
+
+
+def test_eval_argv_no_runtime_no_seg():
+    argv = eval_argv("py", Path("/e.py"), Path("/r"), Path("/t"), "field", Path("/m"),
+                     "localfield", Path("/o"), stage="sweep", name="sweep", track="sim")
+    assert "--runtime" not in argv and "--seg" not in argv
+    assert argv[-3:] == ["--name", "sweep", "--track"] or argv[-1] == "sim"
+    assert argv[-6:] == ["--stage", "sweep", "--name", "sweep", "--track", "sim"]
+
+
+def test_eval_argv_seg_without_runtime():
+    """sweep/combo pass seg but never runtime — seg must still land at the tail in the right order."""
+    argv = eval_argv("py", Path("/e.py"), Path("/r"), Path("/t"), "chi", Path("/m"),
+                     "chimap", Path("/o"), stage="combo-sweep", name="combo-sweep", track="sim",
+                     seg=Path("/gt/dseg.nii.gz"))
+    assert "--runtime" not in argv
+    assert argv[-2:] == ["--seg", "/gt/dseg.nii.gz"]
+
+
+def test_eval_argv_runtime_int_stringified():
+    argv = eval_argv("py", Path("/e.py"), Path("/r"), Path("/t"), "chi", Path("/m"),
+                     "chimap", Path("/o"), stage="dipole", name="tv", track="sim", runtime=3)
+    assert argv[argv.index("--runtime") + 1] == "3"


### PR DESCRIPTION
## Summary

Removes the copy-pasted scoring primitives that `scripts/pipeline.py`, `scripts/sweep.py` and `scripts/combo_sweep.py` each carried, by extracting the shared pure-ish helpers into one tested module, `qsm_ci/scoring.py`, and rewiring all three callers to import them.

**Stacks on #100** (branched off `refactor/pipeline-import-stages`, not `main`, to avoid `pipeline.py` conflicts). Does **not** touch `qsm_ci/runner.py` (owned by #99) or `eval/qsm_eval.py`.

## What moved to `qsm_ci/scoring.py`

- `cli_run_argv(...)` — the `qsm-ci run …` argv builder (per-artifact `--<art>` flags, magnitude-optional skip, `--set NAME=VALUE` overrides, `-o … --runner …`). It takes an optional `fmt` callable for override *values*: the default `str(v)` matches pipeline/`run_algo`; sweep passes its `fmt` so a swept float like `8.0` still renders as `8` (its long-standing, and deliberately different, formatting).
- `gt_sources(dataset)` — artifact → GT-source path map (raw artifacts from `inputs/`, stage boundaries from `groundtruth/`).
- `parse_shard(spec)` / `shard_owns(index, i, n)` / `shard_partition(items, spec)` — the `--shard i/n` round-robin partition, pulled out of `pipeline.main()`.
- `eval_argv(...)` — the `python qsm_eval.py …` flag assembly the three scoring wrappers shared (`--runtime` and `--seg` gated exactly as each caller did).

No heavy deps at module import — nothing imports numpy/nibabel/subprocess at top level, matching the standalone-script style (a bare `python scripts/pipeline.py` builds argv / parses shards without the scientific stack).

## What I deliberately did NOT unify (and why)

The three **scoring wrappers** — `pipeline.score`, `sweep.score_xsim`, `combo_sweep.score_chi_xsim` — stay separate. They are not identical: different `--stage`/`--name`/`--track` labels (`isolated`/composed meta vs `sweep` vs `combo-sweep`), pipeline passes `--runtime` while the sweeps never do, the sweeps use `capture_output=True`, pipeline layers on status/DNF classification, meta merge, and `emit_volumes`, and the return shapes differ (full result dict vs bare `metrics`). Only the genuinely-identical **argv assembly** inside them was factored into `eval_argv`; the mask build (nibabel), the `subprocess.run` call, and result handling stay in each caller. `_valid_mask` (nibabel-dependent) also stays in `pipeline.py` where sweep/combo already import it — moving it would add a nibabel import concern to the shared module for no dedup gain.

## Equivalence evidence (behaviour unchanged)

Reconstructed each script's OLD inline logic and asserted byte-identical output vs the new helpers:

- **cli_run_argv** — dipole/bfr/field-mapping stages; magnitude present vs missing; string overrides (pipeline tuned pass) and float/int overrides (sweep, incl. `8.0` → `8` via `fmt`): **all identical**.
- **gt_sources** — dev/scoring/abs datasets: **identical mappings**.
- **shard_partition** — for n ∈ {1,2,3,5,7,23,30,100} the union of all n shards equals the input exactly once each (disjoint, order-preserving), `n > len` leaves trailing shards empty, `1/1` returns all, `None`/`""` returns all: **matches old `_owns`**.
- **eval_argv** — pipeline (chi+runtime+seg / field no-runtime-no-seg / chi+runtime+seg-missing), sweep (chi+seg / field), combo (chi+seg / chi-no-seg): **all identical flag order**.

## Verification

- `python3 eval/qsm_eval.py --selfcheck` → ok
- `pytest tests/test_scoring.py tests/test_stages_sync.py tests/test_manifest.py tests/test_runner_help.py tests/test_submissions.py tests/test_registry.py eval/test_metrics.py` → **97 passed** (test_pipeline.py also green; its integration test skips without a dataset)
- `python3 scripts/pipeline.py --help`, `scripts/sweep.py --help`, `scripts/combo_sweep.py --help` → all exit 0, standalone, no install (each uses the `sys.path.insert(0, ROOT)` pattern so `qsm_ci` resolves from a bare checkout)
- Grep confirms no caller retains a stale inline copy (`"qsm-ci", "run"` literal, inline `gt_sources` def, inline `--recon` cmd list, `_cli_run_argv` refs, inline shard `split("/")`) and all modules import cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)