### PR TITLE
refactor(pipeline): parse algorithm.yml with pyyaml instead of regex

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -23,12 +23,13 @@ import concurrent.futures as _cf
 import json
 import math
 import os
-import re
 import shutil
 import subprocess
 import sys
 import time
 from pathlib import Path
+
+import yaml
 
 ROOT = Path(__file__).resolve().parent.parent
 EVAL = ROOT / "eval" / "qsm_eval.py"
@@ -192,21 +193,32 @@ def _emit_composed_resources(run_id: str, stages: list, emit_volumes_on: bool) -
         pass
 
 
-def _tuned_overrides(text: str) -> dict:
-    """Extract `{param: tuned_value}` from an algorithm.yml `parameters:` block — the settings we
-    optimised on the scoring phantom (each parameter may carry a `tuned:` alongside its `default:`).
-    Regex, not YAML, to keep this module dependency-free like the rest of the runner. The block runs
-    to the next top-level key (or EOF), NOT to the next non-space line — YAML list items may be
-    unindented (`- name:` at column 0, as the MATLAB ymls write them), and those must not end it."""
-    m = re.search(r"^parameters:[ \t]*\n(.*?)(?=^[A-Za-z_]|\Z)", text, re.M | re.S)
-    if not m:
+def _yaml_scalar(v) -> str:
+    """Render a parsed YAML scalar as the bare token the old regex captured (`\\S+`).
+
+    The previous parser read `stage:`/`image:`/`tuned:`/list items straight out of the text as
+    strings, so every consumer downstream expects a `str`. yaml.safe_load instead coerces `520`→int,
+    `0.00015`→float, etc. Stringifying restores the old type/shape without a lossy re-parse — and for
+    every value in the repo's ymls `str(safe_load(tok)) == tok` (ints, plain floats, and `NeM`
+    exponents alike), so the tuned/optional/stage strings are byte-identical to the regex output."""
+    return str(v)
+
+
+def _tuned_overrides(doc: dict) -> dict:
+    """Extract `{param: tuned_value}` from a parsed algorithm.yml `parameters:` block — the settings
+    we optimised on the scoring phantom (each parameter may carry a `tuned:` alongside its
+    `default:`). Values are returned as strings to match the old regex parser (they flow into
+    `overrides` -> config.json / `--set`, which expect the raw token). YAML handles the unindented
+    list items (`- name:` at column 0, as the MATLAB ymls write them) that the old regex needed a
+    special workaround for."""
+    params = doc.get("parameters")
+    if not isinstance(params, list):
         return {}
     out = {}
-    for item in re.split(r"^[ \t]*-[ \t]*name:[ \t]*", m.group(1), flags=re.M)[1:]:
-        name = item.splitlines()[0].strip()
-        tm = re.search(r"^[ \t]*tuned:[ \t]*(\S+)", item, re.M)
-        if tm:
-            out[name] = tm.group(1)
+    for item in params:
+        if not isinstance(item, dict) or "name" not in item or "tuned" not in item:
+            continue
+        out[_yaml_scalar(item["name"])] = _yaml_scalar(item["tuned"])
     return out
 
 
@@ -216,23 +228,28 @@ def discover_algorithms() -> list[dict]:
         spec = d / "algorithm.yml"
         if d.name.startswith("_") or not spec.exists():
             continue
-        text = spec.read_text()
-        stage = re.search(r"^stage:\s*(\S+)", text, re.M)
-        image = re.search(r"^image:\s*(\S+)", text, re.M)
-        if not stage:
+        try:
+            doc = yaml.safe_load(spec.read_text())
+        except yaml.YAMLError:
+            # A malformed yaml the old regex parser might have limped past — skip rather than crash
+            # the whole discovery, matching the old `if not stage: continue` graceful behaviour.
             continue
-        s = stage.group(1)
+        if not isinstance(doc, dict) or doc.get("stage") is None:
+            continue
+        s = _yaml_scalar(doc["stage"])
+        image = doc.get("image")
         # A method may declare optional extra inputs (algorithm.yml `optional_inputs:`) beyond its
         # stage's baseline — e.g. MEDI (dipole) uses magnitude for edge weighting. Append them so the
         # scorer mounts + passes exactly what `qsm-ci run` accepts (its _consumes does the same);
         # otherwise it passes a flag the CLI rejects (--magnitude) and the run DNFs.
-        opt = re.search(r"^optional_inputs:\s*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n?)+)", text, re.M)
-        optional = re.findall(r"-[ \t]*(\S+)", opt.group(1)) if opt else []
+        opt = doc.get("optional_inputs")
+        optional = [_yaml_scalar(a) for a in opt] if isinstance(opt, list) else []
         consumes = STAGES[s]["consumes"] + [a for a in optional if a not in STAGES[s]["consumes"]]
         algos.append({
-            "slug": d.name, "dir": d, "stage": s, "image": image.group(1) if image else None,
+            "slug": d.name, "dir": d, "stage": s,
+            "image": _yaml_scalar(image) if image is not None else None,
             "consumes": consumes, "produces": STAGES[s]["produces"],
-            "tuned": _tuned_overrides(text),
+            "tuned": _tuned_overrides(doc),
         })
     return algos
 


### PR DESCRIPTION
## What

Replace the brittle regex/line parsing of `algorithm.yml` in `scripts/pipeline.py` with real YAML parsing via `yaml.safe_load`. `pyyaml` is already a dependency (used by `qsm_ci/runner.py` `_parse_manifest` and `scripts/gen_manifest.py`).

Two functions changed, **only in `scripts/pipeline.py`**:

- **`discover_algorithms`** — now `yaml.safe_load`s each spec and reads `stage` / `image` / `optional_inputs` from the parsed dict instead of per-field regexes.
- **`_tuned_overrides`** — now takes the parsed dict and reads `parameters[].tuned` directly. This removes the special-case workaround the old docstring described for **unindented YAML list items** (`- name:` at column 0, as the MATLAB ymls write them) that broke a naive block-scan.

A small `_yaml_scalar(v) -> str` shim keeps the returned tokens as the same **strings** the regex captured (yaml would otherwise coerce `520`→int, `0.00015`→float). These strings flow into `overrides` → `config.json` / `--set`, which expect the raw token. For every value in the repo's ymls, `str(safe_load(tok)) == tok`.

Malformed yaml is caught and skipped (`continue`), preserving the old `if not stage: continue` graceful behaviour rather than crashing discovery.

## Equivalence proof

A scratch harness imported the **old** regex functions (from `origin/refactor/pipeline-decompose-main`) and the **new** yaml functions, ran both over **every** `algorithms/*/algorithm.yml`, and diffed:

```
algorithm.yml files scanned: 46
OLD discovered algos: 46   NEW discovered algos: 46
tuned_overrides diffs: 0
tuned value TYPE diffs: 0
discover_algorithms diffs: 0
RESULT: IDENTICAL across all algorithms.
```

Byte-identical results (values and types) for both functions across all 46 algorithms — no behavior change.

## Tests

- `pytest tests/test_scoring.py tests/test_stages_sync.py tests/test_manifest.py tests/test_runner_help.py tests/test_submissions.py tests/test_registry.py eval/test_metrics.py -q` → **97 passed**
- `python3 scripts/pipeline.py --help` → exit 0
- `python3 eval/qsm_eval.py --selfcheck` → `[qsm-eval] selfcheck ok`

## Scope

Does **not** touch `qsm_ci/runner.py` (refactored by #99) or `score.yml`'s shell-side `is_self_hosted` grep. Only `scripts/pipeline.py`.

Stacks on #103 (top of the backend stack #100→#101→#103); base branch `refactor/pipeline-decompose-main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)