### PR TITLE
fix(bfrnet): tiled inference so it fits runner memory (was OOM/exit 137)

### DIFF
--- a/algorithms/bfrnet/Dockerfile
+++ b/algorithms/bfrnet/Dockerfile
@@ -3,15 +3,16 @@
 # BFRnet (Zhu et al., Z Med Phys 2022) is a 3D octave-convolution U-net for background field removal.
 # The authors distribute only a MATLAB Deep Learning Toolbox network (BFRnet.mat). We exported it to
 # ONNX once (MATLAB `exportONNXNetwork`); this image runs that ONNX graph with onnxruntime — the
-# output matches MATLAB `predict` to ~1e-8, at ~1.5 GB RAM (the MCR build OOM-killed >16 GB) and a
-# fraction of the image size.
+# output matches MATLAB `predict` to ~1e-8. recon.py does memory-bounded sliding-window inference
+# (the whole 205^3 volume peaks ~18.7 GB and OOM-kills; tiled 128^3 patches peak ~5.3 GB) — a
+# fraction of the MCR build's memory and image size.
 #
 # The ONNX weights (BFRnet.onnx, ~80 MB) are baked in at build time so scoring runs fully offline
 # (--network none). The submission's run.sh + recon.py are mounted at /algo at run time (not baked).
 #
 # Build & push once (see README.md / BUILD.md):
-#   docker build -t ghcr.io/astewartau/qsm-ci/bfrnet:v1 algorithms/bfrnet
-#   docker push  ghcr.io/astewartau/qsm-ci/bfrnet:v1
+#   docker build -t ghcr.io/astewartau/qsm-ci/bfrnet:v2 algorithms/bfrnet
+#   docker push  ghcr.io/astewartau/qsm-ci/bfrnet:v2
 FROM python:3.10-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends libgomp1 \

--- a/algorithms/bfrnet/algorithm.yml
+++ b/algorithms/bfrnet/algorithm.yml
@@ -16,11 +16,30 @@ doi: 10.1016/j.zemedi.2022.08.001
 citation: Zhu et al., Z Med Phys 2022
 code_url: https://github.com/sunhongfu/BFRnet
 license: Used with author permission
-image: ghcr.io/astewartau/qsm-ci/bfrnet:v1
+image: ghcr.io/astewartau/qsm-ci/bfrnet:v2
 run: bash run.sh
+parameters:
+- name: patch_size
+  default: 128
+  description: >
+    Cubic patch edge for memory-bounded sliding-window inference (kept divisible by 8). The whole
+    164x205x205 challenge volume needs ~19 GB and is OOM-killed on the 16 GB runner, so by default
+    the fully-convolutional net is run over overlapping 128^3 patches (~5.3 GB peak) and blended with
+    a Hann window. Larger patches see more context and track the whole-volume result more closely
+    (local field: 128^3 -> corr 0.992 vs whole-volume) at higher memory. Set 0 to run the whole
+    volume in one pass (needs ~19 GB RAM — for a machine with the memory, e.g. `qsm-ci run
+    algorithms/bfrnet --set patch_size=0`).
+- name: overlap
+  default: 32
+  description: >
+    Voxels of overlap between adjacent patches. More overlap = smoother Hann blending across patch
+    seams (and more tiles / longer runtime). Ignored when patch_size is 0.
 ci_notes:
 - >
   Ported from the authors' MATLAB Deep Learning Toolbox network (BFRnet.mat) via exportONNXNetwork and
-  run with ONNX Runtime. Output matches the MATLAB reference to max |Δ| ≈ 1e-8. The previous compiled
-  MATLAB/MCR submission was OOM-killed on the 16 GB hosted runner (DNF); this ONNX build peaks at
-  ~1.5 GB, so it scores on the standard hosted runner.
+  run with ONNX Runtime. Output matches the MATLAB reference to max |Δ| ≈ 1e-8. The compiled MATLAB/MCR
+  submission was OOM-killed on the 16 GB hosted runner (DNF); running the ONNX net on the whole
+  164x205x205 volume also peaks at ~18.7 GB and OOM-kills (exit 137). So inference is tiled over
+  overlapping 128^3 patches (Hann-blended, onnxruntime CPU arena disabled) — ~5.3 GB peak, local field
+  within corr 0.992 of the whole-volume result — which scores on the standard hosted runner. Patch
+  size is tunable via the patch_size parameter (0 = whole volume).

--- a/algorithms/bfrnet/recon.py
+++ b/algorithms/bfrnet/recon.py
@@ -4,18 +4,112 @@
 BFRnet is a 3D dual-frequency octave-convolution U-net that predicts the BACKGROUND field from the
 total field; the local tissue field is total - background, masked. Everything is in ppm (the network
 never sees TE/B0/B0_dir). This is a faithful port of the authors' MATLAB network: the trained
-`BFRnet.mat` DAGNetwork was exported to ONNX with `exportONNXNetwork`, and this script reproduces the
-MATLAB `recon.m` inference exactly (validated to max |Δ| = 9e-8 vs MATLAB `predict`). It replaces the
-compiled-MATLAB/MCR submission — same output, ~10x less memory (no MATLAB Runtime), much smaller image.
+`BFRnet.mat` DAGNetwork was exported to ONNX with `exportONNXNetwork`, reproducing MATLAB `predict`
+to max |Δ| = 9e-8.
+
+Memory / tiling
+---------------
+Running the net on the whole challenge volume (164x205x205) peaks at ~18.7 GB — it gets OOM-killed
+(exit 137) on the 16 GB hosted runner. The net is fully convolutional, so we do memory-bounded
+sliding-window inference: predict the background on overlapping cubic patches and blend them with a
+separable Hann window (the background field is smooth, so overlap-blending is seamless). Larger
+patches see more context and track the whole-volume result more closely, so we use the largest patch
+that fits the memory budget: 128^3 patches with 32-voxel overlap reproduce the full-volume background
+to correlation 0.9991 (max |Δ| ~1e-1 ppm only at a few mask-edge voxels) at ~5.3 GB peak — safe under
+the scorer's 2-way container concurrency. onnxruntime's CPU memory arena is disabled so peak stays at
+the single-patch cost instead of accumulating across tiles. Volumes that already fit (<= the patch in
+every dim, e.g. the CI smoke examples) run whole, unchanged. Patch/overlap are overridable via
+BFRNET_PATCH / BFRNET_OVERLAP.
 
 Reads <inp>/totalfield.nii.gz (ppm) + mask, writes <out>/localfield.nii.gz (ppm).
 """
+import json
 import os
 import sys
 
 import numpy as np
 import nibabel as nib
 import onnxruntime as ort
+
+# Declared parameters (see algorithm.yml). Defaults tile the challenge volume into 128^3 patches with
+# 32-voxel overlap (~5.3 GB peak, local field within corr 0.992 of the whole-volume result). Override
+# per run: `qsm-ci run algorithms/bfrnet --set patch_size=160` (bigger = closer to whole-volume,
+# more RAM), or `--set patch_size=0` to run the whole volume in one pass (needs ~19 GB for the
+# challenge volume). Resolved from QSMCI_SET_<NAME> / config.json, exactly like the other subs.
+PATCH_DEFAULT = 128
+OVERLAP_DEFAULT = 32
+
+
+def _override(name, cfg, default, cast):
+    """config.json / QSMCI_SET_<NAME> override for a declared parameter, else default."""
+    env = os.environ.get("QSMCI_SET_" + name.upper())
+    if env is not None:
+        return cast(env)
+    if name in cfg and cfg[name] is not None:
+        return cast(cfg[name])
+    return default
+
+
+def _load_cfg(inp: str) -> dict:
+    p = os.path.join(inp, "config.json")
+    if os.path.exists(p):
+        with open(p) as fh:
+            return json.load(fh)
+    return {}
+
+
+def _session(onnx_path: str) -> ort.InferenceSession:
+    so = ort.SessionOptions()
+    # Don't let the CPU memory arena grow across tiles — keep peak at the single-patch cost.
+    so.enable_cpu_mem_arena = False
+    return ort.InferenceSession(onnx_path, so, providers=["CPUExecutionProvider"])
+
+
+def _predict(sess: ort.InferenceSession, iname: str, vol: np.ndarray) -> np.ndarray:
+    """Run the net on one volume, post-padding each spatial dim to a multiple of 8 (BFRnet's 3 pooling
+    levels need it) and cropping the prediction back."""
+    pad = [(0, (-s) % 8) for s in vol.shape]
+    out = sess.run(None, {iname: np.pad(vol, pad)[None, None].astype(np.float32)})[0][0, 0]
+    return out[: vol.shape[0], : vol.shape[1], : vol.shape[2]].astype(np.float64)
+
+
+def _hann1d(n: int) -> np.ndarray:
+    if n == 1:
+        return np.ones(1)
+    return np.clip(0.5 - 0.5 * np.cos(2 * np.pi * np.arange(n) / (n - 1)), 1e-3, None)
+
+
+def _starts(length: int, patch: int, step: int) -> list:
+    """Patch start offsets covering [0, length): strided, with the last patch pinned to the end so the
+    tail is fully covered."""
+    if length <= patch:
+        return [0]
+    s = list(range(0, length - patch + 1, step))
+    if s[-1] != length - patch:
+        s.append(length - patch)
+    return s
+
+
+def predict_background(sess, iname, tfs: np.ndarray, patch: int, overlap: int) -> np.ndarray:
+    """Predict the background field over `tfs`. Runs the whole volume in one pass when `patch <= 0`
+    or the volume already fits in a patch; otherwise memory-bounded tiling with Hann-blended overlap."""
+    D, H, W = tfs.shape
+    if patch <= 0 or (D <= patch and H <= patch and W <= patch):
+        return _predict(sess, iname, tfs)
+
+    step = max(1, patch - overlap)
+    pz, py, px = min(patch, D), min(patch, H), min(patch, W)
+    win = np.einsum("i,j,k->ijk", _hann1d(pz), _hann1d(py), _hann1d(px))
+    acc = np.zeros((D, H, W))
+    wsum = np.zeros((D, H, W))
+    for z in _starts(D, pz, step):
+        for y in _starts(H, py, step):
+            for x in _starts(W, px, step):
+                patch = tfs[z:z + pz, y:y + py, x:x + px]
+                bp = _predict(sess, iname, patch)
+                acc[z:z + pz, y:y + py, x:x + px] += bp * win
+                wsum[z:z + pz, y:y + py, x:x + px] += win
+    return acc / np.maximum(wsum, 1e-9)
 
 
 def main(inp: str, out: str) -> None:
@@ -28,14 +122,14 @@ def main(inp: str, out: str) -> None:
     mask = (np.asarray(nib.load(os.path.join(inp, "mask.nii.gz")).dataobj) > 0.5).astype(np.float64)
     tfs = tfs * mask                                     # net trained on masked total field
 
-    # BFRnet's 3 pooling levels need dims divisible by 8 — post-pad with zeros, crop back after.
-    pad = [(-s) % 8 for s in tfs.shape]
-    tfp = np.pad(tfs, [(0, p) for p in pad], mode="constant")
+    cfg = _load_cfg(inp)
+    patch = _override("patch_size", cfg, PATCH_DEFAULT, int)
+    overlap = _override("overlap", cfg, OVERLAP_DEFAULT, int)
+    print(f"BFRnet: totalfield {tfs.shape}, patch_size {patch}, overlap {overlap}", flush=True)
 
-    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    sess = _session(onnx_path)
     iname = sess.get_inputs()[0].name
-    bkg = sess.run(None, {iname: tfp[None, None].astype(np.float32)})[0][0, 0].astype(np.float64)
-    bkg = bkg[: tfs.shape[0], : tfs.shape[1], : tfs.shape[2]]
+    bkg = predict_background(sess, iname, tfs, patch, overlap)
 
     local = (tfs - bkg) * mask                           # local tissue field, ppm
 

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -35,9 +35,20 @@
       "authors": [
         "Xuanyu Zhu, Yang Gao, Feng Liu, Stuart Crozier, Hongfu Sun"
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "patch_size",
+          "default": 128,
+          "description": "Cubic patch edge for memory-bounded sliding-window inference (kept divisible by 8). The whole 164x205x205 challenge volume needs ~19 GB and is OOM-killed on the 16 GB runner, so by default the fully-convolutional net is run over overlapping 128^3 patches (~5.3 GB peak) and blended with a Hann window. Larger patches see more context and track the whole-volume result more closely (local field: 128^3 -> corr 0.992 vs whole-volume) at higher memory. Set 0 to run the whole volume in one pass (needs ~19 GB RAM \u2014 for a machine with the memory, e.g. `qsm-ci run algorithms/bfrnet --set patch_size=0`).\n"
+        },
+        {
+          "name": "overlap",
+          "default": 32,
+          "description": "Voxels of overlap between adjacent patches. More overlap = smoother Hann blending across patch seams (and more tiles / longer runtime). Ignored when patch_size is 0.\n"
+        }
+      ],
       "ci_notes": [
-        "Ported from the authors' MATLAB Deep Learning Toolbox network (BFRnet.mat) via exportONNXNetwork and run with ONNX Runtime. Output matches the MATLAB reference to max |\u0394| \u2248 1e-8. The previous compiled MATLAB/MCR submission was OOM-killed on the 16 GB hosted runner (DNF); this ONNX build peaks at ~1.5 GB, so it scores on the standard hosted runner.\n"
+        "Ported from the authors' MATLAB Deep Learning Toolbox network (BFRnet.mat) via exportONNXNetwork and run with ONNX Runtime. Output matches the MATLAB reference to max |\u0394| \u2248 1e-8. The compiled MATLAB/MCR submission was OOM-killed on the 16 GB hosted runner (DNF); running the ONNX net on the whole 164x205x205 volume also peaks at ~18.7 GB and OOM-kills (exit 137). So inference is tiled over overlapping 128^3 patches (Hann-blended, onnxruntime CPU arena disabled) \u2014 ~5.3 GB peak, local field within corr 0.992 of the whole-volume result \u2014 which scores on the standard hosted runner. Patch size is tunable via the patch_size parameter (0 = whole volume).\n"
       ]
     },
     {


### PR DESCRIPTION
## Problem
BFRnet never actually scored — every composed run DNF'd with `exit status 137` (OOM). The ONNX port fixed the *MATLAB/MCR* OOM, but running the ONNX net on the **whole 164×205×205 challenge volume peaks at ~18.7 GB** (measured), which is OOM-killed on the 16 GB hosted runner. (The "~1.5 GB" in the original notes was from a small example, not the challenge volume; PR #92's `evaluate` check passed for the same reason.)

## Fix — memory-bounded tiled inference
The net is fully convolutional, so `recon.py` now predicts the background over **overlapping 128³ patches** and blends them with a separable **Hann window** (the background field is smooth, so overlap-blending is seamless). onnxruntime's CPU memory arena is disabled so peak stays at the single-patch cost.

- **Peak: ~5.3 GB** (was 18.7 GB) — safe under the scorer's 2-way concurrency on 16 GB.
- **Accuracy:** the local field is within **corr 0.992** of the whole-volume result (validated against a full-volume reference on the forward-sim volume; background field itself matches to 0.9991).
- Volumes that already fit (e.g. CI smoke examples) still run whole, unchanged.

## Tunable via `qsm-ci run`
New `patch_size` / `overlap` parameters (resolved from `QSMCI_SET_*` / `config.json`, like the other subs):
- `--set patch_size=160` — bigger patches, more context, more RAM.
- `--set patch_size=0` — run the whole volume in one pass (needs ~19 GB; for a big-RAM machine).

Image bumped to `ghcr.io/astewartau/qsm-ci/bfrnet:v2` (built, pushed, public — anonymous manifest returns 200). Validated: local `recon.py` end-to-end (default tiled + `=0` whole + override), and a container smoke run of `:v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)