### PR TITLE
fix(score): make the results commit race-safe (use merge_index.py, not rebase)

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -212,6 +212,9 @@ jobs:
 
       - name: Merge shard runs into results/index.json
         run: |
+          # Preserve the index this rescore STARTED from (its checkout base) — the commit step needs
+          # it to re-apply only the runs THIS rescore changed onto the latest main at push time.
+          cp results/index.json /tmp/base-index.json
           python3 - <<'PY'
           import json, glob
           from collections import Counter
@@ -242,11 +245,23 @@ jobs:
         run: |
           git config user.name  "qsm-ci-bot"
           git config user.email "qsm-ci@users.noreply.github.com"
-          git add results/index.json
-          git commit -m "Update results" || { echo "no changes"; exit 0; }
+          # This rescore's scored output (base + freshly scored runs).
+          cp results/index.json /tmp/scored-index.json
+          # Never `git pull --rebase` results/index.json: a rescore based on a commit before another
+          # rescore's results landed conflicts on the same file, leaving the loop stuck on "unmerged
+          # files" (the #72 / observed BFRnet-publish failure). Instead, each attempt takes the LATEST
+          # index from main and re-applies ONLY the runs THIS rescore changed (by id, via
+          # merge_index.py), so concurrent rescores of different slugs never clobber each other.
           for attempt in 1 2 3 4 5; do
-            git pull --rebase origin main && git push && exit 0
-            echo "push attempt $attempt rejected — retrying"; sleep $((attempt * 5))
+            git fetch origin main -q
+            git reset --hard origin/main -q          # HEAD + results/index.json = latest main
+            python3 scripts/merge_index.py /tmp/base-index.json /tmp/scored-index.json \
+                    results/index.json results/index.json
+            git add results/index.json
+            git diff --cached --quiet && { echo "no changes to publish"; exit 0; }
+            git commit -q -m "Update results"
+            git push && exit 0
+            echo "push attempt $attempt rejected — re-applying onto latest main"; sleep $((attempt * 3))
           done
           echo "::error::could not push results after 5 attempts"; exit 1
 


### PR DESCRIPTION
The `merge` job's commit step retried a failed push with `git pull --rebase origin main`. When a rescore is based on a commit *before* another rescore's results landed, that rebase **conflicts on `results/index.json`** and leaves the repo mid-rebase — so every subsequent retry fails with *"Pulling is not possible because you have unmerged files"* and the loop can never recover. This is the original #72 failure, and it's what silently dropped the BFRnet / refactor-integration publish (the log showed *"merged 752 shard runs"* then 5 failed push attempts).

`scripts/merge_index.py` was written for exactly this — take the **latest** `index.json` from main and upsert **only the runs this rescore changed** (by id). This wires the commit loop to it: each attempt `git reset --hard origin/main` then re-applies our changed runs via `merge_index.py`, so:
- concurrent rescores of **different slugs** never clobber each other,
- a stale base is harmless (a full rescore still overwrites everything; a focused one touches only its slugs),
- no rebase, so no "unmerged files" dead-end.

Verified the race logic with a unit test (our change applied + a concurrent change preserved). `score.yml` YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)