### PR TITLE
ci(score): hosted-long routing; run modip on the public runner at full quality

### DIFF
--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -97,35 +97,41 @@ jobs:
           TASKS=$(python3 - <<'PY'
           import json, os, re, glob
           full = os.environ['FULL'] == 'true'
-          # Per-task runner routing. A method may set `runner: self-hosted` in its algorithm.yml to run
-          # on QSM-CI's 31 GB private runners (more RAM, no 180-min hosted cap, 4 concurrent containers)
-          # instead of ubuntu-latest — needed by heavy DL/optimization methods. Only the two self-hosted
-          # runners run in parallel, so keep the self-hosted set small.
-          HOSTED     = {'runs_on': 'ubuntu-latest', 'timeout': 180, 'jobs': 2}
-          SELFHOSTED = {'runs_on': ['self-hosted', 'Linux', 'X64'], 'timeout': 360, 'jobs': 4}
-          def is_self_hosted(text):
-              m = re.search(r'^runner:[ \t]*(\S+)', text, re.M)
-              return bool(m and m.group(1) == 'self-hosted')
+          # Per-task runner routing, chosen by each method's `runner:` field in its algorithm.yml:
+          #   (unset)      -> HOSTED:      ubuntu-latest, 180-min cap, 2 concurrent containers. Default;
+          #                   scored inside the parallel shard sweep.
+          #   hosted-long  -> HOSTED_LONG: ubuntu-latest but the full 6-h GitHub cap and 1 container
+          #                   (full 16 GB), for methods that FIT hosted memory but exceed 180 min
+          #                   (e.g. modip: a slow per-subject CPU optimization). Its own focused job.
+          #   self-hosted  -> SELFHOSTED:  QSM-CI's 31 GB private runners (more RAM), for methods that
+          #                   OOM the 16 GB hosted box. Its own focused job; only 2 run in parallel.
+          # hosted-long + self-hosted methods run as dedicated --focus jobs and are excluded from the
+          # 180-min shard sweep (which can't give them the time/memory they need).
+          HOSTED      = {'runs_on': 'ubuntu-latest', 'timeout': 180, 'jobs': 2}
+          HOSTED_LONG = {'runs_on': 'ubuntu-latest', 'timeout': 360, 'jobs': 1}
+          SELFHOSTED  = {'runs_on': ['self-hosted', 'Linux', 'X64'], 'timeout': 360, 'jobs': 4}
           def route(slug):
               try: t = open(f'algorithms/{slug}/algorithm.yml').read()
               except FileNotFoundError: return HOSTED
-              return SELFHOSTED if is_self_hosted(t) else HOSTED
-          def all_self_hosted():
+              m = re.search(r'^runner:[ \t]*(\S+)', t, re.M)
+              return {'self-hosted': SELFHOSTED, 'hosted-long': HOSTED_LONG}.get(m.group(1) if m else '', HOSTED)
+          def dedicated():
+              # Methods that run as their own focused job (not the shard sweep): anything not plain HOSTED.
               out = []
               for p in sorted(glob.glob('algorithms/*/algorithm.yml')):
                   slug = p.split('/')[1]
-                  if not slug.startswith('_') and is_self_hosted(open(p).read()):
+                  if not slug.startswith('_') and route(slug) is not HOSTED:
                       out.append(slug)
               return out
           if full:
-              # Full re-run: hosted shards score the whole matrix MINUS the self-hosted methods
-              # (pipeline.py --exclude), and each self-hosted method runs as its own focused job on the
-              # private runner (--focus). Union = the full matrix, every method on the right runner.
+              # Full re-run: hosted shards score the whole matrix MINUS the dedicated methods
+              # (pipeline.py --exclude), and each dedicated method runs as its own focused job on its
+              # chosen runner (--focus). Union = the full matrix, every method on the right runner.
               N = int(os.environ['N'])
-              sh = all_self_hosted()
-              excl = ','.join(sh)
+              ded = dedicated()
+              excl = ','.join(ded)
               tasks = [{'id': 's%02d' % i, 'shard': '%d/%d' % (i, N), 'exclude': excl, **HOSTED} for i in range(N)]
-              tasks += [{'id': 'f-' + s, 'focus': s, **SELFHOSTED} for s in sh]
+              tasks += [{'id': 'f-' + s, 'focus': s, **route(s)} for s in ded]
           else:
               tasks = [{'id': 'f-' + s, 'focus': s, **route(s)} for s in json.loads(os.environ['SLUGS'])]
           print(json.dumps(tasks))

--- a/algorithms/modip/algorithm.yml
+++ b/algorithms/modip/algorithm.yml
@@ -25,9 +25,10 @@ code_url: https://github.com/sunhongfu/MoDIP
 license: none declared (no LICENSE in repo); academic use, cite the paper
 image: ghcr.io/astewartau/qsm-ci/modip:v1
 run: bash run.sh
-# Route to QSM-CI's 31 GB self-hosted runner: the per-subject optimization exceeds the hosted
-# 180-min budget. Only 2 self-hosted jobs run at once.
-runner: self-hosted
+# Runs on the public runner but with the full 6-h GitHub cap (not the 180-min default) and its own
+# container, since the per-subject CPU optimization (epoch_num iterations) exceeds 180 min but fits
+# the 16 GB hosted box at base=32. Avoids depending on the private self-hosted runners.
+runner: hosted-long
 # Notes on how QSM-CI runs this method vs. its reference (shown on the submission page).
 ci_notes:
 - >


### PR DESCRIPTION
Runs **modip** on the public runner at full quality, removing its dependence on the private self-hosted box (per the runner investigation — modip fits 16 GB at `base=32`; it was self-hosted only for the 180-min cap).

**New `hosted-long` routing tier** in the plan job:
| `runner:` | runner | timeout | containers | scheduling |
|---|---|---|---|---|
| (unset) | ubuntu-latest | 180 min | 2 | in the shard sweep |
| **`hosted-long`** | **ubuntu-latest** | **360 min** (GitHub max) | **1** (full 16 GB) | own focused job |
| `self-hosted` | private 31 GB | 360 min | 4 | own focused job |

`hosted-long` + `self-hosted` methods both run as dedicated `--focus` jobs and are excluded from the 180-min shard sweep. modip switched to `hosted-long` at **full settings** (no `epoch_num`/precision reduction — this preserves quality; the earlier analysis showed BFRnet-style equivalence tricks don't apply to a global optimizer, so we keep quality and just give it the time+memory).

If full-quality modip finishes within GitHub's 6-h job cap on CPU, it lands real scores on reliable infra. If it doesn't, we'll see it hit 360 min and can then decide on reduced epochs. **inr-qsm stays self-hosted** — it OOMs 16 GB, so it needs a memory cut, not just more time.

Verified: `score.yml` YAML valid; plan routing simulated (modip→hosted-long 360/1, inr-qsm→self-hosted, bfrnet→hosted, dedicated set = [inr-qsm, modip]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)