### PR TITLE
chi-sep: fix stale Dr blurb + surface CPU/RAM graph

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -428,9 +428,13 @@ def _score_chisep(a, sfx, variant, overrides, odir, gt, mask, rt, args):
                  else f"xsim={_fmt(m.get('xsim'))} nrmse={_fmt(m.get('nrmse'), '.2f')}%")
         print(f"  isolated  {a['slug']:<16} {variant:<8} {art:<11} {shown}")
     # Viewer volumes: emit both sources under the run id (results/<id>/) — χ+ as the plain set and χ−
-    # with a "-dia" suffix, so the detail viewer's χ+/χ− toggle can load either.
+    # with a "-dia" suffix, so the detail viewer's χ+/χ− toggle can load either. The container runner
+    # writes one resources.json (memory/CPU-over-time) beside the outputs for the whole run; carry it
+    # on the χ+ set so the detail page graphs CPU/RAM for χ-sep methods too, like the QSM ones.
     if args.emit_volumes:
-        emit_volumes(rid, odir / ARTIFACT_FILE["chi-para"], gt / ARTIFACT_FILE["chi-para"], mask)
+        res = odir / "resources.json"
+        emit_volumes(rid, odir / ARTIFACT_FILE["chi-para"], gt / ARTIFACT_FILE["chi-para"], mask,
+                     resources=res if res.exists() else None)
         emit_volumes(rid, odir / ARTIFACT_FILE["chi-dia"], gt / ARTIFACT_FILE["chi-dia"], mask, suffix="-dia")
     return row
 

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -225,7 +225,7 @@
 
     <!-- chi-separation leaderboard (susceptibility source separation: χ+ para vs χ− dia) -->
     <div x-show="domain==='chisep'" x-cloak class="mt-3">
-      <p class="max-w-3xl text-sm text-gray-600">Susceptibility source separation splits net χ into <strong>paramagnetic (χ+, iron)</strong> and <strong>diamagnetic (χ−, myelin / calcium)</strong> sources. Methods are fed the ground-truth local field, R2′ and χ_total, and each source map is scored separately against the qsm-forward chi-separation phantom. R2′ uses physically-realistic split relaxivities (Dr₊ = 114, Dr₋ = 30 Hz/ppm); each method applies its own Dr assumption.</p>
+      <p class="max-w-3xl text-sm text-gray-600">Susceptibility source separation splits net χ into <strong>paramagnetic (χ+, iron)</strong> and <strong>diamagnetic (χ−, myelin / calcium)</strong> sources. Methods are fed the ground-truth local field, R2′ and χ_total, and each source map is scored separately against the qsm-forward chi-separation phantom.</p>
       <div class="mt-8 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
         <table class="w-full text-sm whitespace-nowrap">
           <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">


### PR DESCRIPTION
Two small χ-separation fixes (follow-up to #111).

## 1. Leaderboard blurb — remove the stale Dr claim
The chi-separation blurb still said *"R2′ uses physically-realistic split relaxivities (Dr₊ = 114, Dr₋ = 30 Hz/ppm); each method applies its own Dr assumption."* That split model was retired — qsm-forward unified on a **single Dr = 137** kernel. Removed just that sentence; the source description and scoring-methodology text are unchanged.

## 2. Surface CPU/RAM on chi-sep detail pages
The `/proc` resource sampler runs on every container (engine-agnostic), so a `resources.json` mem/CPU-over-time trace is produced for χ-sep runs too — but `_score_chisep` emitted the χ+/χ− viewer volumes **without** passing `resources=`, so it never landed in `results/<id>/` and the detail page's CPU/RAM graph was blank for χ-sep (QSM methods pass `resources=res` and show it).

Fix: carry the run's `resources.json` onto the χ+ volume set. Takes effect on the next scoring run — populating the graphs for wavesep / chi-sep-ilsqr / chi-sep-medi / chi-sepnet / susep-net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)