### PR TITLE
fix: χ− viewer toggle showed the χ+ volume (publish + wire the -dia set)

### DIFF
--- a/scripts/publish_volumes.py
+++ b/scripts/publish_volumes.py
@@ -101,9 +101,12 @@ def main() -> int:
         if rid not in by_id:
             continue
         for kind in KINDS:
-            f = run_dir / f"{kind}.nii.gz"
-            if f.exists():
-                items.append((rid, kind, "nii.gz", f))
+            # χ-separation writes a second "-dia" volume set (recon-dia/truth-dia/error-dia) for its χ−
+            # source alongside the plain χ+ set; publish both so the viewer's χ+/χ− toggle can load either.
+            for sfx in ("", "-dia"):
+                f = run_dir / f"{kind}{sfx}.nii.gz"
+                if f.exists():
+                    items.append((rid, kind + sfx, "nii.gz", f))
         rf = run_dir / "resources.json"
         if rf.exists():
             items.append((rid, "resources", "json", rf))

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -593,9 +593,12 @@ const isChisepRun = () => run && (run.domain === "chisep" || run.stage === "chi-
 // χ-separation writes a second set of volumes for the χ− source with a "-dia" suffix
 // (recon-dia.nii.gz, truth-dia.nii.gz, error-dia.nii.gz); the χ+ set uses the plain names.
 const volUrl = (kind) => {
-  if (run && run.volumes && run.volumes[kind]) return run.volumes[kind];
+  // Apply the χ− "-dia" suffix to the KEY too, not just the dev-fallback path — otherwise an
+  // HF-backed run returns run.volumes["recon"] (the χ+ volume) for the χ− toggle.
   const suffix = (isChisepRun() && chisepComp === "dia") ? "-dia" : "";
-  return baseUrl + kind + suffix + ".nii.gz";
+  const k = kind + suffix;
+  if (run && run.volumes && run.volumes[k]) return run.volumes[k];
+  return baseUrl + k + ".nii.gz";
 };
 
 // Reconcile the viewer with (curBase, showError): reload the base only when it changes, add/remove the


### PR DESCRIPTION
**Symptom:** on the live submission viewer, the **χ− (diamagnetic)** map looked like the **χ+ (paramagnetic)** one — e.g. deep gray matter reading strongly positive (~0.1) in χ− where it should be ~0. Reported across chi-separation methods.

**Root cause:** the scored data is correct (verified locally: MEDI χ− in DGM ≈ 0.0006, GT ≈ 0.012). The bug is in publishing + display of the χ− volume set:

1. `emit_volumes` writes a second `-dia` set (`recon-dia/truth-dia/error-dia.nii.gz`) for χ−, but **`publish_volumes.py` only uploaded `recon/truth/error`** — the χ− set never reached Hugging Face.
2. **`viewer.js` `volUrl()` applied the `-dia` suffix only on the local-dev fallback**, not the HF-backed path. On the live site it returned `run.volumes["recon"]` (the χ+ volume) for the χ− toggle.

So the χ− toggle fell back to the χ+ volume — hence "χ− looks like χ+". (Locally it looked fine because the dev fallback path *does* apply the suffix.)

**Fix:**
- `publish_volumes.py`: upload the `-dia` set too, keyed `recon-dia/truth-dia/error-dia`.
- `viewer.js`: apply the suffix to the HF key lookup, not just the fallback.

**Rollout:** the viewer fix ships with the Pages deploy; the χ− volumes populate on the next scoring run (`publish_volumes.py` is a `score.yml` trigger path, so merging this auto-kicks a re-score + re-publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)