### PR TITLE
chi-sep: whole-brain χ+↔χ− leakage metric + surface leakage in UI

### DIFF
--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -401,10 +401,38 @@ def iso_variants(a: dict) -> list:
 CHISEP_PREFIX = {"chi-para": "para", "chi-dia": "dia"}
 
 
+def _chisep_leakage(odir, gt, mask) -> "dict | None":
+    """Whole-brain cross-source leakage for a χ-separation run: {para_leak, dia_leak}.
+
+    Regress each reconstructed source on BOTH ground-truth sources (recon ≈ a·GT_same + b·GT_other + c)
+    and take the slope `b` on the WRONG source — the fraction of the other source that bleeds into this
+    map (0 = clean separation). Because it controls for the correct source, it isolates true χ+↔χ−
+    contamination, unlike xSIM/NRMSE which are dominated by the shared R2'/2Dr common mode. Needs both
+    GT sources, so it's computed here rather than per-component. Returns None if a map can't be read."""
+    import numpy as np
+    import nibabel as nib
+    L = lambda p: np.asarray(nib.load(str(p)).get_fdata(), np.float64)
+    try:
+        rp, rd = L(odir / ARTIFACT_FILE["chi-para"]), L(odir / ARTIFACT_FILE["chi-dia"])
+        gp, gd = L(gt / ARTIFACT_FILE["chi-para"]), L(gt / ARTIFACT_FILE["chi-dia"])
+        m = L(mask) > 0.5
+    except Exception:  # noqa: BLE001 — a missing/unreadable map just means "no leakage number"
+        return None
+    def slope(recon, same, other):
+        A = np.c_[same[m], other[m], np.ones(int(m.sum()))]
+        return float(np.linalg.lstsq(A, recon[m], rcond=None)[0][1])
+    return {"para_leak": slope(rp, gp, gd),   # χ− (diamagnetic) bleeding INTO the χ+ map
+            "dia_leak":  slope(rd, gd, gp)}   # χ+ (paramagnetic) bleeding INTO the χ− map
+
+
 def _score_chisep(a, sfx, variant, overrides, odir, gt, mask, rt, args):
     """Score a χ-separation run's two source maps (χ+, χ−) and fold them into ONE leaderboard row with
     para_*/dia_* prefixed metrics and domain='chisep' — the chi-sep leaderboard shows one row per
-    method with χ+ vs χ− columns, not two separate rows. A DNF in either component marks the row DNF."""
+    method with χ+ vs χ− columns, not two separate rows. A DNF in either component marks the row DNF.
+
+    Metrics per source: xsim/nrmse/correlation, region leakage (dia_iron_leak = mean |χ−| in the
+    iron/DGM+vein regions where χ− should be ~0; para_calc_leak = mean |χ+| in calcification), and the
+    whole-brain regression leakage (para_leak / dia_leak) from _chisep_leakage."""
     rid = f"{a['slug']}-iso{sfx}"
     row = {"id": rid, "slug": a["slug"], "name": a.get("name", a["slug"]), "stage": a["stage"], "mode": "isolated",
            "track": args.track, "runtime_s": rt, "variant": variant, "domain": "chisep",
@@ -427,6 +455,12 @@ def _score_chisep(a, sfx, variant, overrides, odir, gt, mask, rt, args):
         shown = ("DNF" if r.get("status") == "DNF"
                  else f"xsim={_fmt(m.get('xsim'))} nrmse={_fmt(m.get('nrmse'), '.2f')}%")
         print(f"  isolated  {a['slug']:<16} {variant:<8} {art:<11} {shown}")
+    if row["status"] != "DNF":  # whole-brain χ+↔χ− leakage (needs both GT + both recon maps)
+        lk = _chisep_leakage(odir, gt, mask)
+        if lk:
+            row["metrics"].update(lk)
+            print(f"  isolated  {a['slug']:<16} {variant:<8} {'leakage':<11} "
+                  f"para_leak={_fmt(lk['para_leak'])} dia_leak={_fmt(lk['dia_leak'])}")
     # Viewer volumes: emit both sources under the run id (results/<id>/) — χ+ as the plain set and χ−
     # with a "-dia" suffix, so the detail viewer's χ+/χ− toggle can load either. The container runner
     # writes one resources.json (memory/CPU-over-time) beside the outputs for the whole run; carry it

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -138,6 +138,10 @@ const METRICS = {
     desc: "Pearson correlation between reconstructed and ground-truth χ within the mask. 1 = perfect." },
   xsim:            { label: "XSIM",             unit: "",  better: "higher", dp: 3,
     desc: "Structural-similarity index tuned for QSM (5×5×5 windows). 1 = identical to the ground truth." },
+  para_leak:       { label: "χ−→χ+ leak",       unit: "",  better: "lower",  dp: 3,
+    desc: "Whole-brain regression slope of χ+ on the χ− ground truth — the fraction of diamagnetic signal bleeding into the paramagnetic map. 0 = clean; magnitude = contamination. Unlike xSIM it isn't fooled by the shared R2' common mode." },
+  dia_leak:        { label: "χ+→χ− leak",       unit: "",  better: "lower",  dp: 3,
+    desc: "Whole-brain regression slope of χ− on the χ+ ground truth — the fraction of paramagnetic signal bleeding into the diamagnetic map. 0 = clean; magnitude = contamination. Unlike xSIM it isn't fooled by the shared R2' common mode." },
   runtime_s:       { label: "Runtime",          unit: "s", better: "lower",  dp: 1,
     desc: "Wall-clock time to produce this output — for a combined pipeline, the sum of its field-mapping, background-removal and dipole-inversion stages. Measured on GitHub-hosted runners (≈4 vCPU, 16 GB RAM, no GPU — so learning-based methods run on CPU); treat it as relative speed, not an absolute benchmark." },
 };

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -441,14 +441,16 @@ function renderChisepMetrics() {
       ["DGM iron NRMSE", m.para_nrmse_dgm, "pct", "↓", "χ+ error in deep gray matter (iron)."],
       ["DGM linearity", m.para_dgm_linearity, "num", "↓", "|1 − slope| of χ+ across DGM iron regions; 0 = perfect iron quantification."],
       ["Vein NRMSE", m.para_nrmse_blood, "pct", "↓", "χ+ error in venous blood."],
-      ["Calcium leakage", m.para_calc_leak, "num", "↓", "Mean |χ+| in the calcification (should be ~0) — calcium wrongly bleeding into the paramagnetic map."],
+      ["Calcium leakage (region)", m.para_calc_leak, "num", "↓", "Mean |χ+| in the calcification (should be ~0) — calcium wrongly bleeding into the paramagnetic map."],
+      ["Leakage χ−→χ+ (whole-brain)", m.para_leak, "num", "↓", "Regression slope of χ+ on the χ− ground truth over the whole brain — the fraction of diamagnetic signal bleeding into the paramagnetic map (0 = clean). Unlike xSIM it isn't fooled by the shared R2' common mode."],
     ]],
     ["χ− diamagnetic (calcium, myelin)", [
       ["xSIM", m.dia_xsim, "xsim", "↑", "Structural similarity of χ− vs ground truth."],
       ["NRMSE", m.dia_nrmse, "pct", "↓", "Normalised RMS error of χ− (%)."],
       ["Calcification dev", m.dia_calc_moment_dev, "num", "↓", "Deviation of the recovered calcification's susceptibility moment."],
       ["Streaking", m.dia_calc_streak, "num", "↓", "Streaking-artifact level around the calcification."],
-      ["Iron leakage", m.dia_iron_leak, "num", "↓", "Mean |χ−| in DGM/veins (should be ~0) — iron wrongly bleeding into the diamagnetic map."],
+      ["Iron leakage (region)", m.dia_iron_leak, "num", "↓", "Mean |χ−| in DGM/veins (should be ~0) — iron wrongly bleeding into the diamagnetic map."],
+      ["Leakage χ+→χ− (whole-brain)", m.dia_leak, "num", "↓", "Regression slope of χ− on the χ+ ground truth over the whole brain — the fraction of paramagnetic signal bleeding into the diamagnetic map (0 = clean). The whole-map counterpart to the DGM iron leakage above; unlike xSIM it isn't fooled by the shared R2' common mode."],
     ]],
     [null, [["Runtime", run.runtime_s, "sec", "", "Wall-clock runtime."]]],
   ];

--- a/web/leaderboard.html
+++ b/web/leaderboard.html
@@ -235,15 +235,17 @@
                 <span class="has-tip" data-tip="Mean of the χ+ and χ− xSIM — the headline combined source-separation score. Higher is better.">Avg xSIM</span>
                 <span x-show="chisepSort==='avg'" x-text="chisepDir==='asc'?'↑':'↓'"></span>
               </th>
-              <th class="px-4 py-2 text-center font-medium border-l border-gray-200" colspan="2"><span class="has-tip" data-tip="Paramagnetic susceptibility source (positive χ) — dominated by iron.">χ+ paramagnetic</span></th>
-              <th class="px-4 py-2 text-center font-medium border-l border-gray-200" colspan="2"><span class="has-tip" data-tip="Diamagnetic susceptibility source (negative χ, reported as magnitude) — myelin and calcium.">χ− diamagnetic</span></th>
+              <th class="px-4 py-2 text-center font-medium border-l border-gray-200" colspan="3"><span class="has-tip" data-tip="Paramagnetic susceptibility source (positive χ) — dominated by iron.">χ+ paramagnetic</span></th>
+              <th class="px-4 py-2 text-center font-medium border-l border-gray-200" colspan="3"><span class="has-tip" data-tip="Diamagnetic susceptibility source (negative χ, reported as magnitude) — myelin and calcium.">χ− diamagnetic</span></th>
               <th class="px-4 py-3 text-right font-medium border-l border-gray-200" rowspan="2">Runtime</th>
             </tr>
             <tr>
               <th @click="chiSepSort('para_xsim')" class="px-4 py-2 text-right font-normal cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100 border-l border-gray-200"><span class="has-tip" data-tip="Structural similarity of the χ+ map vs ground truth. Higher is better.">xSIM</span><span x-show="chisepSort==='para_xsim'" x-text="chisepDir==='asc'?'↑':'↓'"></span></th>
               <th @click="chiSepSort('para_nrmse')" class="px-4 py-2 text-right font-normal cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100"><span class="has-tip" data-tip="Normalised RMS error of χ+ vs ground truth (%). Lower is better.">NRMSE</span><span x-show="chisepSort==='para_nrmse'" x-text="chisepDir==='asc'?'↑':'↓'"></span></th>
+              <th @click="chiSepSort('para_leak')" class="px-4 py-2 text-right font-normal cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100"><span class="has-tip" data-tip="Whole-brain leakage: fraction of χ− (diamagnetic) signal bleeding into the χ+ map. 0 = clean. Lower is better.">leak</span><span x-show="chisepSort==='para_leak'" x-text="chisepDir==='asc'?'↑':'↓'"></span></th>
               <th @click="chiSepSort('dia_xsim')" class="px-4 py-2 text-right font-normal cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100 border-l border-gray-200"><span class="has-tip" data-tip="Structural similarity of the χ− map vs ground truth. Higher is better.">xSIM</span><span x-show="chisepSort==='dia_xsim'" x-text="chisepDir==='asc'?'↑':'↓'"></span></th>
               <th @click="chiSepSort('dia_nrmse')" class="px-4 py-2 text-right font-normal cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100"><span class="has-tip" data-tip="Normalised RMS error of χ− vs ground truth (%). Lower is better.">NRMSE</span><span x-show="chisepSort==='dia_nrmse'" x-text="chisepDir==='asc'?'↑':'↓'"></span></th>
+              <th @click="chiSepSort('dia_leak')" class="px-4 py-2 text-right font-normal cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100"><span class="has-tip" data-tip="Whole-brain leakage: fraction of χ+ (paramagnetic/iron) signal bleeding into the χ− map. 0 = clean. Lower is better — this is the whole-map version of the DGM iron-leak issue.">leak</span><span x-show="chisepSort==='dia_leak'" x-text="chisepDir==='asc'?'↑':'↓'"></span></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
@@ -259,8 +261,10 @@
                 <td class="px-4 py-3 text-right tabular-nums font-semibold text-gray-900 group-hover:bg-emerald-50/40" x-text="fmt(chiVal(r,'avg'),'xsim')"></td>
                 <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="chisepSort==='para_xsim' ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt((r.metrics||{}).para_xsim,'xsim')"></td>
                 <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="chisepSort==='para_nrmse' ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt((r.metrics||{}).para_nrmse,'nrmse')"></td>
+                <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="chisepSort==='para_leak' ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt((r.metrics||{}).para_leak,'para_leak')"></td>
                 <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="chisepSort==='dia_xsim' ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt((r.metrics||{}).dia_xsim,'xsim')"></td>
                 <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="chisepSort==='dia_nrmse' ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt((r.metrics||{}).dia_nrmse,'nrmse')"></td>
+                <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="chisepSort==='dia_leak' ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="fmt((r.metrics||{}).dia_leak,'dia_leak')"></td>
                 <td class="px-4 py-3 text-right tabular-nums text-gray-500 group-hover:bg-emerald-50/40" x-text="fmt(r.runtime_s,'runtime_s')"></td>
               </tr>
             </template>


### PR DESCRIPTION
Follow-up on the χ-separation thread: xSIM/NRMSE are dominated by the shared R2'/2Dr common mode and don't expose **cross-source contamination** (paramagnetic iron bleeding into χ−, etc.). This adds a whole-brain leakage metric and surfaces leakage in the UI.

## Metric
`_chisep_leakage` (pipeline.py): regress each reconstructed source on **both** GT sources — `recon ≈ a·GT_same + b·GT_other + c`. The slope **b** on the *wrong* source is the fraction of the other source bleeding in (**0 = clean**). Because it controls for the correct source, it isn't fooled by the natural anti-correlation of GT χ+/χ−, and — unlike xSIM — not by the common mode. Emits `para_leak` (χ−→χ+) and `dia_leak` (χ+→χ−).

Validated locally: wavesep `dia_leak` 0.034, medi −0.078, ilsqr −0.023 — small, consistent with clean maps (the "χ− looks like χ+" seen earlier was the viewer bug, since fixed).

## UI (both leaderboard + detail, as requested)
- **Leaderboard**: new sortable **leak** column under each source (χ−→χ+ and χ+→χ−).
- **Detail page**: whole-brain leakage rows next to the existing **region** leaks (Calcium/Iron leakage, now labelled "(region)") — so you get both the whole-map number and the DGM/calcification-specific ones.

Populates on the next scoring run. QSM rows are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)