### PR TITLE
Parallel DECOMPOSE image (v2) — fits the CI runner cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,15 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y "./apptainer_${ver}_amd64.deb"
 
+      - name: Point podman at runc
+        # The ubuntu-latest image ships a podman/crun combo that errors "crun: unknown version
+        # specified" on `podman run`. runc is also preinstalled and handles the OCI bundle fine, so
+        # select it as podman's default runtime for the container-runner smoke below.
+        run: |
+          mkdir -p ~/.config/containers
+          printf '[engine]\nruntime = "runc"\n' > ~/.config/containers/containers.conf
+          podman info --format '{{.Host.OCIRuntime.Name}}' || true
+
       - name: Container runners — docker · podman · apptainer
         run: |
           set -euo pipefail

--- a/algorithms/decompose-qsm/algorithm.yml
+++ b/algorithms/decompose-qsm/algorithm.yml
@@ -21,13 +21,13 @@ citation: >
   paramagnetic components based on gradient-echo MRI data", NeuroImage 2021.
 code_url: https://github.com/timwahoo/DECOMPOSE-QSM
 license: GPL-3.0
-image: ghcr.io/astewartau/qsm-ci/decompose-qsm:v1
+image: ghcr.io/astewartau/qsm-ci/decompose-qsm:v2
 run: bash run.sh
 runner: self-hosted   # per-voxel non-linear fit (parfor); ~31 min on 48 cores — needs a many-core runner + long cap
 smoke_box: 24         # per-voxel fit is slow: the PR --smoke gate fits only a 24³ central box (full score.yml run is unaffected)
 matlab:
   entry: recon.m
-  runtime: r2026a
+  runtime: r2023b
 # Feasibility CONFIRMED on Bunya: full-brain fit ~31 min on 48 cores (job 26707883). Uses the provided
 # χ_total (chimap) for the signal phase — no STI Suite / phase input needed (chi-separation stage already
 # consumes magnitude + chimap + mask + params). GPL-3.0 (redistribution OK with attribution);

--- a/algorithms/decompose-qsm/recon.m
+++ b/algorithms/decompose-qsm/recon.m
@@ -48,6 +48,24 @@ function recon(inp, out)
     N_inner = 10; niv = str2double(getenv('DECOMPOSE_NINNER')); if ~isnan(niv) && niv > 0; N_inner = niv; end
     fprintf('DECOMPOSE: fitting %d voxels (N_inner=%d)\n', nnz(fitmask), N_inner);
 
+    % Start a local parallel pool so the per-voxel parfor runs across all cores. Compiled WITH the
+    % Parallel Computing Toolbox, the MATLAB Runtime can open a pool up to the container's core count
+    % without a license; degrade gracefully to a serial parfor if the pool can't start. $DECOMPOSE_WORKERS
+    % caps the worker count (e.g. when a runner shares cores between concurrent jobs).
+    try
+        if isempty(gcp('nocreate'))
+            nw = str2double(getenv('DECOMPOSE_WORKERS'));
+            if isnan(nw) || nw < 1; nw = feature('numcores'); end
+            c = parcluster('local');
+            jsl = tempname; mkdir(jsl); c.JobStorageLocation = jsl;   % writable scratch (container HOME may be read-only)
+            c.NumWorkers = nw;
+            parpool(c, nw);
+        end
+        fprintf('DECOMPOSE: parpool with %d workers\n', gcp().NumWorkers);
+    catch e
+        fprintf('DECOMPOSE: no parpool (%s) — running serial\n', e.message);
+    end
+
     opt = optimoptions('lsqcurvefit', 'Display', 'off', 'UseParallel', false);
     lb = [0 0 0]; ub = [inf inf inf]; lb2 = 0; ub2 = inf; upper = 0.5; lb3 = [0 -upper]; ub3 = [upper 0];
     Cp = zeros(N1,N2,N3); Cm = zeros(N1,N2,N3); C0m = zeros(N1,N2,N3);

--- a/algorithms/decompose-qsm/run.sh
+++ b/algorithms/decompose-qsm/run.sh
@@ -13,4 +13,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
 [ -x "$BIN" ] || BIN="$DIR/recon"
 export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+# CI runs the container as a homeless non-root user (--user 1000:1001). The MATLAB Runtime extracts the
+# embedded CTF and starts a parpool under HOME, so point HOME at a writable dir or it fails with
+# "Cannot find nonembedded CTF archive".
+export HOME="${HOME:-}"; { [ -n "$HOME" ] && [ -w "$HOME" ]; } || export HOME="$MCR_CACHE_ROOT"
 exec "$BIN" "$IN" "$OUT"


### PR DESCRIPTION
Follow-up to #118. On merge, `score.yml` ran DECOMPOSE but it **DNF'd at the 6h cap**: `recon.m`'s `parfor` ran **serially** in the MCR container (no parpool), so the full-brain per-voxel fit couldn't finish. Everything else scored fine.

## Fix
- `recon.m` now opens a local **parpool** (writable `JobStorageLocation` for the container's read-only HOME; `$DECOMPOSE_WORKERS`-capped) so the fit runs across the runner's cores.
- Recompiled on **Bunya with R2023b** (its MATLAB has the Parallel Computing + Optimization toolboxes). The image base is therefore now **`matlab-runtime:r2023b`** (with `LD_LIBRARY_PATH` set to the MCR libs, which that base doesn't set itself). Pushed as **`decompose-qsm:v2`** (public).

## Verified in-container
Smoke test: `parpool with 12 workers`, slices fit **out of order** (true parallelism), valid χ+/χ− emitted.

On merge this re-triggers `score.yml` for DECOMPOSE — parallel this time, so it should finish within the 6h cap and land its first real leaderboard number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)