### PR TITLE
ci: point podman at runc in the interfaces job (crun regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y "./apptainer_${ver}_amd64.deb"
 
+      - name: Point podman at runc
+        # ubuntu-latest's podman/crun combo errors "crun: unknown version specified"; the interface
+        # tests run methods through podman, so select runc (also preinstalled) as podman's runtime.
+        run: |
+          mkdir -p ~/.config/containers
+          printf '[engine]\nruntime = "runc"\n' > ~/.config/containers/containers.conf
+          podman info --format '{{.Host.OCIRuntime.Name}}' || true
+
       - name: Generate a qsm-forward phantom
         run: |
           qsm-forward simple /tmp/bids --resolution 40 40 40 --save-field


### PR DESCRIPTION
Follow-up to the runc fix in #119, which only covered the `cli` job's container-runner step. The **`interfaces`** job's pytest (`test_nipype_dipole[podman]`) also runs a method through podman and hits the same `ubuntu-latest` `crun: unknown version specified` regression (it passed on #119 only because that job landed on a not-yet-broken runner instance — the regression is per-runner-image).

Applies the same `runc` runtime selection in the interfaces job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)