### PR TITLE
Add TFI (total field inversion) submission

### DIFF
--- a/algorithms/tfi/algorithm.yml
+++ b/algorithms/tfi/algorithm.yml
@@ -1,0 +1,32 @@
+name: TFI
+slug: tfi
+stage: bfr+dipole
+language: Rust
+family: iterative
+learning: none
+engine: QSMxT / QSM.rs
+description: >
+  Preconditioned Total Field Inversion: a single-step method that inverts the total field directly
+  to susceptibility over the whole field-of-view, jointly performing background-field removal and
+  dipole inversion. Uses a preconditioner (χ = P·y, larger outside the brain) so the large
+  out-of-brain background susceptibility is well-conditioned, with MEDI-style L1 morphology
+  regularization.
+authors:
+- name: Zhe Liu
+- name: Youngwook Kee
+- name: Dong Zhou
+- name: Yi Wang
+- name: Pascal Spincemaille
+doi: 10.1002/mrm.26946
+citation: Liu et al., Magn Reson Med 2017;78(1):303-315
+code_url: https://github.com/astewartau/QSM.rs
+license: MIT
+image: ghcr.io/astewartau/qsm-ci/qsmxt:v9.11.0
+run: bash run.sh
+parameters:
+- name: lambda
+  default: 7.5e-5
+  description: data-fidelity weight (matches MEDI's default; larger = closer data fit, less regularization)
+- name: precond
+  default: 30
+  description: preconditioner — susceptibility scaling outside the brain mask (Liu 2017 uses ~30 for in-vivo air)

--- a/algorithms/tfi/run.sh
+++ b/algorithms/tfi/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# QSM-CI submission — TFI (bfr+dipole stage) via QSMxT / QSM.rs.
+# Preconditioned total field inversion: total field -> susceptibility, doing its own background removal.
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+# Acquisition parameters are injected as env vars — no need to parse params.json/config.json:
+#   $QSMCI_B0 (T)   $QSMCI_TE / $QSMCI_TE0 (s)   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm)
+#   $QSMCI_SET_<NAME>  for each  qsm-ci run --set NAME=VALUE  override
+B0=$(jq -r '.B0_dir | join(" ")' "$IN/params.json")
+
+# TFI takes the total field in ppm directly (like NDI — no radians conversion; the QSM-CI contract's
+# totalfield is already ppm and `qsmxt invert tfi` consumes ppm). Magnitude (provided by the
+# bfr+dipole stage) is used for the SNR data weight + morphology mask.
+MAG=""; [ -f "$IN/magnitude.nii.gz" ] && MAG="--magnitude $IN/magnitude.nii.gz"
+
+# Parameter overrides (qsm-ci run --set NAME=VALUE) arrive as /input/config.json. Absent -> qsm-core
+# TfiParams defaults (lambda 7.5e-5, precond 30) — honest, non-dataset-tuned.
+SET=""
+CFG="$IN/config.json"
+if [ -f "$CFG" ]; then
+  V=$(jq -r '.lambda // empty' "$CFG");  [ -n "$V" ] && SET="$SET --lambda $V"
+  V=$(jq -r '.precond // empty' "$CFG"); [ -n "$V" ] && SET="$SET --precond $V"
+fi
+
+qsmxt invert tfi "$IN/totalfield.nii.gz" -m "$IN/mask.nii.gz" -o "$OUT/chimap.nii.gz" \
+  --b0-direction $B0 $MAG $SET

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -1551,6 +1551,44 @@
       "ci_notes": []
     },
     {
+      "slug": "tfi",
+      "name": "TFI",
+      "stage": "bfr+dipole",
+      "inputs": [
+        "totalfield",
+        "mask",
+        "params",
+        "magnitude"
+      ],
+      "domain": "qsm",
+      "engine": "QSMxT / QSM.rs",
+      "description": "Preconditioned Total Field Inversion: a single-step method that inverts the total field directly to susceptibility over the whole field-of-view, jointly performing background-field removal and dipole inversion. Uses a preconditioner (\u03c7 = P\u00b7y, larger outside the brain) so the large out-of-brain background susceptibility is well-conditioned, with MEDI-style L1 morphology regularization.",
+      "citation": "Liu et al., Magn Reson Med 2017;78(1):303-315",
+      "doi": "10.1002/mrm.26946",
+      "code_url": "https://github.com/astewartau/QSM.rs",
+      "license": "MIT",
+      "authors": [
+        "Zhe Liu",
+        "Youngwook Kee",
+        "Dong Zhou",
+        "Yi Wang",
+        "Pascal Spincemaille"
+      ],
+      "parameters": [
+        {
+          "name": "lambda",
+          "default": 7.5e-05,
+          "description": "data-fidelity weight (matches MEDI's default; larger = closer data fit, less regularization)"
+        },
+        {
+          "name": "precond",
+          "default": 30,
+          "description": "preconditioner \u2014 susceptibility scaling outside the brain mask (Liu 2017 uses ~30 for in-vivo air)"
+        }
+      ],
+      "ci_notes": []
+    },
+    {
       "slug": "tgv",
       "name": "TGV",
       "stage": "bfr+dipole",


### PR DESCRIPTION
Adds **TFI** (preconditioned Total Field Inversion; Z. Liu et al., *Magn Reson Med* 2017, [doi:10.1002/mrm.26946](https://doi.org/10.1002/mrm.26946)) as a **`bfr+dipole`** span via QSMxT / QSM.rs.

TFI is single-step: it inverts the **total field** directly to susceptibility over the whole FOV, doing its own background-field removal via a preconditioner (χ = P·y, larger outside the brain) with MEDI-style L1 morphology regularization.

## Details
- `run.sh` → `qsmxt invert tfi` on the total field, fed in **ppm** (no radians conversion — the large total field would wrap the nonlinear data term). Magnitude (provided by the span) drives the SNR weight + morphology mask.
- **Honest, non-tuned defaults**: `lambda 7.5e-5` (MEDI's default; TFI shares its L1 machinery), `precond 30` (Liu 2017). Both overridable via `--set`.
- Image: `ghcr.io/astewartau/qsm-ci/qsmxt:v9.11.0` (public).
- Implemented across QSM.rs (v0.23.0) + qsmxt (v9.11.0); scored in the Combined section of the QSM.rs CI at corr ~0.70 on the background-heavy phantom (on par with TGV-from-field). Smoke-tested offline here on `data/sim/dev`: corr 0.93 (masked to brain).

All submission + manifest gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)