### PR TITLE
feat(web): dataset selector + badge on the submission page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QSM-CI
 
-**An open challenge and leaderboard for Quantitative Susceptibility Mapping (QSM) reconstruction.**
+**An open benchmarking platform and leaderboard for Quantitative Susceptibility Mapping (QSM) reconstruction.**
 
 Submit a QSM algorithm — in any language, as a container — and QSM-CI runs it on standardized data,
 scores it against held-out ground truth, and publishes the result to an interactive leaderboard.

--- a/algorithms/amp-pe/recon.m
+++ b/algorithms/amp-pe/recon.m
@@ -66,6 +66,23 @@ function recon(inp, out)
 
     gyro_ratio = 42.58;                                   % MHz/T (matches upstream)
 
+    %% ---- pad to a multiple of 2^nlevel for the wavelet transform ---------------------------
+    % wavedec3/waverec3 at `nlevel` levels need each dimension divisible by 2^nlevel. The QSM
+    % Challenge 2.0 phantom is 164x205x205 (none divisible by 8), which breaks the sparsifying
+    % wavelet operators and yields a structureless map (xSIM ~ 0), while the 160^3 in-vivo grid
+    % (all divisible by 8) reconstructs fine. Zero-pad the field / mask / magnitude to the next
+    % multiple, reconstruct on that grid, then crop chi back at the end. The padded rim has mask = 0
+    % so it never enters the data term; enlarging the FFT grid is standard (benign) for the kernel.
+    orig_sz  = mat_sz;
+    pad_mult = 2^nlevel;
+    pad_sz   = ceil(orig_sz / pad_mult) * pad_mult;
+    if ~isequal(pad_sz, orig_sz)
+        localfield = local_pad(localfield, pad_sz);
+        mask       = local_pad(mask,       pad_sz);
+        iMagWtd    = local_pad(iMagWtd,     pad_sz);
+        mat_sz = pad_sz;  sx = pad_sz(1);  sy = pad_sz(2);  sz = pad_sz(3);
+    end
+
     %% ---- simulate single-echo tissue phase (radians) from the local field (ppm) ------------
     % mut_cst converts a ppm field to radians at simulated_TE. It appears in both the measurement and
     % the forward operator, so the recovered susceptibility is invariant to the simulated_TE choice
@@ -225,11 +242,18 @@ function recon(inp, out)
 
     chi = res.x_hat_meas;
     chi(mask == 0) = 0;
+    chi = chi(1:orig_sz(1), 1:orig_sz(2), 1:orig_sz(3));   % crop back to the input grid
 
     %% ---- write output ----------------------------------------------------------------------
     lf_nii.img = single(chi);
     lf_nii.hdr.dime.datatype = 16;  lf_nii.hdr.dime.bitpix = 32;
     write_niigz(lf_nii, fullfile(out, 'chimap.nii.gz'));
+end
+
+function w = local_pad(v, sz)
+% Zero-pad a 3D array up to sz at the high index of each dimension (no toolbox dependency).
+    w = zeros(sz, 'like', v);
+    w(1:size(v,1), 1:size(v,2), 1:size(v,3)) = v;
 end
 
 function v = getparam(cfg, name, default)

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>QSM-CI · QSM reconstruction challenge</title>
+  <title>QSM-CI · QSM benchmarking platform</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
@@ -62,78 +62,6 @@
       </div>
     </section>
 
-    <!-- Pipeline -->
-    <section class="mx-auto max-w-6xl px-6 pb-4">
-      <div class="rounded-2xl border border-gray-200 bg-gradient-to-br from-gray-50 to-white p-8 dark:border-gray-800 dark:from-gray-900 dark:to-gray-800/60">
-        <h2 class="text-xl font-semibold text-gray-900">The QSM pipeline is modular</h2>
-        <p class="mt-1 text-sm text-gray-600">Submit one stage, a span, or the whole thing. We score each stage alone and every combination.</p>
-        <div class="mt-6 flex flex-wrap items-center gap-3 text-sm">
-          <span class="rounded-lg bg-white px-3 py-1.5 font-mono text-xs text-gray-500 ring-1 ring-gray-200">phase</span>
-          <span class="text-gray-300">→</span>
-          <span class="rounded-lg bg-emerald-600 px-4 py-2 font-medium text-white shadow-sm">Field mapping</span>
-          <span class="text-gray-300">→</span>
-          <span class="rounded-lg bg-white px-3 py-1.5 font-mono text-xs text-gray-500 ring-1 ring-gray-200">total field</span>
-          <span class="text-gray-300">→</span>
-          <span class="rounded-lg bg-teal-600 px-4 py-2 font-medium text-white shadow-sm">Background removal</span>
-          <span class="text-gray-300">→</span>
-          <span class="rounded-lg bg-white px-3 py-1.5 font-mono text-xs text-gray-500 ring-1 ring-gray-200">local field</span>
-          <span class="text-gray-300">→</span>
-          <span class="rounded-lg bg-cyan-700 px-4 py-2 font-medium text-white shadow-sm">Dipole inversion</span>
-          <span class="text-gray-300">→</span>
-          <span class="rounded-lg bg-white px-3 py-1.5 font-mono text-xs text-gray-500 ring-1 ring-gray-200">χ map</span>
-        </div>
-      </div>
-    </section>
-
-    <!-- Data & citation -->
-    <section class="mx-auto max-w-6xl px-6 pt-6">
-      <div class="rounded-2xl border border-gray-200 bg-white p-5 text-sm text-gray-600 shadow-sm dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400">
-        <span class="font-semibold text-gray-900 dark:text-gray-100">Data.</span>
-        Algorithms are evaluated on the <strong>Realistic In Silico Head Phantom</strong> from the QSM
-        Reconstruction Challenge 2.0: Marques J.P., Meineke J., Milovic C., et al.,
-        <em>Magnetic Resonance in Medicine</em> 2021;86(1):526–542
-        (<a href="https://doi.org/10.1002/mrm.28716" class="text-emerald-600 hover:underline">doi:10.1002/mrm.28716</a>),
-        simulated to BIDS with
-        <a href="https://github.com/astewartau/qsm-forward" class="text-emerald-600 hover:underline">qsm-forward</a>.
-        Please cite the phantom paper if you use QSM-CI results.
-      </div>
-    </section>
-
-    <!-- Top pipelines teaser -->
-    <section class="mx-auto max-w-6xl px-6 py-16">
-      <div class="flex items-end justify-between">
-        <div>
-          <h2 class="text-2xl font-bold tracking-tight">Top pipelines</h2>
-          <p class="mt-1 text-sm text-gray-600">Best end-to-end BFR + inversion combinations, by XSIM.</p>
-        </div>
-        <a href="results.html" class="text-sm font-semibold text-emerald-600 hover:text-emerald-700">Full leaderboard →</a>
-      </div>
-      <div class="mt-6 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-        <table class="w-full text-sm">
-          <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
-            <tr>
-              <th class="px-5 py-3 text-left font-medium">Pipeline</th>
-              <th class="px-5 py-3 text-right font-medium">XSIM</th>
-              <th class="px-5 py-3 text-right font-medium">Correlation</th>
-              <th class="px-5 py-3 text-right font-medium">NRMSE</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-100">
-            <template x-for="(r, i) in top" :key="r.id">
-              <tr class="hover:bg-gray-50 cursor-pointer" @click="go(r)">
-                <td class="px-5 py-3 font-medium text-gray-900">
-                  <span x-text="i < 3 ? MEDALS[i] : ('#' + (i+1))" class="mr-2"></span>
-                  <span x-text="r.name"></span>
-                </td>
-                <td class="px-5 py-3 text-right font-semibold text-gray-900" x-text="fmt(val(r,'xsim'),'xsim')"></td>
-                <td class="px-5 py-3 text-right text-gray-600" x-text="fmt(val(r,'correlation'),'correlation')"></td>
-                <td class="px-5 py-3 text-right text-gray-600" x-text="fmt(val(r,'nrmse'),'nrmse')"></td>
-              </tr>
-            </template>
-          </tbody>
-        </table>
-      </div>
-    </section>
   </main>
 
   <footer id="site-footer"></footer>
@@ -146,9 +74,9 @@
         steps: [
           { title: "Submit", body: "Add a folder with your code + a stage declaration. Any language; MATLAB, Python, Julia, your choice.",
             icon: '<svg width=\"22\" height=\"22\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"1.8\"><path d=\"M12 16V4m0 0L8 8m4-4l4 4M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>' },
-          { title: "Run", body: "We run your container on the challenge data (network-isolated, so it never sees the answer) on its own and chained with other methods.",
+          { title: "Run", body: "We run your container across test datasets (network-isolated, so it never sees the answer) on its own and chained with other methods.",
             icon: '<svg width=\"22\" height=\"22\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"1.8\"><rect x=\"4\" y=\"4\" width=\"16\" height=\"16\" rx=\"2\"/><path d=\"M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2\" stroke-linecap=\"round\"/></svg>' },
-          { title: "Score", body: "Outputs are scored against held-out ground truth with the QSM.rs metrics, then ranked on the interactive leaderboard.",
+          { title: "Score", body: "Outputs are scored against held-out ground truth, then ranked on the interactive leaderboard.",
             icon: '<svg width=\"22\" height=\"22\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"1.8\"><path d=\"M4 20V10M10 20V4M16 20v-7M22 20H2\" stroke-linecap=\"round\"/></svg>' },
         ],
         async init() {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -311,9 +311,8 @@ function injectChrome() {
     footer.className = "border-t border-gray-200 mt-20 dark:border-gray-800";
     footer.innerHTML = `
       <div class="mx-auto max-w-6xl px-6 py-10 text-sm text-gray-500 dark:text-gray-400 flex flex-col sm:flex-row justify-between gap-4">
-        <p>QSM-CI: a challenge for Quantitative Susceptibility Mapping reconstruction.</p>
-        <p>Scored with <a href="${GH}/tree/main/eval" class="text-emerald-600 hover:underline">qsm-eval</a>
-           · metrics from <a href="https://github.com/astewartau/QSM.rs" class="text-emerald-600 hover:underline">QSM.rs</a></p>
+        <p>QSM-CI: a benchmarking platform for Quantitative Susceptibility Mapping.</p>
+        <p><a href="${GH}" class="text-emerald-600 hover:underline">github.com/QSMxT/QSM-CI</a></p>
       </div>`;
   }
 }

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -183,6 +183,28 @@ const hasInvivo = () => invivoRuns().length > 0;
 // Which dataset/domain sidebar view a run belongs to.
 const datasetOf = (r) => isInvivo(r) ? "invivo"
   : (r.domain === "chisep" || r.stage === "chi-separation") ? "chisep" : "qsm";
+const DATASET_LABEL = { invivo: "In vivo (2016)", qsm: "In silico (2019)", chisep: "χ-sep (2026)" };
+
+// The isolated-dipole run for `slug` on a given dataset — the "same algorithm, other dataset" target.
+// Only dipole methods span the 2016/2019 datasets (in-vivo scores dipole only).
+function dipoleRunOn(slug, dom) {
+  if (dom === "invivo") return invivoRuns().find((r) => r.slug === slug);
+  return allRuns.find((r) => r.slug === slug && !isInvivo(r) && datasetOf(r) === dom
+    && r.mode === "isolated" && r.stage === "dipole" && (r.variant || "default") === "default");
+}
+// The datasets (2016 / 2019) on which the CURRENT method has an isolated dipole run, in display order.
+function datasetPeers() {
+  if (!run || run.stage !== "dipole" || run.mode !== "isolated") return [];
+  return ["invivo", "qsm"].map((d) => ({ dom: d, run: dipoleRunOn(run.slug, d) })).filter((p) => p.run);
+}
+// Switch dataset while keeping the same algorithm open when it exists on the target (re-selecting its
+// run there); otherwise just browse the target dataset's list.
+function switchDataset(dom) {
+  const peer = run ? dipoleRunOn(run.slug, dom) : null;
+  if (peer) { selectRun(peer.id); return; }  // selectRun re-derives `domain` from the chosen run
+  domain = dom;
+  buildSidebar();
+}
 // Combined single-step methods (bfr+dipole / end-to-end, e.g. NeXtQSM/TGV/QSMART/MEDI/iQSM) go
 // straight to a chi map in one step, so they have no fmap×bfr×dipole combo and are missed by the
 // matrix axes. Surface them as their own Pipelines group: one run per slug, preferring the composed
@@ -303,6 +325,29 @@ function buildSidebar() {
     : (navMode === "stages" ? stagesHTML() : pipelinesHTML());
   $("run-list").querySelectorAll(".run-item").forEach((b) => b.addEventListener("click", () => { if (b.dataset.id) selectRun(b.dataset.id); }));
 }
+// In-content dataset switch, shown above the viewer/metrics only for a dipole method that has an
+// isolated run on more than one dataset (In vivo 2016 / In silico 2019): swap dataset, same method.
+function renderDatasetSwitch() {
+  const el = $("dataset-switch");
+  if (!el) return;
+  const peers = datasetPeers();
+  if (peers.length < 2) { el.classList.add("hidden"); el.innerHTML = ""; return; }
+  const cur = datasetOf(run);
+  const btns = peers.map((p) => {
+    const on = p.dom === cur;
+    return `<button data-switch="${p.dom}" class="rounded-md px-3 py-1.5 transition ${on
+      ? "bg-white shadow-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100"
+      : "text-gray-500 hover:text-gray-700 dark:text-gray-400"}">${DATASET_LABEL[p.dom]}</button>`;
+  }).join("");
+  el.innerHTML = `<div class="flex flex-wrap items-center gap-3">
+    <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Dataset</span>
+    <div class="inline-flex rounded-lg bg-gray-100 p-1 text-xs font-medium dark:bg-gray-800">${btns}</div>
+    <span class="text-xs text-gray-400 dark:text-gray-500">same method — switch the dataset it was scored on</span>
+  </div>`;
+  el.querySelectorAll("[data-switch]").forEach((b) =>
+    b.addEventListener("click", () => switchDataset(b.dataset.switch)));
+  el.classList.remove("hidden");
+}
 function selectRun(id) {
   run = allRuns.find((r) => r.id === id);
   domain = datasetOf(run);   // keep the sidebar on the dataset this run belongs to
@@ -402,6 +447,7 @@ async function loadRun() {
   $("sub-meta").innerHTML = bits.join(" · ");
   renderMethodInfo();
   renderHowToRun();
+  renderDatasetSwitch();
   renderMetrics();
   // Render the resource graph up front, independent of (and before) the WebGL/NiiVue viewer, so a
   // browser without WebGL2, or a run whose volumes fail to load, still shows the usage trace.
@@ -784,7 +830,7 @@ async function init() {
   navMode = run.mode === "composed" ? "pipelines" : "stages";
   $("run-filter").addEventListener("input", (e) => { filter = e.target.value; buildSidebar(); });
   document.querySelectorAll("#nav-toggle button").forEach((b) => b.addEventListener("click", () => { navMode = b.dataset.mode; buildSidebar(); }));
-  document.querySelectorAll("#domain-toggle button").forEach((b) => b.addEventListener("click", () => { domain = b.dataset.domain; buildSidebar(); }));
+  document.querySelectorAll("#domain-toggle button").forEach((b) => b.addEventListener("click", () => switchDataset(b.dataset.domain)));
   // Deep links: ?layer=truth selects the ground-truth base; ?layer=error (or ?error=1) turns on the
   // error overlay. Applied before the first render so loadRun picks them up.
   const layer = q.get("layer");

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -501,7 +501,12 @@ async function loadRun() {
 function metricRank(k) {
   const meta = METRICS[k], v = val(run, k);   // val() also reaches top-level fields (e.g. runtime_s)
   if (v == null) return null;
-  const sameGroup = (r) => (run.combo ? r.mode === "composed" : r.mode === "isolated" && r.stage === run.stage);
+  // Composed pipelines are ranked within their OWN field-mapping (the leaderboard groups the same
+  // way: it shows one field-mapping's bfr×dipole matrix at a time), so the denominator matches the
+  // table you clicked from — not the full cross-field-mapping pool of ~845 pipelines.
+  const sameGroup = (r) => (run.combo
+    ? r.mode === "composed" && (r.combo?.field_mapping || "gt") === (run.combo.field_mapping || "gt")
+    : r.mode === "isolated" && r.stage === run.stage);
   const peers = allRuns.filter((r) => r.status !== "DNF" && sameGroup(r) && val(r, k) != null);
   if (peers.length < 2) return null;
   const higher = meta.better !== "lower";
@@ -518,7 +523,12 @@ function metricRank(k) {
 function rankBy(accessor, higher) {
   const v = accessor(run);
   if (v == null) return null;
-  const sameGroup = (r) => (run.combo ? r.mode === "composed" : r.mode === "isolated" && r.stage === run.stage);
+  // Composed pipelines are ranked within their OWN field-mapping (the leaderboard groups the same
+  // way: it shows one field-mapping's bfr×dipole matrix at a time), so the denominator matches the
+  // table you clicked from — not the full cross-field-mapping pool of ~845 pipelines.
+  const sameGroup = (r) => (run.combo
+    ? r.mode === "composed" && (r.combo?.field_mapping || "gt") === (run.combo.field_mapping || "gt")
+    : r.mode === "isolated" && r.stage === run.stage);
   const peers = allRuns.filter((r) => r.status !== "DNF" && sameGroup(r) && accessor(r) != null);
   if (peers.length < 2) return null;
   const rank = 1 + peers.filter((r) => (higher ? accessor(r) > v : accessor(r) < v)).length;

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -224,8 +224,10 @@ const fmapsList = () => {
   const s = uniq(composedRuns().map((r) => r.combo.field_mapping || "gt"));
   return s.includes("gt") ? ["gt", ...s.filter((x) => x !== "gt")] : s;
 };
-const bfrList = () => uniq(composedRuns().map((r) => r.combo.bfr));
-const dipoleList = () => uniq(composedRuns().map((r) => r.combo.dipole));
+// Single-step spans (bfr+dipole / end-to-end, e.g. TGV/MEDI/AutoQSM) have a composed run with no
+// bfr/dipole in the combo — filter those out so they don't add an empty "Undefined" row to the axes.
+const bfrList = () => uniq(composedRuns().map((r) => r.combo.bfr).filter(Boolean));
+const dipoleList = () => uniq(composedRuns().map((r) => r.combo.dipole).filter(Boolean));
 const findPipeline = (f, b, d) => composedRuns().find((r) =>
   (r.combo.field_mapping || "gt") === f && r.combo.bfr === b && r.combo.dipole === d);
 const algoName = (slug) => { const a = algos.find((x) => x.slug === slug); return (a && a.name) || slug; };

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -14,6 +14,14 @@ const STAGE_COLOR = {
   dipole: "bg-fuchsia-50 text-fuchsia-700 ring-fuchsia-100 dark:bg-fuchsia-500/10 dark:text-fuchsia-300 dark:ring-fuchsia-500/20",
 };
 
+// Which dataset a run was scored on — shown as the leading badge on the detail page so an in-vivo
+// (2016) run is never mistaken for an in-silico (2019) one. Amber for in-vivo matches results.html.
+const DATASET_BADGE = {
+  qsm:    ["In silico (2019)", "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-300 dark:ring-emerald-500/20"],
+  chisep: ["χ-separation",     "bg-indigo-50 text-indigo-700 ring-indigo-200 dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-500/20"],
+  invivo: ["In vivo (2016)",   "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-300 dark:ring-amber-500/20"],
+};
+
 // Stage I/O for generating "how to run" qsm-ci commands (mirrors stages.yml; magnitude is optional
 // and omitted for brevity). Each stage's output filename is the next stage's input, so a composed
 // pipeline chains as written.
@@ -167,6 +175,14 @@ const composedRuns = () => allRuns.filter((r) => r.mode === "composed" && r.comb
 const chisepRuns = () => allRuns.filter((r) => (r.domain === "chisep" || r.stage === "chi-separation")
   && (r.variant || "default") === "default");
 const hasChisep = () => chisepRuns().length > 0;
+// In-vivo (2016 challenge) runs: a distinct DATASET (not just a domain) — dipole-only, scored vs
+// COSMOS + STI χ33. One flat list, default variant only, like χ-separation.
+const isInvivo = (r) => r.track === "invivo";
+const invivoRuns = () => allRuns.filter((r) => isInvivo(r) && (r.variant || "default") === "default");
+const hasInvivo = () => invivoRuns().length > 0;
+// Which dataset/domain sidebar view a run belongs to.
+const datasetOf = (r) => isInvivo(r) ? "invivo"
+  : (r.domain === "chisep" || r.stage === "chi-separation") ? "chisep" : "qsm";
 // Combined single-step methods (bfr+dipole / end-to-end, e.g. NeXtQSM/TGV/QSMART/MEDI/iQSM) go
 // straight to a chi map in one step, so they have no fmap×bfr×dipole combo and are missed by the
 // matrix axes. Surface them as their own Pipelines group: one run per slug, preferring the composed
@@ -220,7 +236,7 @@ function stagesHTML() {
   // Pipeline order: field mapping → background removal → dipole inversion, then the combined
   // single-method spans (bfr+dipole like TGV/QSMART/MEDI, unwrap+bfr like HARPERELLA, end-to-end).
   return ["field-mapping", "bfr", "dipole", "bfr+dipole", "unwrap+bfr", "end-to-end"].map((s) => {
-    const rs = allRuns.filter((r) => r.mode === "isolated" && r.stage === s && (r.variant || "default") === "default" && (!f || r.name.toLowerCase().includes(f)));
+    const rs = allRuns.filter((r) => r.mode === "isolated" && r.stage === s && (r.variant || "default") === "default" && !isInvivo(r) && (!f || r.name.toLowerCase().includes(f)));
     if (!rs.length) return "";
     const rows = rs.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("");
     return `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">${STAGE_LABEL[s] || s}</div>${rows}</div>`;
@@ -260,23 +276,36 @@ function chisepHTML() {
   const rows = rs.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("");
   return `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">χ-separation</div>${rows}</div>`;
 }
+function invivoHTML() {
+  const f = filter.toLowerCase();
+  const rs = invivoRuns().filter((r) => !f || r.name.toLowerCase().includes(f));
+  if (!rs.length) return `<p class="p-3 text-sm text-gray-400">No in-vivo runs yet.</p>`;
+  const rows = rs.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("");
+  return `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">In vivo (2016) · dipole</div>${rows}</div>`;
+}
 function buildSidebar() {
+  // Fall back to the in-silico dataset if the selected one has no runs.
   if (domain === "chisep" && !hasChisep()) domain = "qsm";
-  // Domain toggle: the χ-separation button is present only when such methods exist.
+  if (domain === "invivo" && !hasInvivo()) domain = "qsm";
+  // Dataset toggle: the χ-separation and In-vivo buttons appear only when such runs exist.
   document.querySelectorAll("#domain-toggle button").forEach((b) =>
     b.className = "flex-1 rounded-md px-2 py-1 transition "
-      + (b.dataset.domain === "chisep" && !hasChisep() ? "hidden " : "")
+      + ((b.dataset.domain === "chisep" && !hasChisep()) || (b.dataset.domain === "invivo" && !hasInvivo()) ? "hidden " : "")
       + (b.dataset.domain === domain ? "bg-white shadow-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100" : "text-gray-500 hover:text-gray-700 dark:text-gray-400"));
-  // The Stages/Pipelines split is meaningless for χ-separation (one flat list); hide it there.
-  $("nav-toggle")?.classList.toggle("hidden", domain === "chisep");
+  // The Stages/Pipelines split is meaningless for the flat χ-separation / in-vivo lists; hide it there.
+  const flat = domain === "chisep" || domain === "invivo";
+  $("nav-toggle")?.classList.toggle("hidden", flat);
   document.querySelectorAll("#nav-toggle button").forEach((b) =>
     b.className = "flex-1 rounded-md px-2 py-1 transition " +
       (b.dataset.mode === navMode ? "bg-white shadow-sm text-gray-900 dark:bg-gray-700 dark:text-gray-100" : "text-gray-500 hover:text-gray-700 dark:text-gray-400"));
-  $("run-list").innerHTML = domain === "chisep" ? chisepHTML() : (navMode === "stages" ? stagesHTML() : pipelinesHTML());
+  $("run-list").innerHTML = domain === "chisep" ? chisepHTML()
+    : domain === "invivo" ? invivoHTML()
+    : (navMode === "stages" ? stagesHTML() : pipelinesHTML());
   $("run-list").querySelectorAll(".run-item").forEach((b) => b.addEventListener("click", () => { if (b.dataset.id) selectRun(b.dataset.id); }));
 }
 function selectRun(id) {
   run = allRuns.find((r) => r.id === id);
+  domain = datasetOf(run);   // keep the sidebar on the dataset this run belongs to
   history.replaceState(null, "", "?run=" + encodeURIComponent(id));
   buildSidebar();
   loadRun();
@@ -357,7 +386,9 @@ function variantToggleHTML() {
 async function loadRun() {
   $("sub-title").textContent = run.name;
   const stageCls = STAGE_COLOR[run.stage] || "bg-gray-100 text-gray-600 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700";
+  const ds = DATASET_BADGE[datasetOf(run)];
   $("sub-badges").innerHTML =
+    badge(ds[0], ds[1]) +
     badge(STAGE_LABEL[run.stage] || run.stage, stageCls) +
     badge(run.mode === "composed" ? "Composed pipeline" : "Isolated", "bg-gray-100 text-gray-600 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700") +
     (run.status === "DNF" ? badge("DNF", "bg-red-50 text-red-600 ring-red-100 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/20") : "") +
@@ -365,6 +396,7 @@ async function loadRun() {
   $("sub-badges").querySelectorAll("[data-variant-id]").forEach((b) =>
     b.addEventListener("click", () => selectRun(b.dataset.variantId)));
   const bits = [];
+  if (isInvivo(run)) bits.push("2016 challenge · scored vs COSMOS + STI χ33 (no true χ in vivo)");
   if (run.artifact) bits.push(`scored artifact <code class="text-gray-700 dark:text-gray-300">${run.artifact}</code>`);
   if (run.image) bits.push(`image <code class="text-gray-700 dark:text-gray-300">${run.image}</code>`);
   $("sub-meta").innerHTML = bits.join(" · ");
@@ -748,7 +780,7 @@ async function init() {
     || allRuns.find((r) => r.mode === "isolated" && r.slug === want)
     || allRuns.find((r) => r.status !== "DNF") || allRuns[0];
   if (!run) { $("sub-title").textContent = "No runs"; return; }
-  domain = (run.domain === "chisep" || run.stage === "chi-separation") ? "chisep" : "qsm";
+  domain = datasetOf(run);
   navMode = run.mode === "composed" ? "pipelines" : "stages";
   $("run-filter").addEventListener("input", (e) => { filter = e.target.value; buildSidebar(); });
   document.querySelectorAll("#nav-toggle button").forEach((b) => b.addEventListener("click", () => { navMode = b.dataset.mode; buildSidebar(); }));

--- a/web/results.html
+++ b/web/results.html
@@ -393,8 +393,8 @@
           <div class="mt-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
             <div class="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <h3 class="font-semibold text-gray-900">The isolated ranking misleads about real pipelines</h3>
-                <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Dipole inversion ranked on the clean ground-truth field (left) versus chained after real background removal (right), by NRMSE, best at top. <span style="color:#10b981" class="font-semibold">Green</span> rises when composed (robust to upstream error); <span style="color:#e11d48" class="font-semibold">red</span> falls. TV-family methods top the clean ranking, then collapse; several networks climb.</p>
+                <h3 class="text-lg font-semibold text-gray-900">The isolated ranking misleads about real pipelines</h3>
+                <p class="mt-2 text-sm text-gray-600 leading-relaxed">Dipole inversion ranked on the clean ground-truth field (left) versus chained after real background removal (right), by NRMSE, best at top. <span style="color:#10b981" class="font-semibold">Green</span> rises when composed (robust to upstream error); <span style="color:#e11d48" class="font-semibold">red</span> falls. TV-family methods top the clean ranking, then collapse; several networks climb.</p>
               </div>
               <label class="inline-flex shrink-0 items-center gap-2 text-xs text-gray-500" data-tip="How each dipole method is summarised across its background-removal partners: the mean (rewards robustness) or its single best pairing (fairest per method).">Summarise by
                 <select x-model="insightMode" class="rounded-lg border-gray-300 text-xs py-1 pr-7">
@@ -403,20 +403,20 @@
                 </select>
               </label>
             </div>
-            <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="slopeSVG"></div>
+            <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="slopeSVG"></div>
           </div>
 
           <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h3 class="font-semibold text-gray-900">Accurate but fragile, or reliable but modest</h3>
-            <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each dipole method by its mean NRMSE across background-removal partners (x) versus how much that error <em>varies</em> between partners (y). Bottom-left is the sweet spot: accurate <em>and</em> consistent. Iterative methods lead on average but scatter wildly with a poor upstream stage; networks are dull but dependable.</p>
+            <h3 class="text-lg font-semibold text-gray-900">Accurate but fragile, or reliable but modest</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Each dipole method by its mean NRMSE across background-removal partners (x) versus how much that error <em>varies</em> between partners (y). Bottom-left is the sweet spot: accurate <em>and</em> consistent. Iterative methods lead on average but scatter wildly with a poor upstream stage; networks are dull but dependable.</p>
             <div class="mt-2" x-html="familyLegend"></div>
             <div class="mt-2 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="reliabilitySVG"></div>
           </div>
 
           <template x-if="pipelineFacts">
             <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h3 class="font-semibold text-gray-900">You can't build the best pipeline greedily</h3>
-              <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Picking the strongest method at each stage independently does <em>not</em> give the best end-to-end pipeline: stages interact. The best full pipeline beats the greedy per-stage choice by <span class="font-semibold" x-text="pipelineFacts.deltaPct+'%'"></span> NRMSE.</p>
+              <h3 class="text-lg font-semibold text-gray-900">You can't build the best pipeline greedily</h3>
+              <p class="mt-2 text-sm text-gray-600 leading-relaxed">Picking the strongest method at each stage independently does <em>not</em> give the best end-to-end pipeline: stages interact. The best full pipeline beats the greedy per-stage choice by <span class="font-semibold" x-text="pipelineFacts.deltaPct+'%'"></span> NRMSE.</p>
               <div class="mt-4 space-y-3">
                 <template x-for="row in [{k:'optimal',lab:'Best full pipeline',c:'#10b981'},{k:'greedy',lab:'Greedy (best method per stage)',c:'#e11d48'}]" :key="row.k">
                   <div>
@@ -460,8 +460,8 @@
 
           <template x-if="stageImportance">
             <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h3 class="font-semibold text-gray-900">Which stage decides your result?</h3>
-              <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Share of full-pipeline NRMSE variance explained by the choice at each stage, across every pipeline. Background removal dominates: it swings the final error far more than the dipole-inversion method the field usually focuses on.</p>
+              <h3 class="text-lg font-semibold text-gray-900">Which stage decides your result?</h3>
+              <p class="mt-2 text-sm text-gray-600 leading-relaxed">Share of full-pipeline NRMSE variance explained by the choice at each stage, across every pipeline. Background removal dominates: it swings the final error far more than the dipole-inversion method the field usually focuses on.</p>
               <div class="mt-4 space-y-3">
                 <template x-for="st in stageImportance" :key="st.f">
                   <div>
@@ -484,20 +484,20 @@
         <!-- ---- Different metrics, different winners ---- -->
         <div x-show="findView==='metrics'">
           <div class="mt-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h3 class="font-semibold text-gray-900">The best method depends on what you measure</h3>
-            <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Isolated dipole methods across five metrics, each normalised so <em>higher is better</em>. Grey lines are all methods; the coloured lines are the winner of a given axis, showing they lose elsewhere: the global-NRMSE / xSIM leader is among the <em>worst</em> at calcification, and the fast direct methods that under-quantify iron.</p>
+            <h3 class="text-lg font-semibold text-gray-900">The best method depends on what you measure</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Isolated dipole methods across five metrics, each normalised so <em>higher is better</em>. Grey lines are all methods; the coloured lines are the winner of a given axis, showing they lose elsewhere: the global-NRMSE / xSIM leader is among the <em>worst</em> at calcification, and the fast direct methods that under-quantify iron.</p>
             <div class="mt-2 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="parallelSVG"></div>
           </div>
 
           <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h3 class="font-semibold text-gray-900">Where the error lives</h3>
-            <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Isolated dipole error by region and artefact (rows sorted by overall NRMSE). <span style="color:#6ea886" class="font-semibold">Green</span> is good, <span style="color:#be6b6b" class="font-semibold">red</span> is poor, coloured within each column. Venous blood is universally hardest; the calcification columns reshuffle the ranking entirely.</p>
+            <h3 class="text-lg font-semibold text-gray-900">Where the error lives</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Isolated dipole error by region and artefact (rows sorted by overall NRMSE). <span style="color:#6ea886" class="font-semibold">Green</span> is good, <span style="color:#be6b6b" class="font-semibold">red</span> is poor, coloured within each column. Venous blood is universally hardest; the calcification columns reshuffle the ranking entirely.</p>
             <div class="mt-3 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="roiHeatSVG"></div>
           </div>
 
           <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h3 class="font-semibold text-gray-900">Which metrics are redundant</h3>
-            <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Rank agreement (Spearman ρ) between metrics over the isolated dipole methods, sign-aligned so +1 means they reward the same methods. NRMSE, detrended NRMSE and correlation are near-interchangeable; DGM linearity, calcification and runtime are their own axes, so a single headline number can't stand in for them.</p>
+            <h3 class="text-lg font-semibold text-gray-900">Which metrics are redundant</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Rank agreement (Spearman ρ) between metrics over the isolated dipole methods, sign-aligned so +1 means they reward the same methods. NRMSE, detrended NRMSE and correlation are near-interchangeable; DGM linearity, calcification and runtime are their own axes, so a single headline number can't stand in for them.</p>
             <div class="mt-3 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="corrSVG"></div>
           </div>
         </div>
@@ -505,16 +505,16 @@
         <!-- ---- Speed & tuning ---- -->
         <div x-show="findView==='speed'">
           <div class="mt-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h3 class="font-semibold text-gray-900">Accuracy vs compute</h3>
-            <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Isolated dipole inversion: structural similarity (xSIM, higher is better) against wall-clock runtime on a log scale. <span style="color:#10b981" class="font-semibold">Green</span> points are Pareto-optimal (nothing is both faster and more accurate); grey points are dominated. Some methods cost minutes for no accuracy gain.</p>
-            <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="paretoSVG"></div>
+            <h3 class="text-lg font-semibold text-gray-900">Accuracy vs compute</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Isolated dipole inversion: structural similarity (xSIM, higher is better) against wall-clock runtime on a log scale. <span style="color:#10b981" class="font-semibold">Green</span> points are Pareto-optimal (nothing is both faster and more accurate); grey points are dominated. Some methods cost minutes for no accuracy gain.</p>
+            <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="paretoSVG"></div>
           </div>
 
           <template x-if="tuningRows.length">
             <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h3 class="font-semibold text-gray-900">What tuning buys</h3>
-              <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Isolated dipole NRMSE at default parameters (grey) versus tuned on the scoring phantom (green). Only a handful of methods are tunable (pretrained networks aren't), which is why <em>defaults</em> is the fair cross-method ranking. Tuning on the scored data is a mild form of overfitting.</p>
-              <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="tuningSVG"></div>
+              <h3 class="text-lg font-semibold text-gray-900">What tuning buys</h3>
+              <p class="mt-2 text-sm text-gray-600 leading-relaxed">Isolated dipole NRMSE at default parameters (grey) versus tuned on the scoring phantom (green). Only a handful of methods are tunable (pretrained networks aren't), which is why <em>defaults</em> is the fair cross-method ranking. Tuning on the scored data is a mild form of overfitting.</p>
+              <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="tuningSVG"></div>
             </div>
           </template>
         </div>
@@ -522,8 +522,8 @@
         <!-- ---- Explore ---- -->
         <div x-show="findView==='explore'">
           <div class="mt-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-            <h3 class="font-semibold text-gray-900">Build your own comparison</h3>
-            <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Plot any two metrics against each other for any isolated stage. Points are methods, coloured by family; hover to identify, click to open a method. Runtime uses a log scale.</p>
+            <h3 class="text-lg font-semibold text-gray-900">Build your own comparison</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Plot any two metrics against each other for any isolated stage. Points are methods, coloured by family; hover to identify, click to open a method. Runtime uses a log scale.</p>
             <div class="mt-3 flex flex-wrap items-center gap-3 text-sm">
               <label class="inline-flex items-center gap-2 text-gray-600 dark:text-gray-400">Stage
                 <select x-model="expStage" @change="fixExpMetrics()" class="rounded-lg border-gray-300 text-sm py-1.5 pr-8">
@@ -658,15 +658,15 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <!-- χ-separation · Findings (figures split out of the Leaderboard, mirroring the in-silico dataset) -->
       <div x-show="chisepView==='findings'" x-cloak>
       <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-        <h3 class="font-semibold text-gray-900">Myelin (χ−) is harder to recover than iron (χ+)</h3>
-        <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Structural similarity (xSIM) of the recovered paramagnetic χ+ (iron) source versus the diamagnetic χ− (myelin / calcium) source. Every method drops from left to right, so the diamagnetic map is systematically the harder of the two.</p>
-        <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="chisepSVG"></div>
+        <h3 class="text-lg font-semibold text-gray-900">Myelin (χ−) is harder to recover than iron (χ+)</h3>
+        <p class="mt-2 text-sm text-gray-600 leading-relaxed">Structural similarity (xSIM) of the recovered paramagnetic χ+ (iron) source versus the diamagnetic χ− (myelin / calcium) source. Every method drops from left to right, so the diamagnetic map is systematically the harder of the two.</p>
+        <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="chisepSVG"></div>
       </div>
 
       <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-        <h3 class="font-semibold text-gray-900">Cross-contamination between the two sources</h3>
-        <p class="mt-0.5 max-w-2xl text-xs text-gray-500">How much each source map bleeds into the other (regression slope, 0 = clean): iron leaking into the myelin map (x) versus myelin leaking into iron (y). The origin is perfect separation; distance from it is contamination that xSIM can miss.</p>
-        <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="leakSVG"></div>
+        <h3 class="text-lg font-semibold text-gray-900">Cross-contamination between the two sources</h3>
+        <p class="mt-2 text-sm text-gray-600 leading-relaxed">How much each source map bleeds into the other (regression slope, 0 = clean): iron leaking into the myelin map (x) versus myelin leaking into iron (y). The origin is perfect separation; distance from it is contamination that xSIM can miss.</p>
+        <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="leakSVG"></div>
       </div>
       </div><!-- /chisep findings -->
 
@@ -781,20 +781,20 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <!-- In vivo · Findings -->
       <div x-show="invivoView==='findings'" x-cloak>
         <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 class="font-semibold text-gray-900">COSMOS vs STI χ33 — the harder reference</h3>
-          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each method's structural similarity against the two references. Every point sits below the diagonal — STI χ33 is a systematically harder target than COSMOS (roughly +20 NRMSE across the board) — yet the two references rank methods almost identically. Coloured by family; hover for values.</p>
+          <h3 class="text-lg font-semibold text-gray-900">COSMOS vs STI χ33 — the harder reference</h3>
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">Each method's structural similarity against the two references. Every point sits below the diagonal — STI χ33 is a systematically harder target than COSMOS (roughly +20 NRMSE across the board) — yet the two references rank methods almost identically. Coloured by family; hover for values.</p>
           <div class="mt-2" x-html="familyLegend"></div>
-          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivRefScatterSVG"></div>
+          <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivRefScatterSVG"></div>
         </div>
         <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 class="font-semibold text-gray-900">Do NRMSE and HFEN agree?</h3>
-          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">The headline error metric (NRMSE) against the fine-detail metric (HFEN, the 2016 challenge's signature), both vs COSMOS. A high Spearman ρ means they reward the same methods; where a point strays off the trend, a method wins on bulk error but loses fine structure, or vice-versa.</p>
-          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivHfenNrmseSVG"></div>
+          <h3 class="text-lg font-semibold text-gray-900">Do NRMSE and HFEN agree?</h3>
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">The headline error metric (NRMSE) against the fine-detail metric (HFEN, the 2016 challenge's signature), both vs COSMOS. A high Spearman ρ means they reward the same methods; where a point strays off the trend, a method wins on bulk error but loses fine structure, or vice-versa.</p>
+          <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivHfenNrmseSVG"></div>
         </div>
         <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-          <h3 class="font-semibold text-gray-900">Runtime vs accuracy</h3>
-          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">In-vivo structural similarity (xSIM vs COSMOS) against wall-clock runtime on a log scale. <span style="color:#10b981" class="font-semibold">Green</span> points are Pareto-optimal (nothing is both faster and more accurate); grey points are dominated.</p>
-          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivParetoSVG"></div>
+          <h3 class="text-lg font-semibold text-gray-900">Runtime vs accuracy</h3>
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">In-vivo structural similarity (xSIM vs COSMOS) against wall-clock runtime on a log scale. <span style="color:#10b981" class="font-semibold">Green</span> points are Pareto-optimal (nothing is both faster and more accurate); grey points are dominated.</p>
+          <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivParetoSVG"></div>
         </div>
       </div><!-- /in-vivo findings -->
 
@@ -827,22 +827,22 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Dipole inversion across datasets</h2>
           <p class="mt-2 max-w-3xl text-gray-600 dark:text-gray-400 leading-relaxed">The same isolated dipole-inversion methods, scored on the in-silico phantom (2019, true χ) and the in-vivo challenge (2016, COSMOS reference). Does a ranking on the idealised phantom carry over to real acquired data?</p>
         </div>
-        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h3 class="font-semibold text-gray-900 dark:text-gray-100">Phantom rank does not predict in-vivo rank</h3>
-          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each method's xSIM on the in-silico phantom (x) against its xSIM in vivo (y), coloured by family. The two are essentially uncorrelated: classical iterative and direct methods that win on the clean phantom collapse in vivo, while deep-learning methods hold up. Hover for values; click to open a method.</p>
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">Phantom rank does not predict in-vivo rank</h3>
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">Each method's xSIM on the in-silico phantom (x) against its xSIM in vivo (y), coloured by family. The two are essentially uncorrelated: classical iterative and direct methods that win on the clean phantom collapse in vivo, while deep-learning methods hold up. Hover for values; click to open a method.</p>
           <div class="mt-2" x-html="familyLegend"></div>
-          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossScatterSVG"></div>
+          <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossScatterSVG"></div>
         </div>
-        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h3 class="font-semibold text-gray-900 dark:text-gray-100">How methods move between datasets</h3>
-          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each method's rank on the in-silico phantom (left) linked to its rank in vivo (right), by xSIM. Lines coloured by family: deep-learning methods tend to climb left-to-right; classical methods fall.</p>
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">How methods move between datasets</h3>
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">Each method's rank on the in-silico phantom (left) linked to its rank in vivo (right), by xSIM. Lines coloured by family: deep-learning methods tend to climb left-to-right; classical methods fall.</p>
           <div class="mt-2" x-html="familyLegend"></div>
-          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBumpSVG"></div>
+          <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBumpSVG"></div>
         </div>
-        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h3 class="font-semibold text-gray-900 dark:text-gray-100">Domain robustness by family</h3>
-          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Mean xSIM per method family on each dataset. Deep-learning methods barely drop from phantom to in-vivo; classical iterative and direct methods lose far more — tuned to the idealised phantom, they generalise worse to real 3 T data.</p>
-          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBarsSVG"></div>
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h3 class="text-lg font-semibold text-gray-900">Domain robustness by family</h3>
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">Mean xSIM per method family on each dataset. Deep-learning methods barely drop from phantom to in-vivo; classical iterative and direct methods lose far more — tuned to the idealised phantom, they generalise worse to real 3 T data.</p>
+          <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBarsSVG"></div>
         </div>
       </div>
     </section>

--- a/web/results.html
+++ b/web/results.html
@@ -130,6 +130,9 @@
       <template x-if="hasInvivo()">
         <button class="dtab" :class="{'dtab-on': dataset==='invivo'}" @click="setDataset('invivo')">In vivo (2016)</button>
       </template>
+      <template x-if="hasCross()">
+        <button class="dtab" :class="{'dtab-on': dataset==='cross'}" @click="setDataset('cross')">Cross-dataset</button>
+      </template>
     </div>
 
     <!-- ===================== IN SILICO (2019) ===================== -->
@@ -721,6 +724,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <div class="rtabs">
         <button class="rtab" :class="{'rtab-on': invivoView==='info'}" @click="invivoView='info'">Info</button>
         <button class="rtab" :class="{'rtab-on': invivoView==='board'}" @click="invivoView='board'">Leaderboard</button>
+        <button class="rtab" :class="{'rtab-on': invivoView==='findings'}" @click="invivoView='findings'">Findings</button>
       </div>
 
       <div x-show="invivoView==='board'" x-cloak>
@@ -774,6 +778,26 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       </div>
       </div><!-- /in-vivo board -->
 
+      <!-- In vivo · Findings -->
+      <div x-show="invivoView==='findings'" x-cloak>
+        <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h3 class="font-semibold text-gray-900">COSMOS vs STI χ33 — the harder reference</h3>
+          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each method's structural similarity against the two references. Every point sits below the diagonal — STI χ33 is a systematically harder target than COSMOS (roughly +20 NRMSE across the board) — yet the two references rank methods almost identically. Coloured by family; hover for values.</p>
+          <div class="mt-2" x-html="familyLegend"></div>
+          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivRefScatterSVG"></div>
+        </div>
+        <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h3 class="font-semibold text-gray-900">Do NRMSE and HFEN agree?</h3>
+          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">The headline error metric (NRMSE) against the fine-detail metric (HFEN, the 2016 challenge's signature), both vs COSMOS. A high Spearman ρ means they reward the same methods; where a point strays off the trend, a method wins on bulk error but loses fine structure, or vice-versa.</p>
+          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivHfenNrmseSVG"></div>
+        </div>
+        <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h3 class="font-semibold text-gray-900">Runtime vs accuracy</h3>
+          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">In-vivo structural similarity (xSIM vs COSMOS) against wall-clock runtime on a log scale. <span style="color:#10b981" class="font-semibold">Green</span> points are Pareto-optimal (nothing is both faster and more accurate); grey points are dominated.</p>
+          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivParetoSVG"></div>
+        </div>
+      </div><!-- /in-vivo findings -->
+
       <!-- In vivo · Info -->
       <div x-show="invivoView==='info'" x-cloak class="info mt-6 space-y-8">
         <div>
@@ -792,6 +816,33 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
             <li><strong>2016 Challenge lessons:</strong> Milovic C., Tejos C., Acosta-Cabronero J., et&nbsp;al. &ldquo;The 2016 QSM Challenge: Lessons learned and considerations for a future challenge design.&rdquo; <em>Magn Reson Med</em> 2020;84(3):1624&ndash;1637. <a href="https://doi.org/10.1002/mrm.28185" class="text-emerald-600 hover:underline">doi:10.1002/mrm.28185</a>.</li>
             <li><strong>COSMOS reference:</strong> Liu T., Spincemaille P., de&nbsp;Rochefort L., Kressler B., Wang Y. &ldquo;Calculation of susceptibility through multiple orientation sampling (COSMOS).&rdquo; <em>Magn Reson Med</em> 2009;61(1):196&ndash;204. <a href="https://doi.org/10.1002/mrm.21828" class="text-emerald-600 hover:underline">doi:10.1002/mrm.21828</a>.</li>
           </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================== CROSS-DATASET ===================== -->
+    <section x-show="dataset==='cross'" x-cloak class="mt-3">
+      <div class="mt-6 space-y-8">
+        <div>
+          <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Dipole inversion across datasets</h2>
+          <p class="mt-2 max-w-3xl text-gray-600 dark:text-gray-400 leading-relaxed">The same isolated dipole-inversion methods, scored on the in-silico phantom (2019, true χ) and the in-vivo challenge (2016, COSMOS reference). Does a ranking on the idealised phantom carry over to real acquired data?</p>
+        </div>
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h3 class="font-semibold text-gray-900 dark:text-gray-100">Phantom rank does not predict in-vivo rank</h3>
+          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each method's xSIM on the in-silico phantom (x) against its xSIM in vivo (y), coloured by family. The two are essentially uncorrelated: classical iterative and direct methods that win on the clean phantom collapse in vivo, while deep-learning methods hold up. Hover for values; click to open a method.</p>
+          <div class="mt-2" x-html="familyLegend"></div>
+          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossScatterSVG"></div>
+        </div>
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h3 class="font-semibold text-gray-900 dark:text-gray-100">How methods move between datasets</h3>
+          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Each method's rank on the in-silico phantom (left) linked to its rank in vivo (right), by xSIM. Lines coloured by family: deep-learning methods tend to climb left-to-right; classical methods fall.</p>
+          <div class="mt-2" x-html="familyLegend"></div>
+          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBumpSVG"></div>
+        </div>
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          <h3 class="font-semibold text-gray-900 dark:text-gray-100">Domain robustness by family</h3>
+          <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Mean xSIM per method family on each dataset. Deep-learning methods barely drop from phantom to in-vivo; classical iterative and direct methods lose far more — tuned to the idealised phantom, they generalise worse to real 3 T data.</p>
+          <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBarsSVG"></div>
         </div>
       </div>
     </section>
@@ -886,6 +937,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           // top-level dataset (default in-silico); legacy ?tab=invivo also selects the in-vivo dataset
           if (q.get("dataset") === "invivo" || q.get("tab") === "invivo") this.dataset = "invivo";
           if (q.get("dataset") === "chisep" || q.get("tab") === "chisep") this.dataset = "chisep";
+          if (q.get("dataset") === "cross") this.dataset = "cross";
           const t = q.get("tab");
           if (["info", "leaderboard", "findings"].includes(t)) this.tab = t;
           else if (["pipelines", "stages"].includes(t)) this.tab = "leaderboard";
@@ -903,6 +955,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
             if (!this.runs.some((r) => r.mode === "composed")) { this.lbView = "stages"; this.syncView(); }
             if (!this.hasChiSep() && this.dataset === "chisep") this.dataset = "sim";
             if (!this.hasInvivo() && this.dataset === "invivo") this.dataset = "sim";
+            if (!this.hasCross() && this.dataset === "cross") this.dataset = "sim";
           } finally {
             this.loading = false;   // only reveal the empty-state once the fetch has actually resolved
           }
@@ -1099,6 +1152,185 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           const d = rx.reduce((a, _, i) => a + (rx[i] - ry[i]) ** 2, 0);
           return 1 - 6 * d / (n * (n * n - 1));
         },
+
+        // ---- in-vivo (2016) + cross-dataset findings -------------------------------------
+        _ivDip() {
+          const by = {};
+          this._invivo().filter((r) => r.mode === "isolated" && (r.variant || "default") === "default" && r.status !== "DNF" && val(r, "xsim") != null)
+            .forEach((r) => { by[r.slug] = r; });
+          return Object.values(by);
+        },
+        _ivRunId(slug) { const r = this.runs.find((x) => this._isInvivo(x) && x.mode === "isolated" && x.slug === slug && (x.variant || "default") === "default"); return r ? r.id : ""; },
+        _ptIv(slug, tip) { const id = this._ivRunId(slug); return `data-tip="${this._esc(tip)}"` + (id ? ` data-run="${id}"` : ""); },
+        hasCross() { return this._isoDip().length > 0 && this.hasInvivo(); },
+        _crossDip() {
+          const iv = {}; this._ivDip().forEach((r) => { iv[r.slug] = r; });
+          return this._isoDip().filter((r) => iv[r.slug] && val(r, "xsim") != null && val(iv[r.slug], "xsim") != null)
+            .map((r) => ({ slug: r.slug, name: this.algoName(r.slug), si: val(r, "xsim"), iv: val(iv[r.slug], "xsim"), fam: this._fam(r.slug) }));
+        },
+
+        // In-vivo · COSMOS vs STI reference agreement (points below the diagonal = STI is the harder target).
+        get ivRefScatterSVG() {
+          return _cache("ivref", this.runs.length, () => {
+            const E = this._esc;
+            const rows = this._ivDip().map((r) => ({ slug: r.slug, name: this.algoName(r.slug), x: val(r, "xsim"), y: val(r, "xsim_sti"), fam: this._fam(r.slug) })).filter((p) => p.x != null && p.y != null);
+            if (rows.length < 2) return "<svg></svg>";
+            const w = 700, h = 420, pl = 52, pr = 20, pt = 20, pb = 46;
+            const all = rows.flatMap((r) => [r.x, r.y]), lo = Math.max(0, Math.min(...all) - 0.03), hi = Math.min(1, Math.max(...all) + 0.03);
+            const SX = (v) => pl + (v - lo) / (hi - lo || 1) * (w - pl - pr), SY = (v) => h - pb - (v - lo) / (hi - lo || 1) * (h - pt - pb);
+            let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+            s += `<line x1="${SX(lo)}" y1="${SY(lo)}" x2="${SX(hi)}" y2="${SY(hi)}" stroke="currentColor" stroke-dasharray="4 4" opacity="0.25"/>`;
+            s += `<text x="${SX(hi) - 4}" y="${SY(hi) + 14}" text-anchor="end" fill="currentColor" opacity="0.4" style="font-size:10px;font-style:italic">equal agreement</text>`;
+            s += `<line x1="${pl}" y1="${h - pb}" x2="${w - 8}" y2="${h - pb}" stroke="currentColor" opacity="0.2"/><line x1="${pl}" y1="${pt}" x2="${pl}" y2="${h - pb}" stroke="currentColor" opacity="0.2"/>`;
+            s += `<text x="${(pl + w) / 2}" y="${h - 5}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600">xSIM vs COSMOS →</text>`;
+            s += `<text x="14" y="${(pt + h - pb) / 2}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600" transform="rotate(-90 14 ${(pt + h - pb) / 2})">xSIM vs STI χ33 →</text>`;
+            const lab = new Set([...rows].sort((a, b) => b.x - a.x).slice(0, 3).map((r) => r.slug)); [...rows].sort((a, b) => a.x - b.x).slice(0, 2).forEach((r) => lab.add(r.slug));
+            rows.forEach((r) => {
+              const x = SX(r.x), y = SY(r.y);
+              s += `<circle cx="${x}" cy="${y}" r="4.5" fill="${FAM[r.fam].c}" opacity="0.85" ${this._ptIv(r.slug, `${r.name} — COSMOS ${r.x.toFixed(2)}, STI ${r.y.toFixed(2)} xSIM`)}/>`;
+              if (lab.has(r.slug)) s += `<text x="${x + 7}" y="${y + 3}" fill="currentColor" opacity="0.8" style="font-size:10px">${E(r.name)}</text>`;
+            });
+            return s + "</svg>";
+          });
+        },
+
+        // In-vivo · do the two agreement metrics (NRMSE, HFEN) rank methods the same?
+        get ivHfenNrmseSVG() {
+          return _cache("ivhn", this.runs.length, () => {
+            const E = this._esc;
+            const rows = this._ivDip().map((r) => ({ slug: r.slug, name: this.algoName(r.slug), x: val(r, "nrmse"), y: val(r, "hfen"), fam: this._fam(r.slug) })).filter((p) => p.x != null && p.y != null);
+            if (rows.length < 2) return "<svg></svg>";
+            const w = 700, h = 400, pl = 50, pr = 20, pt = 18, pb = 46;
+            const [x0, x1] = robustRange(rows.map((r) => r.x)), [y0, y1] = robustRange(rows.map((r) => r.y));
+            const SX = (v) => pl + (Math.min(v, x1) - x0) / (x1 - x0 || 1) * (w - pl - pr), SY = (v) => h - pb - (Math.min(v, y1) - y0) / (y1 - y0 || 1) * (h - pt - pb);
+            const rho = this._spear(rows.map((r) => r.x), rows.map((r) => r.y));
+            let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+            s += `<line x1="${pl}" y1="${h - pb}" x2="${w - 8}" y2="${h - pb}" stroke="currentColor" opacity="0.2"/><line x1="${pl}" y1="${pt}" x2="${pl}" y2="${h - pb}" stroke="currentColor" opacity="0.2"/>`;
+            s += `<text x="${(pl + w) / 2}" y="${h - 5}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600">NRMSE vs COSMOS (%) →</text>`;
+            s += `<text x="14" y="${(pt + h - pb) / 2}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600" transform="rotate(-90 14 ${(pt + h - pb) / 2})">HFEN vs COSMOS (%) →</text>`;
+            s += `<text x="${w - 14}" y="${pt + 12}" text-anchor="end" fill="currentColor" opacity="0.6" style="font-size:11px;font-weight:600">Spearman ρ = ${rho.toFixed(2)}</text>`;
+            const lab = new Set([...rows].sort((a, b) => a.x - b.x).slice(0, 3).map((r) => r.slug)); [...rows].sort((a, b) => b.x - a.x).slice(0, 2).forEach((r) => lab.add(r.slug));
+            rows.forEach((r) => {
+              const x = SX(r.x), y = SY(r.y);
+              s += `<circle cx="${x}" cy="${y}" r="4.5" fill="${FAM[r.fam].c}" opacity="0.85" ${this._ptIv(r.slug, `${r.name} — NRMSE ${r.x.toFixed(0)}%, HFEN ${r.y.toFixed(0)}%`)}/>`;
+              if (lab.has(r.slug)) s += `<text x="${x + 7}" y="${y + 3}" fill="currentColor" opacity="0.8" style="font-size:10px">${E(r.name)}</text>`;
+            });
+            return s + "</svg>";
+          });
+        },
+
+        // In-vivo · runtime vs accuracy Pareto (COSMOS xSIM).
+        get ivParetoSVG() {
+          return _cache("ivpar", this.runs.length, () => {
+            const E = this._esc;
+            const pts = this._ivDip().filter((r) => val(r, "xsim") != null && val(r, "runtime_s") != null)
+              .map((r) => ({ slug: r.slug, name: this.algoName(r.slug), rt: val(r, "runtime_s"), xsim: val(r, "xsim") }));
+            const w = 690, h = 380, pl = 46, pr = 16, pt = 16, pb = 46;
+            if (!pts.length) return "<svg></svg>";
+            pts.forEach((p) => { p.pareto = !pts.some((q) => q !== p && q.xsim >= p.xsim && q.rt <= p.rt && (q.xsim > p.xsim || q.rt < p.rt)); });
+            const lx = pts.map((p) => Math.log10(p.rt)), x0 = Math.min(...lx), x1 = Math.max(...lx);
+            const ys = pts.map((p) => p.xsim), y0 = Math.max(0, Math.min(...ys) - 0.03), y1 = Math.min(1, Math.max(...ys) + 0.03);
+            const sx = (v) => pl + (Math.log10(v) - x0) / (x1 - x0 || 1) * (w - pl - pr), sy = (v) => h - pb - (v - y0) / (y1 - y0 || 1) * (h - pt - pb);
+            pts.forEach((p) => { p.px = sx(p.rt); p.py = sy(p.xsim); });
+            const front = pts.filter((p) => p.pareto).sort((a, b) => a.rt - b.rt), fr = (v) => v >= 3600 ? Math.round(v / 3600) + "h" : v >= 60 ? Math.round(v / 60) + "m" : Math.round(v) + "s", ay = h - pb;
+            let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+            s += `<line x1="${pl}" y1="${ay}" x2="${w - 8}" y2="${ay}" stroke="currentColor" opacity="0.2"/><line x1="${pl}" y1="${pt}" x2="${pl}" y2="${ay}" stroke="currentColor" opacity="0.2"/>`;
+            for (let e = Math.ceil(x0); e <= Math.floor(x1); e++) { const v = 10 ** e, x = sx(v); s += `<line x1="${x}" y1="${ay}" x2="${x}" y2="${ay + 4}" stroke="currentColor" opacity="0.3"/><text x="${x}" y="${ay + 16}" text-anchor="middle" fill="currentColor" opacity="0.5" style="font-size:10px">${fr(v)}</text>`; }
+            s += `<text x="${(pl + w) / 2}" y="${h - 3}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600">runtime (log scale)</text>`;
+            s += `<text x="13" y="${(pt + ay) / 2}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600" transform="rotate(-90 13 ${(pt + ay) / 2})">xSIM vs COSMOS</text>`;
+            if (front.length > 1) s += `<polyline points="${front.map((p) => p.px + "," + p.py).join(" ")}" fill="none" stroke="#10b981" stroke-width="1.5" opacity="0.5" stroke-dasharray="4 3"/>`;
+            pts.forEach((p) => {
+              s += `<circle cx="${p.px}" cy="${p.py}" r="${p.pareto ? 4.5 : 3.5}" fill="${p.pareto ? "#10b981" : "#94a3b8"}" opacity="${p.pareto ? 1 : 0.5}" ${this._ptIv(p.slug, `${p.name} — xSIM ${p.xsim.toFixed(2)}, ${fmt(p.rt, "runtime_s")}`)}/>`;
+              if (p.pareto) s += `<text x="${p.px + 7}" y="${p.py + 3}" fill="currentColor" opacity="0.85" style="font-size:10px">${E(p.name)}</text>`;
+            });
+            return s + "</svg>";
+          });
+        },
+
+        // Cross-dataset · in-silico xSIM vs in-vivo (COSMOS) xSIM, coloured by family — the money shot.
+        get crossScatterSVG() {
+          return _cache("xsc", this.runs.length, () => {
+            const E = this._esc, rows = this._crossDip();
+            if (rows.length < 3) return "<svg></svg>";
+            const w = 720, h = 460, pl = 52, pr = 20, pt = 22, pb = 46;
+            const xs = rows.map((r) => r.si), ys = rows.map((r) => r.iv);
+            const x0 = Math.max(0, Math.min(...xs) - 0.03), x1 = Math.min(1, Math.max(...xs) + 0.03), y0 = Math.max(0, Math.min(...ys) - 0.03), y1 = Math.min(1, Math.max(...ys) + 0.03);
+            const SX = (v) => pl + (v - x0) / (x1 - x0 || 1) * (w - pl - pr), SY = (v) => h - pb - (v - y0) / (y1 - y0 || 1) * (h - pt - pb);
+            const rho = this._spear(xs, ys);
+            let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+            s += `<line x1="${pl}" y1="${h - pb}" x2="${w - 8}" y2="${h - pb}" stroke="currentColor" opacity="0.2"/><line x1="${pl}" y1="${pt}" x2="${pl}" y2="${h - pb}" stroke="currentColor" opacity="0.2"/>`;
+            s += `<text x="${(pl + w) / 2}" y="${h - 5}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600">in-silico (2019) xSIM · true χ →</text>`;
+            s += `<text x="14" y="${(pt + h - pb) / 2}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600" transform="rotate(-90 14 ${(pt + h - pb) / 2})">in-vivo (2016) xSIM · COSMOS →</text>`;
+            s += `<text x="${w - 14}" y="${pt + 12}" text-anchor="end" fill="currentColor" opacity="0.65" style="font-size:12px;font-weight:700">Spearman ρ = ${rho.toFixed(2)}</text>`;
+            s += `<text x="${w - 14}" y="${pt + 28}" text-anchor="end" fill="currentColor" opacity="0.45" style="font-size:10px">phantom rank ≠ in-vivo rank</text>`;
+            const lab = new Set(); [...rows].sort((a, b) => b.si - a.si).slice(0, 2).forEach((r) => lab.add(r.slug)); [...rows].sort((a, b) => b.iv - a.iv).slice(0, 2).forEach((r) => lab.add(r.slug));
+            [...rows].sort((a, b) => Math.abs(b.si - b.iv) - Math.abs(a.si - a.iv)).slice(0, 4).forEach((r) => lab.add(r.slug));
+            rows.forEach((r) => {
+              const x = SX(r.si), y = SY(r.iv);
+              s += `<circle cx="${x}" cy="${y}" r="5" fill="${FAM[r.fam].c}" opacity="0.85" ${this._ptIv(r.slug, `${r.name} — silico ${r.si.toFixed(2)}, in-vivo ${r.iv.toFixed(2)} xSIM`)}/>`;
+              if (lab.has(r.slug)) s += `<text x="${x + 7}" y="${y + 3}" fill="currentColor" opacity="0.85" style="font-size:10px">${E(r.name)}</text>`;
+            });
+            return s + "</svg>";
+          });
+        },
+
+        // Cross-dataset · rank slope chart (in-silico rank → in-vivo rank), lines coloured by family.
+        get crossBumpSVG() {
+          return _cache("xbump", this.runs.length, () => {
+            const E = this._esc, rows = this._crossDip();
+            if (rows.length < 3) return "<svg></svg>";
+            [...rows].sort((a, b) => b.si - a.si).forEach((r, i) => { r.sR = i; });
+            [...rows].sort((a, b) => b.iv - a.iv).forEach((r, i) => { r.vR = i; });
+            const rh = 24, top = 40, xL = 200, xR = 520, w = 740, h = top + rows.length * rh + 12;
+            let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+            s += `<text x="${xL}" y="22" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600">in-silico (2019) rank</text>`;
+            s += `<text x="${xR}" y="22" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600">in-vivo (2016) rank</text>`;
+            rows.forEach((r) => {
+              const yL = top + r.sR * rh, yR = top + r.vR * rh, c = FAM[r.fam].c;
+              s += `<g ${this._ptIv(r.slug, `${r.name} — silico #${r.sR + 1} → in-vivo #${r.vR + 1}`)}>`;
+              s += `<line x1="${xL}" y1="${yL}" x2="${xR}" y2="${yR}" stroke="${c}" stroke-width="1.5" opacity="0.6"/>`;
+              s += `<circle cx="${xL}" cy="${yL}" r="3.5" fill="${c}"/><circle cx="${xR}" cy="${yR}" r="3.5" fill="${c}"/>`;
+              s += `<text x="${xL - 9}" y="${yL + 3.5}" text-anchor="end" fill="currentColor" opacity="0.8" style="font-size:11px">${E(r.name)}</text>`;
+              s += `<text x="${xR + 9}" y="${yR + 3.5}" text-anchor="start" fill="currentColor" opacity="0.8" style="font-size:11px">${E(r.name)}</text>`;
+              s += `</g>`;
+            });
+            return s + "</svg>";
+          });
+        },
+
+        // Cross-dataset · mean xSIM by family on each dataset (the robustness gap).
+        get crossBarsSVG() {
+          return _cache("xbar", this.runs.length, () => {
+            const E = this._esc, rows = this._crossDip();
+            if (rows.length < 3) return "<svg></svg>";
+            const order = ["dl", "iter", "direct"];
+            const groups = order.map((f) => {
+              const g = rows.filter((r) => r.fam === f);
+              const mean = (k) => g.length ? g.reduce((a, r) => a + r[k], 0) / g.length : 0;
+              return { fam: f, n: g.length, si: mean("si"), iv: mean("iv") };
+            }).filter((g) => g.n);
+            const w = 640, h = 360, pl = 44, pr = 16, pt = 20, pb = 54, gw = (w - pl - pr) / groups.length;
+            const y1 = Math.min(1, Math.max(...groups.flatMap((g) => [g.si, g.iv])) + 0.08);
+            const SY = (v) => h - pb - v / (y1 || 1) * (h - pt - pb), base = h - pb;
+            let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+            s += `<line x1="${pl}" y1="${base}" x2="${w - 8}" y2="${base}" stroke="currentColor" opacity="0.2"/><line x1="${pl}" y1="${pt}" x2="${pl}" y2="${base}" stroke="currentColor" opacity="0.2"/>`;
+            for (let t = 0.2; t <= y1 + 1e-9; t += 0.2) s += `<text x="${pl - 6}" y="${SY(t) + 3}" text-anchor="end" fill="currentColor" opacity="0.5" style="font-size:10px">${t.toFixed(1)}</text>`;
+            s += `<text x="13" y="${(pt + base) / 2}" text-anchor="middle" fill="currentColor" opacity="0.55" style="font-size:11px;font-weight:600" transform="rotate(-90 13 ${(pt + base) / 2})">mean xSIM</text>`;
+            groups.forEach((g, i) => {
+              const cx = pl + gw * i + gw / 2, bw = Math.min(52, gw / 3), c = FAM[g.fam].c;
+              const bars = [["silico", g.si, 0.45], ["in-vivo", g.iv, 0.95]];
+              bars.forEach(([lab, v, op], j) => {
+                const x = cx - bw - 4 + j * (bw + 8), y = SY(v);
+                s += `<rect x="${x}" y="${y}" width="${bw}" height="${base - y}" rx="3" fill="${c}" opacity="${op}"><title>${E(FAM[g.fam].label)} · ${lab}: ${v.toFixed(2)}</title></rect>`;
+                s += `<text x="${x + bw / 2}" y="${y - 4}" text-anchor="middle" fill="currentColor" opacity="0.7" style="font-size:10px">${v.toFixed(2)}</text>`;
+                s += `<text x="${x + bw / 2}" y="${base + 14}" text-anchor="middle" fill="currentColor" opacity="0.5" style="font-size:9px">${lab}</text>`;
+              });
+              s += `<text x="${cx}" y="${base + 30}" text-anchor="middle" fill="currentColor" opacity="0.75" style="font-size:11px;font-weight:600">${E(FAM[g.fam].label)} (n=${g.n})</text>`;
+            });
+            return s + "</svg>";
+          });
+        },
+
         get familyLegend() {
           return Object.values(FAM).map((f) => `<span style="display:inline-flex;align-items:center;gap:5px;margin-right:14px;font-size:11px"><span style="width:9px;height:9px;border-radius:50%;background:${f.c};display:inline-block"></span>${f.label}</span>`).join("");
         },

--- a/web/results.html
+++ b/web/results.html
@@ -198,6 +198,10 @@
       <template x-if="(lbView==='pipelines'&&pipeView==='table')||lbView==='stages'">
         <div class="flex flex-wrap items-center gap-3">
           <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
+          <button @click="downloadCSV(csvRowsSim(), csvNameSim())" data-tip="Download every method and all fields (all metrics, runtime, peak memory, avg/peak CPU) as CSV" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            CSV
+          </button>
           <div class="relative" @click.outside="colMenu=false">
             <button @click="colMenu=!colMenu" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
               Metrics
@@ -600,6 +604,10 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <div class="mt-6 flex flex-wrap items-center gap-3">
         <div class="grow"></div>
         <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
+        <button @click="downloadCSV(csvRowsChisep(), 'qsm-ci_chi-separation.csv')" data-tip="Download every method and all fields (all metrics, runtime, peak memory, avg/peak CPU) as CSV" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          CSV
+        </button>
         <div class="relative" @click.outside="chisepColMenu=false">
           <button @click="chisepColMenu=!chisepColMenu" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
             Metrics
@@ -733,6 +741,10 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <div class="mt-6 flex flex-wrap items-center gap-3">
         <div class="grow"></div>
         <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
+        <button @click="downloadCSV(csvRowsInvivo(), 'qsm-ci_in-vivo-2016.csv')" data-tip="Download every method and all fields (all metrics vs COSMOS + STI, runtime, peak memory, avg/peak CPU) as CSV" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          CSV
+        </button>
       </div>
       <div class="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
         <div class="overflow-x-auto">
@@ -1041,6 +1053,43 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         stages() { return [...new Set(this.runs.filter((r) => r.mode === "isolated" && !this._isChisep(r) && !this._isInvivo(r)).map((r) => r.stage))]; },
         fmaps() { return [...new Set(this.runs.filter((r) => r.mode === "composed" && r.combo).map((r) => r.combo.field_mapping || "gt"))]; },
         hasTuned() { return this.runs.some((r) => r.variant === "tuned"); },
+        // ---- CSV export: dump a table's full rows with EVERY available field (all metrics + runtime,
+        // peak memory, avg/peak CPU), independent of which metric columns are ticked. --------------
+        _csvCell(v) {
+          if (v == null) return "";
+          const s = typeof v === "number" ? String(v) : String(v);
+          return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+        },
+        downloadCSV(rows, filename) {
+          rows = (rows || []).filter(Boolean);
+          if (!rows.length) return;
+          const ID = ["name", "slug", "stage", "mode", "variant", "track", "status", "id", "image"];
+          const RES = ["runtime_s", "mem_peak_bytes", "cpu_cores_avg", "cpu_cores_max"];
+          const hasCombo = rows.some((r) => r.combo);
+          const COMBO = hasCombo ? ["combo_field_mapping", "combo_bfr", "combo_dipole"] : [];
+          // union of every metric key present across the rows, so chi-sep (para_/dia_) and in-vivo
+          // (_sti) tables export their full metric set too.
+          const metricKeys = [], seen = new Set();
+          rows.forEach((r) => Object.keys(r.metrics || {}).forEach((k) => { if (!seen.has(k)) { seen.add(k); metricKeys.push(k); } }));
+          metricKeys.sort();
+          const cols = [...ID, ...COMBO, ...RES, ...metricKeys];
+          const cell = (r, c) =>
+            c === "combo_field_mapping" ? this._csvCell(r.combo && (r.combo.field_mapping || "gt"))
+            : c === "combo_bfr" ? this._csvCell(r.combo && r.combo.bfr)
+            : c === "combo_dipole" ? this._csvCell(r.combo && r.combo.dipole)
+            : (ID.includes(c) || RES.includes(c)) ? this._csvCell(r[c])
+            : this._csvCell((r.metrics || {})[c]);
+          const csv = [cols.join(","), ...rows.map((r) => cols.map((c) => cell(r, c)).join(","))].join("\n");
+          const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8" }));
+          const a = document.createElement("a");
+          a.href = url; a.download = filename; document.body.appendChild(a); a.click(); a.remove();
+          URL.revokeObjectURL(url);
+        },
+        // The full row set behind the in-silico leaderboard (ignores the text filter → a complete table).
+        csvRowsSim() { return this.baseRows; },
+        csvNameSim() { return this.view === "isolated" ? `qsm-ci_in-silico_${this.stage}.csv` : `qsm-ci_in-silico_pipelines_fmap-${this.fmap}.csv`; },
+        csvRowsChisep() { return this._chisep(); },
+        csvRowsInvivo() { const by = {}; this._invivo().filter((r) => r.mode === "isolated").forEach((r) => { by[r.slug] = r; }); return Object.values(by); },
         pickVariant(pool) {
           if (this.variant !== "tuned") return pool.filter((r) => (r.variant || "default") === "default");
           const by = {};

--- a/web/results.html
+++ b/web/results.html
@@ -376,7 +376,7 @@
         <button class="subtab" :class="{'subtab-on': findView==='speed'}" @click="findView='speed'">Cost &amp; tuning</button>
         <button class="subtab" :class="{'subtab-on': findView==='explore'}" @click="findView='explore'">Explore</button>
       </div>
-      <p class="mt-5 max-w-3xl text-gray-600 dark:text-gray-400 leading-relaxed">
+      <p class="mt-5 text-gray-600 dark:text-gray-400 leading-relaxed">
         Patterns the leaderboard tables don't surface, computed live from the same results. The recurring
         lesson: a method's standing depends heavily on <em>what</em> you score, and on the pipeline it sits
         in, not just on a single number.
@@ -822,24 +822,24 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
 
     <!-- ===================== CROSS-DATASET ===================== -->
     <section x-show="dataset==='cross'" x-cloak class="mt-3">
-      <div class="mt-6 space-y-8">
+      <div class="mt-6">
         <div>
           <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Dipole inversion across datasets</h2>
-          <p class="mt-2 max-w-3xl text-gray-600 dark:text-gray-400 leading-relaxed">The same isolated dipole-inversion methods, scored on the in-silico phantom (2019, true χ) and the in-vivo challenge (2016, COSMOS reference). Does a ranking on the idealised phantom carry over to real acquired data?</p>
+          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">The same isolated dipole-inversion methods, scored on the in-silico phantom (2019, true χ) and the in-vivo challenge (2016, COSMOS reference). Does a ranking on the idealised phantom carry over to real acquired data?</p>
         </div>
-        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
           <h3 class="text-lg font-semibold text-gray-900">Phantom rank does not predict in-vivo rank</h3>
           <p class="mt-2 text-sm text-gray-600 leading-relaxed">Each method's xSIM on the in-silico phantom (x) against its xSIM in vivo (y), coloured by family. The two are essentially uncorrelated: classical iterative and direct methods that win on the clean phantom collapse in vivo, while deep-learning methods hold up. Hover for values; click to open a method.</p>
           <div class="mt-2" x-html="familyLegend"></div>
           <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossScatterSVG"></div>
         </div>
-        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
           <h3 class="text-lg font-semibold text-gray-900">How methods move between datasets</h3>
           <p class="mt-2 text-sm text-gray-600 leading-relaxed">Each method's rank on the in-silico phantom (left) linked to its rank in vivo (right), by xSIM. Lines coloured by family: deep-learning methods tend to climb left-to-right; classical methods fall.</p>
           <div class="mt-2" x-html="familyLegend"></div>
           <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBumpSVG"></div>
         </div>
-        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
           <h3 class="text-lg font-semibold text-gray-900">Domain robustness by family</h3>
           <p class="mt-2 text-sm text-gray-600 leading-relaxed">Mean xSIM per method family on each dataset. Deep-learning methods barely drop from phantom to in-vivo; classical iterative and direct methods lose far more — tuned to the idealised phantom, they generalise worse to real 3 T data.</p>
           <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBarsSVG"></div>

--- a/web/results.html
+++ b/web/results.html
@@ -328,7 +328,8 @@
           <table class="w-full text-sm whitespace-nowrap">
             <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
               <tr>
-                <th class="px-5 py-3 text-left font-medium sticky left-0 bg-gray-50" x-text="view==='composed' ? 'Pipeline' : 'Algorithm'"></th>
+                <th class="px-4 py-3 text-right font-medium sticky left-0 bg-gray-50" style="min-width:3rem">#</th>
+                <th class="px-5 py-3 text-left font-medium sticky bg-gray-50" style="left:3rem" x-text="view==='composed' ? 'Pipeline' : 'Algorithm'"></th>
                 <template x-for="c in displayCols" :key="c">
                   <th @click="sort(c)" class="px-4 py-3 text-right font-medium cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100">
                     <span x-text="METRICS[c].label" :data-tip="METRICS[c].desc"></span>
@@ -340,7 +341,8 @@
             <tbody class="divide-y divide-gray-100">
               <template x-for="(r, i) in rows" :key="r.id">
                 <tr @click="go(r)" class="group cursor-pointer" :class="(r.status==='DNF' ? 'opacity-50 ' : '') + (r.variant==='tuned' ? 'tuned-row' : '')">
-                  <td class="px-5 py-3 text-left font-medium text-gray-900 sticky left-0 bg-white group-hover:bg-emerald-50/40">
+                  <td class="px-4 py-3 text-right tabular-nums text-gray-400 sticky left-0 bg-white group-hover:bg-emerald-50/40" style="min-width:3rem" x-text="i+1"></td>
+                  <td class="px-5 py-3 text-left font-medium text-gray-900 sticky bg-white group-hover:bg-emerald-50/40" style="left:3rem">
                     <span class="mr-1.5 inline-block w-5 text-center" x-text="medal(i)"></span>
                     <span x-text="r.name"></span>
                     <template x-if="doi(r)">
@@ -631,7 +633,8 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         <table class="w-full text-sm whitespace-nowrap">
           <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
             <tr>
-              <th class="px-5 py-3 text-left font-medium sticky left-0 bg-gray-50">Algorithm</th>
+              <th class="px-4 py-3 text-right font-medium sticky left-0 bg-gray-50" style="min-width:3rem">#</th>
+              <th class="px-5 py-3 text-left font-medium sticky bg-gray-50" style="left:3rem">Algorithm</th>
               <template x-for="c in chisepDisplayCols()" :key="c.key">
                 <th @click="chiSepSort(c.key)" class="px-4 py-3 text-right font-medium cursor-pointer select-none hover:text-gray-800 dark:hover:text-gray-100">
                   <span class="has-tip" :data-tip="c.tip" x-text="c.label"></span>
@@ -643,7 +646,8 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           <tbody class="divide-y divide-gray-100">
             <template x-for="(r,i) in chiSepRows()" :key="r.id">
               <tr @click="go(r)" class="group cursor-pointer" :class="r.status==='DNF' ? 'opacity-50' : ''">
-                <td class="px-5 py-3 text-left font-medium text-gray-900 sticky left-0 bg-white group-hover:bg-emerald-50/40">
+                <td class="px-4 py-3 text-right tabular-nums text-gray-400 sticky left-0 bg-white group-hover:bg-emerald-50/40" style="min-width:3rem" x-text="i+1"></td>
+                <td class="px-5 py-3 text-left font-medium text-gray-900 sticky bg-white group-hover:bg-emerald-50/40" style="left:3rem">
                   <span class="mr-1.5 inline-block w-5 text-center" x-text="medal(i)"></span>
                   <span x-text="r.name"></span>
                   <template x-if="r.doi"><a :href="'https://doi.org/'+r.doi" @click.stop target="_blank" rel="noopener" class="ml-2 rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-700 hover:bg-emerald-100">paper</a></template>
@@ -752,7 +756,8 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
             <thead class="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
               <!-- grouped reference header -->
               <tr>
-                <th class="px-5 py-2 text-left font-medium sticky left-0 bg-gray-50" rowspan="2">Algorithm</th>
+                <th class="px-4 py-2 text-right font-medium sticky left-0 bg-gray-50" style="min-width:3rem" rowspan="2">#</th>
+                <th class="px-5 py-2 text-left font-medium sticky bg-gray-50" style="left:3rem" rowspan="2">Algorithm</th>
                 <th class="px-4 py-2 text-center font-semibold border-l border-gray-200" :colspan="INVIVO_COLS.filter(c=>c.grp==='cosmos').length">vs COSMOS</th>
                 <th class="px-4 py-2 text-center font-semibold border-l border-gray-200" :colspan="INVIVO_COLS.filter(c=>c.grp==='sti').length">vs STI χ33</th>
                 <th class="px-4 py-2 text-center font-semibold border-l border-gray-200" rowspan="2">Runtime</th>
@@ -770,7 +775,8 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
             <tbody class="divide-y divide-gray-100">
               <template x-for="(r,i) in invivoRows()" :key="r.id">
                 <tr @click="go(r)" class="group cursor-pointer" :class="r.status==='DNF' ? 'opacity-50' : ''">
-                  <td class="px-5 py-3 text-left font-medium text-gray-900 sticky left-0 bg-white group-hover:bg-emerald-50/40">
+                  <td class="px-4 py-3 text-right tabular-nums text-gray-400 sticky left-0 bg-white group-hover:bg-emerald-50/40" style="min-width:3rem" x-text="i+1"></td>
+                  <td class="px-5 py-3 text-left font-medium text-gray-900 sticky bg-white group-hover:bg-emerald-50/40" style="left:3rem">
                     <span class="mr-1.5 inline-block w-5 text-center" x-text="invMedal(i)"></span>
                     <span x-text="r.name"></span>
                     <span x-show="r.status==='DNF'" class="ml-2 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500">DNF</span>

--- a/web/results.html
+++ b/web/results.html
@@ -588,6 +588,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <div class="rtabs">
         <button class="rtab" :class="{'rtab-on': chisepView==='info'}" @click="chisepView='info'">Info</button>
         <button class="rtab" :class="{'rtab-on': chisepView==='board'}" @click="chisepView='board'">Leaderboard</button>
+        <button class="rtab" :class="{'rtab-on': chisepView==='findings'}" @click="chisepView='findings'">Findings</button>
       </div>
 
       <div x-show="chisepView==='board'" x-cloak>
@@ -649,7 +650,10 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         <p x-show="chiSepRows().length===0" class="px-5 py-10 text-center text-gray-400">No chi-separation results yet.</p>
       </div>
 
-      <!-- chi-sep figures -->
+      </div><!-- /chisep board -->
+
+      <!-- χ-separation · Findings (figures split out of the Leaderboard, mirroring the in-silico dataset) -->
+      <div x-show="chisepView==='findings'" x-cloak>
       <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
         <h3 class="font-semibold text-gray-900">Myelin (χ−) is harder to recover than iron (χ+)</h3>
         <p class="mt-0.5 max-w-2xl text-xs text-gray-500">Structural similarity (xSIM) of the recovered paramagnetic χ+ (iron) source versus the diamagnetic χ− (myelin / calcium) source. Every method drops from left to right, so the diamagnetic map is systematically the harder of the two.</p>
@@ -661,7 +665,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         <p class="mt-0.5 max-w-2xl text-xs text-gray-500">How much each source map bleeds into the other (regression slope, 0 = clean): iron leaking into the myelin map (x) versus myelin leaking into iron (y). The origin is perfect separation; distance from it is contamination that xSIM can miss.</p>
         <div class="mt-4 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="leakSVG"></div>
       </div>
-      </div><!-- /chisep board -->
+      </div><!-- /chisep findings -->
 
       <!-- χ-separation · Info -->
       <div x-show="chisepView==='info'" x-cloak class="info mt-6 space-y-8">

--- a/web/submission.html
+++ b/web/submission.html
@@ -61,11 +61,13 @@
       <aside class="lg:sticky lg:top-20 self-start">
         <div class="rounded-2xl border border-gray-200 bg-white shadow-sm overflow-hidden dark:border-gray-800 dark:bg-gray-900">
           <div class="p-3 border-b border-gray-100 space-y-2 dark:border-gray-800">
-            <!-- domain: QSM pipeline vs χ-separation. The χ-separation button is revealed only when
-                 chi-sep methods exist, so the sidebar isn't cluttered with the wrong category. -->
-            <div id="domain-toggle" class="inline-flex w-full rounded-lg bg-gray-100 p-1 text-xs font-medium dark:bg-gray-800">
-              <button data-domain="qsm" class="flex-1 rounded-md px-2 py-1 transition">QSM</button>
+            <!-- dataset / domain: the in-silico (2019) QSM phantom, χ-separation, or the in-vivo (2016)
+                 challenge. The χ-separation and In-vivo buttons are revealed only when such runs exist,
+                 so the sidebar isn't cluttered with an empty category. -->
+            <div id="domain-toggle" class="inline-flex w-full rounded-lg bg-gray-100 p-1 text-[11px] font-medium dark:bg-gray-800">
+              <button data-domain="qsm" class="flex-1 rounded-md px-2 py-1 transition">In silico (2019)</button>
               <button data-domain="chisep" class="flex-1 rounded-md px-2 py-1 transition hidden">χ-separation</button>
+              <button data-domain="invivo" class="flex-1 rounded-md px-2 py-1 transition hidden">In vivo (2016)</button>
             </div>
             <div id="nav-toggle" class="inline-flex w-full rounded-lg bg-gray-100 p-1 text-xs font-medium dark:bg-gray-800">
               <button data-mode="stages" class="flex-1 rounded-md px-2 py-1 transition">Stages</button>

--- a/web/submission.html
+++ b/web/submission.html
@@ -65,9 +65,9 @@
                  challenge. The χ-separation and In-vivo buttons are revealed only when such runs exist,
                  so the sidebar isn't cluttered with an empty category. -->
             <div id="domain-toggle" class="inline-flex w-full rounded-lg bg-gray-100 p-1 text-[11px] font-medium dark:bg-gray-800">
-              <button data-domain="qsm" class="flex-1 rounded-md px-2 py-1 transition">In silico (2019)</button>
-              <button data-domain="chisep" class="flex-1 rounded-md px-2 py-1 transition hidden">χ-separation</button>
               <button data-domain="invivo" class="flex-1 rounded-md px-2 py-1 transition hidden">In vivo (2016)</button>
+              <button data-domain="qsm" class="flex-1 rounded-md px-2 py-1 transition">In silico (2019)</button>
+              <button data-domain="chisep" class="flex-1 rounded-md px-2 py-1 transition hidden">χ-sep (2026)</button>
             </div>
             <div id="nav-toggle" class="inline-flex w-full rounded-lg bg-gray-100 p-1 text-xs font-medium dark:bg-gray-800">
               <button data-mode="stages" class="flex-1 rounded-md px-2 py-1 transition">Stages</button>
@@ -91,6 +91,10 @@
         </div>
 
         <div id="how-to-run" class="mt-6 hidden rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900"></div>
+
+        <!-- Dataset switch for a dipole method scored on more than one dataset (In vivo 2016 /
+             In silico 2019): keep the same algorithm open, swap the dataset. Populated by viewer.js. -->
+        <div id="dataset-switch" class="mt-6 hidden"></div>
 
         <div class="mt-6 grid xl:grid-cols-5 gap-6">
           <section class="xl:col-span-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">

--- a/web/submit.html
+++ b/web/submit.html
@@ -62,6 +62,7 @@ qsm-ci doctor            # checks you have what you need (Docker, etc.)</code></
             <tr><td class="px-4 py-2 font-medium">Field mapping</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">phase &amp; magnitude images</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">total field</td></tr>
             <tr><td class="px-4 py-2 font-medium">Background field removal</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">total field</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">local (tissue) field</td></tr>
             <tr><td class="px-4 py-2 font-medium">Dipole inversion</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">local field</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">susceptibility map (χ)</td></tr>
+            <tr><td class="px-4 py-2 font-medium">χ-separation</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">local field, R2′, χ map (&amp; magnitude)</td><td class="px-4 py-2 text-gray-600 dark:text-gray-400">χ+ (paramagnetic) &amp; χ− (diamagnetic) source maps</td></tr>
           </tbody>
         </table>
       </div>
@@ -89,7 +90,6 @@ qsm-ci doctor            # checks you have what you need (Docker, etc.)</code></
                 <tr><td class="px-3 py-1.5 font-mono">unwrap+bfr</td><td class="px-3 py-1.5">phase, magnitude</td><td class="px-3 py-1.5">local field</td></tr>
                 <tr><td class="px-3 py-1.5 font-mono">bfr+dipole</td><td class="px-3 py-1.5">total field</td><td class="px-3 py-1.5">susceptibility (χ)</td></tr>
                 <tr><td class="px-3 py-1.5 font-mono">end-to-end</td><td class="px-3 py-1.5">phase, magnitude</td><td class="px-3 py-1.5">susceptibility (χ)</td></tr>
-                <tr><td class="px-3 py-1.5 font-mono">chi-separation</td><td class="px-3 py-1.5">local field, R2′, χ_total, magnitude</td><td class="px-3 py-1.5">χ+ (paramagnetic) &amp; χ− (diamagnetic)</td></tr>
               </tbody>
             </table>
           </div>
@@ -262,10 +262,6 @@ RUN chmod +x /opt/qsm-ci/recon
       </p>
     </section>
 
-    <p class="mt-10 text-sm text-gray-500 dark:text-gray-500">
-      Want the nitty-gritty? The tool, the reference methods, and the full technical spec live in the
-      <a href="https://github.com/QSMxT/QSM-CI" class="text-emerald-600 hover:underline">QSM-CI repository</a>.
-    </p>
   </main>
 
   <footer id="site-footer"></footer>


### PR DESCRIPTION
## What

Gives the per-run **submission page** the dataset dimension that `results.html` has, and lets you move a single method between datasets.

## Changes

- **Dataset selector** in the sidebar: **In vivo (2016) · In silico (2019) · χ-sep (2026)** (χ-sep and In-vivo appear only when such runs exist). In-vivo runs get their own flat dipole list and are removed from the in-silico stages list (no more duplicate "TKD" entries).
- **Dataset badge** on the detail header (amber for in-vivo) + a *"2016 challenge · scored vs COSMOS + STI χ33"* meta note.
- **In-page DATASET toggle** above the viewer/metrics, shown only for a dipole method scored on more than one dataset — switches **2016 ⇄ 2019** keeping the same method open.
- **Carry-across switching**: flipping the dataset (sidebar toggle *or* in-page toggle) re-selects the same method's run on the target dataset (e.g. HD-QSM stays open when you go 2019 → 2016), via `dipoleRunOn` + `selectRun`. Falls back to just browsing the target list when the method has no run there (e.g. a BFR method → In vivo).
- Opening a run / deep-linking `?run=<id>` auto-selects its dataset view.

Touches only `submission.html` and `web/js/viewer.js` — no data changes. Reuses colour classes already in the compiled Tailwind build (amber badge verified in light + dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)