### PR TITLE
feat(tuning): per-dataset tuned params + in-vivo/chi-sep leaderboard toggles

### DIFF
--- a/results/index.json
+++ b/results/index.json
@@ -36159,44 +36159,6 @@
       "cpu_cores_max": 1.872
     },
     {
-      "name": "NLTV",
-      "track": "invivo",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 179.54660367965698,
-      "metrics": {
-        "nrmse": 166.26611052993294,
-        "nrmse_detrend": 140.5919943056924,
-        "hfen": 171.93545409208812,
-        "correlation": 0.5796141337868371,
-        "xsim": 0.1622164692272193,
-        "nrmse_sti": 190.35840916650648,
-        "nrmse_detrend_sti": 188.26761708299188,
-        "hfen_sti": 198.00975451930688,
-        "correlation_sti": 0.4690924039301834,
-        "xsim_sti": 0.10627040055461338
-      },
-      "status": "ok",
-      "id": "nltv-iso-tuned-invivo",
-      "slug": "nltv",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "lambda": "3e-3"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__error.nii.gz"
-      },
-      "mem_peak_bytes": 532152320,
-      "cpu_cores_avg": 1.6048,
-      "cpu_cores_max": 1.7593
-    },
-    {
       "name": "QSMGAN",
       "track": "invivo",
       "stage": "dipole",
@@ -36369,41 +36331,6 @@
       }
     },
     {
-      "name": "Tikhonov",
-      "track": "invivo",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 3.862429618835449,
-      "metrics": {
-        "nrmse": 104.2618978448372,
-        "nrmse_detrend": 103.15811926514573,
-        "hfen": 91.56635409098125,
-        "correlation": 0.6960306215445874,
-        "xsim": 0.3276035651416914,
-        "nrmse_sti": 127.98814338375313,
-        "nrmse_detrend_sti": 146.24138258451546,
-        "hfen_sti": 116.85464024727685,
-        "correlation_sti": 0.5644536231765737,
-        "xsim_sti": 0.2072242214867708
-      },
-      "status": "ok",
-      "id": "tikhonov-iso-tuned-invivo",
-      "slug": "tikhonov",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "lambda": "3e-3"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__error.nii.gz"
-      }
-    },
-    {
       "name": "TKD",
       "track": "invivo",
       "stage": "dipole",
@@ -36468,41 +36395,6 @@
       }
     },
     {
-      "name": "TSVD",
-      "track": "invivo",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 4.681064605712891,
-      "metrics": {
-        "nrmse": 123.75711704031987,
-        "nrmse_detrend": 112.7898918910182,
-        "hfen": 107.59042301652867,
-        "correlation": 0.6634083446643043,
-        "xsim": 0.2623189590200129,
-        "nrmse_sti": 148.30438214882804,
-        "nrmse_detrend_sti": 158.45543274141608,
-        "hfen_sti": 133.73305683092414,
-        "correlation_sti": 0.533698751914367,
-        "xsim_sti": 0.1637208824426778
-      },
-      "status": "ok",
-      "id": "tsvd-iso-tuned-invivo",
-      "slug": "tsvd",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "threshold": "0.05"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__error.nii.gz"
-      }
-    },
-    {
       "name": "TV (ADMM)",
       "track": "invivo",
       "stage": "dipole",
@@ -36536,44 +36428,6 @@
       "mem_peak_bytes": 499122176,
       "cpu_cores_avg": 1.5463,
       "cpu_cores_max": 1.6439
-    },
-    {
-      "name": "TV (ADMM)",
-      "track": "invivo",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 17.428093194961548,
-      "metrics": {
-        "nrmse": 136.3984018305043,
-        "nrmse_detrend": 118.87546655024055,
-        "hfen": 138.24915767868947,
-        "correlation": 0.6437377115254427,
-        "xsim": 0.23130026933096273,
-        "nrmse_sti": 160.2600581227414,
-        "nrmse_detrend_sti": 161.97163845991108,
-        "hfen_sti": 163.75690410147533,
-        "correlation_sti": 0.525335797808969,
-        "xsim_sti": 0.15244439757978653
-      },
-      "status": "ok",
-      "id": "tv-iso-tuned-invivo",
-      "slug": "tv",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "lambda": "3e-5"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tv-iso-tuned-invivo__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tv-iso-tuned-invivo__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tv-iso-tuned-invivo__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tv-iso-tuned-invivo__error.nii.gz"
-      },
-      "mem_peak_bytes": 499331891,
-      "cpu_cores_avg": 1.6794,
-      "cpu_cores_max": 1.8286
     },
     {
       "name": "WH-QSM",

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -209,13 +209,17 @@ def _yaml_scalar(v) -> str:
     return str(v)
 
 
-def _tuned_overrides(doc: dict) -> dict:
-    """Extract `{param: tuned_value}` from a parsed algorithm.yml `parameters:` block — the settings
-    we optimised on the scoring phantom (each parameter may carry a `tuned:` alongside its
-    `default:`). Values are returned as strings to match the old regex parser (they flow into
-    `overrides` -> config.json / `--set`, which expect the raw token). YAML handles the unindented
-    list items (`- name:` at column 0, as the MATLAB ymls write them) that the old regex needed a
-    special workaround for."""
+def _tuned_overrides(doc: dict, dataset: str = "sim") -> dict:
+    """Extract `{param: tuned_value}` for a dataset (`sim` / `invivo` / `chisep`) from a parsed
+    algorithm.yml `parameters:` block — the settings optimised on that dataset (each parameter may
+    carry a `tuned:` alongside its `default:`). `tuned` is either a per-dataset MAP
+    (`tuned: {sim: .., invivo: .., chisep: ..}`) or a legacy SCALAR (which applies to the in-silico/sim
+    dataset only). So sim keeps reading the existing scalar tunings, and a method only gets an
+    in-vivo / chi-sep tuned variant once it declares `tuned.invivo` / `tuned.chisep`.
+
+    Values are returned as strings (they flow into `overrides` -> config.json / `--set`, which expect
+    the raw token). YAML handles the unindented list items (`- name:` at column 0, as the MATLAB ymls
+    write them) that the old regex needed a special workaround for."""
     params = doc.get("parameters")
     if not isinstance(params, list):
         return {}
@@ -223,11 +227,18 @@ def _tuned_overrides(doc: dict) -> dict:
     for item in params:
         if not isinstance(item, dict) or "name" not in item or "tuned" not in item:
             continue
-        out[_yaml_scalar(item["name"])] = _yaml_scalar(item["tuned"])
+        t = item["tuned"]
+        val = t.get(dataset) if isinstance(t, dict) else (t if dataset == "sim" else None)
+        if val is None:
+            continue
+        out[_yaml_scalar(item["name"])] = _yaml_scalar(val)
     return out
 
 
-def discover_algorithms() -> list[dict]:
+def discover_algorithms(track: str = "sim") -> list[dict]:
+    # `track` selects which dataset's tuned params each method carries: a chi-separation method is only
+    # ever scored on the chisep dataset (→ "chisep"), otherwise the in-vivo run uses "invivo" and
+    # everything else "sim". So the tuned variant a run expands is the one optimised on ITS dataset.
     algos = []
     # QSMCI_ALGORITHMS_DIR lets a harness test point discovery at a fixture method set (tests/methods)
     # instead of the real algorithms/ tree — so the orchestration (discover -> isolated/composed ->
@@ -266,7 +277,8 @@ def discover_algorithms() -> list[dict]:
             "name": _yaml_scalar(doc.get("name")) if doc.get("name") is not None else d.name,
             "image": _yaml_scalar(image) if image is not None else None,
             "consumes": consumes, "produces": STAGES[s]["produces"],
-            "tuned": _tuned_overrides(doc),
+            "tuned": _tuned_overrides(doc, "chisep" if s == "chi-separation"
+                                      else ("invivo" if track == "invivo" else "sim")),
             # Optional per-method smoke-crop size (voxels): a slow per-voxel method (e.g. DECOMPOSE)
             # can shrink the --smoke gate's central box so the PR check stays fast; None = CLI default.
             "smoke_box": doc.get("smoke_box"),
@@ -937,7 +949,7 @@ def main() -> None:
     mask, params = inputs / "mask.nii.gz", inputs / "params.json"
     # GT-backed source map: inputs for raw artifacts, groundtruth for stage boundaries (shared helper).
     gt_sources = _gt_sources(args.dataset)
-    algos = discover_algorithms()
+    algos = discover_algorithms(args.track)
     if args.include:
         keep = set(args.include.split(","))
         algos = [a for a in algos if a["slug"] in keep]

--- a/web/results.html
+++ b/web/results.html
@@ -651,7 +651,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           </thead>
           <tbody class="divide-y divide-gray-100">
             <template x-for="(r,i) in chiSepRows()" :key="r.id">
-              <tr @click="go(r)" class="group cursor-pointer" :class="r.status==='DNF' ? 'opacity-50' : ''">
+              <tr @click="go(r)" class="group cursor-pointer" :class="(r.status==='DNF' ? 'opacity-50 ' : '') + (r.variant==='tuned' ? 'tuned-row' : '')">
                 <td class="px-4 py-3 text-right tabular-nums text-gray-400 sticky left-0 bg-white group-hover:bg-emerald-50/40" style="min-width:3rem" x-text="i+1"></td>
                 <td class="px-5 py-3 text-left font-medium text-gray-900 sticky bg-white group-hover:bg-emerald-50/40" style="left:3rem">
                   <span class="mr-1.5 inline-block w-5 text-center" x-text="medal(i)"></span>
@@ -786,7 +786,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
             </thead>
             <tbody class="divide-y divide-gray-100">
               <template x-for="(r,i) in invivoRows()" :key="r.id">
-                <tr @click="go(r)" class="group cursor-pointer" :class="r.status==='DNF' ? 'opacity-50' : ''">
+                <tr @click="go(r)" class="group cursor-pointer" :class="(r.status==='DNF' ? 'opacity-50 ' : '') + (r.variant==='tuned' ? 'tuned-row' : '')">
                   <td class="px-4 py-3 text-right tabular-nums text-gray-400 sticky left-0 bg-white group-hover:bg-emerald-50/40" style="min-width:3rem" x-text="i+1"></td>
                   <td class="px-5 py-3 text-left font-medium text-gray-900 sticky bg-white group-hover:bg-emerald-50/40" style="left:3rem">
                     <span class="mr-1.5 inline-block w-5 text-center" x-text="invMedal(i)"></span>

--- a/web/results.html
+++ b/web/results.html
@@ -604,6 +604,12 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
 
       <!-- table controls (filter + metric columns) -->
       <div class="mt-6 flex flex-wrap items-center gap-3">
+        <template x-if="hasChisepTuned()">
+          <span class="seg">
+            <button class="seg-btn" :class="{'seg-on': variant==='default'}" @click="variant='default'">Defaults</button>
+            <button class="seg-btn" :class="{'seg-on': variant==='tuned', 'seg-on-emerald': variant==='tuned'}" @click="variant='tuned'" data-tip="Each χ-separation method's parameters optimised on the χ-separation phantom, maximising source-separation xSIM.">⚙ Tuned</button>
+          </span>
+        </template>
         <div class="grow"></div>
         <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
         <button @click="downloadCSV(csvRowsChisep(), 'qsm-ci_chi-separation.csv')" data-tip="Download every method and all fields (all metrics, runtime, peak memory, avg/peak CPU) as CSV" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
@@ -743,6 +749,12 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
 
       <!-- table -->
       <div class="mt-6 flex flex-wrap items-center gap-3">
+        <template x-if="hasInvivoTuned()">
+          <span class="seg">
+            <button class="seg-btn" :class="{'seg-on': variant==='default'}" @click="variant='default'">Defaults</button>
+            <button class="seg-btn" :class="{'seg-on': variant==='tuned', 'seg-on-emerald': variant==='tuned'}" @click="variant='tuned'" data-tip="Each dipole method's parameters optimised on the in-vivo (2016) data (COSMOS reference), maximising xSIM. Only some methods are tunable, so Defaults is the fair cross-method ranking.">⚙ Tuned</button>
+          </span>
+        </template>
         <div class="grow"></div>
         <input x-model="filter" type="search" placeholder="Filter…" class="rounded-lg border-gray-300 text-sm px-3 py-1.5 w-44 focus:border-emerald-500 focus:ring-emerald-500" />
         <button @click="downloadCSV(csvRowsInvivo(), 'qsm-ci_in-vivo-2016.csv')" data-tip="Download every method and all fields (all metrics vs COSMOS + STI, runtime, peak memory, avg/peak CPU) as CSV" class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-gray-600 ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
@@ -1023,7 +1035,8 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         },
         chiSepRows() {
           const k = this.chisepSort, dir = this.chisepDir === "asc" ? 1 : -1, f = this.filter.toLowerCase();
-          return this._chisep().filter((r) => !f || r.name.toLowerCase().includes(f)).slice().sort((a, b) => {
+          // one row per method; the Defaults/Tuned toggle (variant) picks default or the chisep-tuned run.
+          return this.pickVariant(this._chisep()).filter((r) => !f || r.name.toLowerCase().includes(f)).slice().sort((a, b) => {
             const va = this.chiVal(a, k), vb = this.chiVal(b, k);
             if (va == null) return 1; if (vb == null) return -1;
             return (va - vb) * dir;
@@ -1032,10 +1045,9 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         // ---- in-vivo (2016 challenge) dipole leaderboard --------------------------------
         invivoRows() {
           const k = this.invivoSortKey, dir = this.invivoDir === "asc" ? 1 : -1, f = this.filter.toLowerCase();
-          // one row per method (default variant only), most recent scoring wins on id collision
-          const by = {};
-          this._invivo().filter((r) => r.mode === "isolated").forEach((r) => { by[r.slug] = r; });
-          return Object.values(by).filter((r) => !f || (r.name || r.slug).toLowerCase().includes(f))
+          // one row per method; the Defaults/Tuned toggle (variant) picks default or the in-vivo-tuned run.
+          return this.pickVariant(this._invivo().filter((r) => r.mode === "isolated"))
+            .filter((r) => !f || (r.name || r.slug).toLowerCase().includes(f))
             .sort((a, b) => {
               const va = val(a, k), vb = val(b, k);
               if (va == null) return 1; if (vb == null) return -1;
@@ -1058,7 +1070,9 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         doi(r) { return this.view === "isolated" ? doiFor(this.registry, r.slug) : null; },
         stages() { return [...new Set(this.runs.filter((r) => r.mode === "isolated" && !this._isChisep(r) && !this._isInvivo(r)).map((r) => r.stage))]; },
         fmaps() { return [...new Set(this.runs.filter((r) => r.mode === "composed" && r.combo).map((r) => r.combo.field_mapping || "gt"))]; },
-        hasTuned() { return this.runs.some((r) => r.variant === "tuned"); },
+        hasTuned() { return this.runs.some((r) => r.variant === "tuned" && !this._isInvivo(r) && !this._isChisep(r)); },
+        hasInvivoTuned() { return this.runs.some((r) => this._isInvivo(r) && r.variant === "tuned"); },
+        hasChisepTuned() { return this.runs.some((r) => this._isChisep(r) && r.variant === "tuned"); },
         // ---- CSV export: dump a table's full rows with EVERY available field (all metrics + runtime,
         // peak memory, avg/peak CPU), independent of which metric columns are ticked. --------------
         _csvCell(v) {


### PR DESCRIPTION
Wires **per-dataset parameter tuning** across all three datasets (in-silico / in-vivo / chi-separation).

### Pipeline
`_tuned_overrides` resolves a parameter's tuned value **per dataset**. A param's `tuned` may be:
- a per-dataset map: `tuned: { sim: .., invivo: .., chisep: .. }`, or
- a legacy scalar (applies to **in-silico** only, so existing tunings are unchanged).

`discover_algorithms(track)` derives each method's dataset key — a χ-sep method → `chisep`, an in-vivo run → `invivo`, else `sim` — so a run only expands the tuned variant **optimised on its own dataset**. This fixes the prior behaviour where a scalar (sim) tuning was wrongly re-run as the "tuned" variant on in-vivo (the 4 stale `*-iso-tuned-invivo` rows currently in the index came from that; a rescore clears them and the sweep fills in real per-dataset tunings).

### Web
- **In-vivo** and **χ-separation** leaderboards get the **Defaults / ⚙ Tuned** toggle (shown only when that dataset actually has tuned runs), with `pickVariant`-based rows.
- `hasTuned()` is now sim-specific, so the in-silico toggle isn't triggered by in-vivo/chi-sep tuned runs.
- χ-sep has no tunable methods today, but the toggle + variant machinery is ready for when one lands.

Pairs with #129 (the per-dataset **tuned param columns** on the submission page). Verified: in-vivo toggle renders and rows switch; `discover_algorithms` returns sim `{lambda:3e-5}` for tv but `{}` on in-vivo/chisep; harness smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)