### PR TITLE
Expose χ-separation parameters, sweep support, and tuned-vs-untuned findings figures

### DIFF
--- a/algorithms/chi-sep-ilsqr/algorithm.yml
+++ b/algorithms/chi-sep-ilsqr/algorithm.yml
@@ -25,6 +25,14 @@ run: bash run.sh
 matlab:
   entry: recon.m
   runtime: r2026a
+parameters:
+  - name: pad_size
+    default: 12
+    description: >
+      Zero-padding (voxels, applied on each axis as [pad pad pad]) for the in-house STI-Suite QSM_iLSQR
+      step that reconstructs the QSM fed to chi_sep_iLSQR. Larger padding reduces dipole-inversion
+      boundary/wrap artifacts at higher memory/runtime. (chi_sep_iLSQR's own internals are a black-box
+      .p toolbox and expose no further knobs here; the Bunya diagnostic found N_std/CSF had no effect.)
 # Inputs consumed (isolated eval): local field + R2' + mask + magnitude. The QSM is reconstructed
 # in-house (STI-Suite QSM_iLSQR); chimap.nii.gz is intentionally NOT used (see recon.m note).
 # Produces two source maps: chi-para (χ+) and chi-dia (χ−).

--- a/algorithms/chi-sep-ilsqr/recon.m
+++ b/algorithms/chi-sep-ilsqr/recon.m
@@ -30,10 +30,15 @@ function recon(inp, out)
     local_field_hz = localfield * 1e-6 * CF;        % ppm -> Hz (chi_sep_iLSQR expects Hz)
     params.b0_dir = b0d; params.CF = CF; params.voxel_size = vox;
 
+    % Parameter overrides (qsm-ci run --set NAME=VALUE) arrive as /input/config.json (absent otherwise).
+    cfg = struct();
+    if isfile(fullfile(inp, 'config.json')); cfg = jsondecode(fileread(fullfile(inp, 'config.json'))); end
+    if isfield(cfg, 'pad_size'); ps = cfg.pad_size; else; ps = 12; end
+
     % --- reconstruct the QSM in-house with STI-Suite QSM_iLSQR (see note above) ---
     tissue_phase = local_field_hz * 2*pi * dTE;     % Hz -> radian tissue phase over one echo spacing
     qsm = QSM_iLSQR(tissue_phase, mask, 'TE', dTE*1e3, 'B0', B0, 'H', b0d, ...
-                    'padsize', [12 12 12], 'voxelsize', vox);
+                    'padsize', [ps ps ps], 'voxelsize', vox);
 
     % noise weighting from magnitude (~1 in tissue, higher where signal is low); CSF from mask edge is
     % not available in isolated eval, so N_std alone. (CSF mask + N_std had no measurable effect vs the

--- a/algorithms/chi-sep-medi/algorithm.yml
+++ b/algorithms/chi-sep-medi/algorithm.yml
@@ -22,6 +22,13 @@ run: bash run.sh
 matlab:
   entry: recon.m
   runtime: r2026a
+parameters:
+  - name: lambda
+    default: 1
+    description: >
+      MEDI data-fidelity / morphology regularisation weight passed to chi_sep_MEDI (params.lambda) —
+      the method's primary regularisation knob. Larger = smoother/more-regularised source maps.
+      (lambda_CSF is held at 0: the isolated-eval stage contract provides no CSF mask.)
 # Inputs consumed (isolated eval, fed ground truth): local field + R2' + QSM + mask + magnitude.
 # Produces two source maps: chi-para (χ+) and chi-dia (χ−). CSF referencing disabled (no CSF mask in
 # the stage contract). Same GHCR/image caveat as the iLSQR submission — runs via `--runner local`.

--- a/algorithms/chi-sep-medi/recon.m
+++ b/algorithms/chi-sep-medi/recon.m
@@ -24,10 +24,15 @@ function recon(inp, out)
     mag4       = rd('magnitude.nii.gz');            % (x,y,z,te)
     mag        = sqrt(sum(mag4.^2, 4));
 
+    % Parameter overrides (qsm-ci run --set NAME=VALUE) arrive as /input/config.json (absent otherwise).
+    cfg = struct();
+    if isfile(fullfile(inp, 'config.json')); cfg = jsondecode(fileread(fullfile(inp, 'config.json'))); end
+    if isfield(cfg, 'lambda'); lambda = cfg.lambda; else; lambda = 1; end
+
     local_field_hz = localfield * 1e-6 * CF;        % ppm -> Hz
     N_std = ones(size(mask));
     params.b0_dir = b0d; params.CF = CF; params.voxel_size = vox;
-    params.lambda = 1; params.lambda_CSF = 0;       % no CSF mask in the contract -> CSF term off
+    params.lambda = lambda; params.lambda_CSF = 0;  % no CSF mask in the contract -> CSF term off
     option_data.qsm = qsm; option_data.N_std = N_std;
     option_data.mask_CSF = false(size(mask));
 

--- a/algorithms/chi-sepnet/algorithm.yml
+++ b/algorithms/chi-sepnet/algorithm.yml
@@ -20,5 +20,13 @@ code_url: https://github.com/SNU-LIST/chi-separation
 license: academic use; toolbox obtained via the SNU-LIST Google Form
 image: ghcr.io/astewartau/qsm-ci/chi-sepnet:v1
 run: bash run.sh
+parameters:
+  - name: Dr
+    default: 114.0
+    description: >
+      Relaxivity (Hz/ppm) used to scale R2' into the network's R2'/Dr input channel. The network was
+      trained at Dr=114 (its COSMOS-referenced value), so moving it feeds off-distribution inputs — this
+      is a research knob, not an accuracy-tuning target. (No patch/overlap knob: the ONNX graph fixes the
+      192×192×128 input, and the weights fix everything else.)
 # Produces two source maps: chi-para (χ+) and chi-dia (χ−). Weights (ONNX) not committed; the image
 # would bundle them. Runs via `--runner local` for the PoC (XSEP_PYTHON = an onnxruntime venv).

--- a/algorithms/chi-sepnet/recon.py
+++ b/algorithms/chi-sepnet/recon.py
@@ -27,7 +27,7 @@ import onnxruntime as ort
 
 IN = sys.argv[1] if len(sys.argv) > 1 else "/input"
 OUT = sys.argv[2] if len(sys.argv) > 2 else "/output"
-DR = 114.0
+DEFAULT_DR = 114.0    # the network's COSMOS-referenced relaxivity (Hz/ppm) — see read_dr()
 PATCH = (192, 192, 128)
 ONNX = "240904_xsepnet.onnx"
 NORM = "xsepnet_train_patch_norm_factor_inplane_largedegree_romeo_arlo.mat"
@@ -49,6 +49,20 @@ def _models_dir():
 MODELS = _models_dir()
 
 
+def read_dr():
+    """Dr (Hz/ppm) used to scale R2' into the network's input channel. Overridable via
+    `qsm-ci run chi-sepnet --set Dr=...` (arrives as /input/config.json), else the trained default 114.
+    NB: the net was trained at Dr=114 — moving it feeds off-distribution inputs, so this is a research
+    knob, not an accuracy-tuning target."""
+    p = os.path.join(IN, "config.json")
+    if os.path.exists(p):
+        with open(p) as f:
+            v = json.load(f).get("Dr")
+        if v is not None:
+            return float(v)
+    return DEFAULT_DR
+
+
 def load(name):
     img = nib.load(os.path.join(IN, name))
     return np.asarray(img.get_fdata(), dtype=np.float64), img
@@ -68,6 +82,7 @@ def main():
     qsm, _ = load("chimap.nii.gz")             # ppm (χ_total)
     r2p, _ = load("r2prime.nii.gz")            # Hz
     mask = (load("mask.nii.gz")[0] > 0.5)
+    dr = read_dr()
 
     N = sio.loadmat(os.path.join(MODELS, NORM))
     def s(k):
@@ -77,7 +92,7 @@ def main():
     chans = [
         (qsm - s("cosmos_sus_mean")) / s("cosmos_sus_std"),
         (field - s("field_mean")) / s("field_std"),
-        ((r2p / DR) - s("r2prime_mean")) / s("r2prime_std"),
+        ((r2p / dr) - s("r2prime_mean")) / s("r2prime_std"),
     ]
     vol = np.stack([c * mask for c in chans]).astype(np.float32)   # (3, X, Y, Z)
     _, X, Y, Z = vol.shape
@@ -108,7 +123,7 @@ def main():
              os.path.join(OUT, "chi-para.nii.gz"))
     nib.save(nib.Nifti1Image(xneg.astype(np.float32), fimg.affine, fimg.header),
              os.path.join(OUT, "chi-dia.nii.gz"))
-    print("chi-sepnet: wrote chi-para/chi-dia", xpos.shape, flush=True)
+    print("chi-sepnet: wrote chi-para/chi-dia", xpos.shape, "Dr=%g" % dr, flush=True)
 
 
 if __name__ == "__main__":

--- a/algorithms/wavesep/algorithm.yml
+++ b/algorithms/wavesep/algorithm.yml
@@ -26,6 +26,27 @@ code_url: https://github.com/ZhenghanFang/WaveSep
 license: academic use (author permission)
 image: ghcr.io/astewartau/qsm-ci/wavesep:v1
 run: bash run.sh
+parameters:
+  - name: Dr
+    default: 137.0
+    description: >
+      Static-dephasing relaxivity kernel (Hz/ppm) tying R2' to the source magnitude
+      (R2' = Dr·(|χ+|+|χ−|)). 137 is the qsm-forward phantom's kernel (Shin 2022); WaveSep assumes
+      Dr_pos == Dr_neg. Overriding here takes precedence over $WAVESEP_DR and params.json "Dr".
+  - name: lambda
+    default: 0.02
+    description: wavelet-domain L1 (soft-thresholding) sparsity weight — the primary regularisation knob.
+  - name: alpha
+    default: 0.2
+    description: proximal-gradient step / data-consistency weight.
+  - name: wavelet
+    default: db4
+    description: PyWavelets wavelet basis for the sparsity transform (e.g. db2, db4, db6, sym4).
+  - name: max_iter
+    default: 100
+    description: >
+      maximum proximal-gradient iterations (early-stops on convergence, ~12 on the phantom). A pure
+      convergence knob, not a regularisation target.
 # Produces two source maps: chi-para (χ+) and chi-dia (χ−). WaveSep's QSM path uses χ_total + R2' only
 # (no B0 direction, so single-orientation data needs no reorientation), with a single relaxivity kernel
 # Dr=137 Hz/ppm (the qsm-forward phantom's kernel; override via $WAVESEP_DR or params.json "Dr").

--- a/algorithms/wavesep/recon.py
+++ b/algorithms/wavesep/recon.py
@@ -43,8 +43,11 @@ from wavesep.utils.solver_wavesep_qsm import Solver
 
 IN = sys.argv[1] if len(sys.argv) > 1 else "/input"
 OUT = sys.argv[2] if len(sys.argv) > 2 else "/output"
-WAVELET = "db4"
-ALPHA, LAMBDA, MAXIT = 0.2, 0.02, 100
+# Repo defaults (WaveSep's own, from wavesep/qsm_sep.py). Each is overridable per run via
+# `qsm-ci run wavesep --set <name>=<value>` (arrives as /input/config.json — see read_cfg / dr_value).
+DEFAULT_WAVELET = "db4"
+DEFAULT_ALPHA, DEFAULT_LAMBDA, DEFAULT_MAXIT = 0.2, 0.02, 100
+DEFAULT_DR = 137.0
 
 
 def load(name):
@@ -65,13 +68,26 @@ def pad_spec(shape, wavelet):
         P *= 2
 
 
-def dr_value(params):
+def read_cfg():
+    """Parameter overrides (`qsm-ci run --set NAME=VALUE`) arrive as /input/config.json; absent when no
+    override is given. Only keys declared in algorithm.yml `parameters:` are ever written here."""
+    p = os.path.join(IN, "config.json")
+    if os.path.exists(p):
+        with open(p) as f:
+            return json.load(f)
+    return {}
+
+
+def dr_value(params, cfg):
+    # precedence: --set Dr (config.json) > $WAVESEP_DR > params.json "Dr" > repo default
+    if cfg.get("Dr") is not None:
+        return float(cfg["Dr"])
     env = os.environ.get("WAVESEP_DR")
     if env:
         return float(env)
     if isinstance(params, dict) and params.get("Dr") is not None:
         return float(params["Dr"])
-    return 137.0
+    return DEFAULT_DR
 
 
 def main():
@@ -80,11 +96,16 @@ def main():
     mask = (load("mask.nii.gz")[0] > 0.5).astype(np.float64)
     with open(os.path.join(IN, "params.json")) as f:
         params = json.load(f)
-    Dr = dr_value(params)
+    cfg = read_cfg()
+    Dr = dr_value(params, cfg)
+    wavelet = str(cfg.get("wavelet", DEFAULT_WAVELET))
+    alpha = float(cfg.get("alpha", DEFAULT_ALPHA))
+    lam = float(cfg.get("lambda", DEFAULT_LAMBDA))
+    maxit = int(cfg.get("max_iter", DEFAULT_MAXIT))
 
     qsm = qsm.squeeze() * mask
     X, Y, Z = qsm.shape
-    pad = pad_spec((X, Y, Z), WAVELET)
+    pad = pad_spec((X, Y, Z), wavelet)
     pf = lambda a: np.pad(a, pad)
     mask_p = pf(mask)
     qsm_p = pf(qsm) * mask_p
@@ -94,7 +115,7 @@ def main():
     # upstream solve() prints self.metrics[-1]; with no ground truth that list is empty -> attach a
     # no-op evaluator so it stays populated (no skimage compute, no change to the optimisation).
     solver.evaluator = type("_NoOpEval", (), {"evaluate": lambda self, x3d: {}})()
-    xp, xn = solver.solve(ALPHA, LAMBDA, WAVELET, level=None, maxit=MAXIT)
+    xp, xn = solver.solve(alpha, lam, wavelet, level=None, maxit=maxit)
 
     xpos = (xp[:X, :Y, :Z] * mask).astype(np.float32)         # χ+
     xneg = (-xn[:X, :Y, :Z] * mask).astype(np.float32)        # χ− (positive magnitude)
@@ -102,7 +123,8 @@ def main():
     os.makedirs(OUT, exist_ok=True)
     nib.save(nib.Nifti1Image(xpos, qimg.affine, qimg.header), os.path.join(OUT, "chi-para.nii.gz"))
     nib.save(nib.Nifti1Image(xneg, qimg.affine, qimg.header), os.path.join(OUT, "chi-dia.nii.gz"))
-    print(f"wavesep: wrote chi-para/chi-dia {xpos.shape} Dr={Dr}", flush=True)
+    print(f"wavesep: wrote chi-para/chi-dia {xpos.shape} "
+          f"Dr={Dr} lambda={lam:g} alpha={alpha:g} wavelet={wavelet} max_iter={maxit}", flush=True)
 
 
 if __name__ == "__main__":

--- a/results/index.json
+++ b/results/index.json
@@ -10628,35 +10628,6 @@
       }
     },
     {
-      "name": "SHARP",
-      "track": "sim",
-      "stage": "bfr",
-      "artifact": "localfield",
-      "kind": "field",
-      "image": null,
-      "runtime_s": 2.9640746116638184,
-      "metrics": {
-        "nrmse": 32.90951827633364,
-        "nrmse_detrend": 34.300006227743985,
-        "correlation": 0.9459044634052274,
-        "xsim": 0.9101204710278267
-      },
-      "status": "ok",
-      "id": "sharp-iso-tuned",
-      "slug": "sharp",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "threshold": "0.01"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/sharp-iso-tuned__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/sharp-iso-tuned__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/sharp-iso-tuned__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/sharp-iso-tuned__error.nii.gz"
-      }
-    },
-    {
       "name": "xQSM",
       "track": "sim",
       "stage": "dipole",
@@ -34086,76 +34057,6 @@
         "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__recon.nii.gz",
         "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__truth.nii.gz",
         "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/nltv-iso-tuned-invivo__error.nii.gz"
-      }
-    },
-    {
-      "name": "Tikhonov",
-      "track": "invivo",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 3.727900981903076,
-      "metrics": {
-        "nrmse": 104.2618978448372,
-        "nrmse_detrend": 103.15811926514573,
-        "hfen": 91.56635409098125,
-        "correlation": 0.6960306215445874,
-        "xsim": 0.3276035651416914,
-        "nrmse_sti": 127.98814338375313,
-        "nrmse_detrend_sti": 146.24138258451546,
-        "hfen_sti": 116.85464024727685,
-        "correlation_sti": 0.5644536231765737,
-        "xsim_sti": 0.2072242214867708
-      },
-      "status": "ok",
-      "id": "tikhonov-iso-tuned-invivo",
-      "slug": "tikhonov",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "lambda": "3e-3"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tikhonov-iso-tuned-invivo__error.nii.gz"
-      }
-    },
-    {
-      "name": "TSVD",
-      "track": "invivo",
-      "stage": "dipole",
-      "artifact": "chimap",
-      "kind": "chi",
-      "image": null,
-      "runtime_s": 6.41684889793396,
-      "metrics": {
-        "nrmse": 123.75711704031987,
-        "nrmse_detrend": 112.7898918910182,
-        "hfen": 107.59042301652867,
-        "correlation": 0.6634083446643043,
-        "xsim": 0.2623189590200129,
-        "nrmse_sti": 148.30438214882804,
-        "nrmse_detrend_sti": 158.45543274141608,
-        "hfen_sti": 133.73305683092414,
-        "correlation_sti": 0.533698751914367,
-        "xsim_sti": 0.1637208824426778
-      },
-      "status": "ok",
-      "id": "tsvd-iso-tuned-invivo",
-      "slug": "tsvd",
-      "mode": "isolated",
-      "variant": "tuned",
-      "params": {
-        "threshold": "0.05"
-      },
-      "resources_url": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__resources.json",
-      "volumes": {
-        "recon": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__recon.nii.gz",
-        "truth": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__truth.nii.gz",
-        "error": "https://huggingface.co/datasets/qsmxt/qsm-ci-volumes/resolve/main/tsvd-iso-tuned-invivo__error.nii.gz"
       }
     },
     {

--- a/scripts/prune_stale_tuned.py
+++ b/scripts/prune_stale_tuned.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Drop orphaned `tuned` runs from results/index.json.
+
+A published isolated `tuned` run is only meaningful while its parameters still match what the method's
+algorithm.yml currently declares as the tuned value for that run's track (`tuned: {sim: .., invivo: ..,
+chisep: ..}`, or a bare scalar = sim). When a tuned value is removed or changed in the yaml — e.g. an
+in-vivo tuning that turned out to hurt is deleted — the old run lingers in index.json and the
+leaderboard keeps showing a "tuned" variant that no longer corresponds to any declared setting (and can
+read as tuned-worse-than-default).
+
+A full re-score naturally omits these (discover_algorithms only expands a tuned variant a method still
+declares for its track), so this is a stopgap to keep the published index.json consistent with the
+current declarations without re-running every container. Idempotent: re-running it changes nothing once
+the index is clean.
+
+  python scripts/prune_stale_tuned.py            # prune results/index.json in place
+  python scripts/prune_stale_tuned.py --check    # exit 1 if any stale run exists (no write)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def declared_tuned(slug: str, track: str) -> dict:
+    """The {param: value} the method currently declares as tuned for `track` (str values, matching how
+    index.json stores run params). Empty if the method/param declares nothing for that track."""
+    spec = ROOT / "algorithms" / slug / "algorithm.yml"
+    if not spec.exists():
+        return {}
+    doc = yaml.safe_load(spec.read_text()) or {}
+    out = {}
+    for p in doc.get("parameters") or []:
+        t = p.get("tuned")
+        v = t.get(track) if isinstance(t, dict) else (t if track == "sim" else None)
+        if v is not None:
+            out[str(p["name"])] = str(v)
+    return out
+
+
+def is_stale(run: dict) -> bool:
+    """A run is stale iff it's an isolated tuned variant whose params no longer match the declared
+    tuned value for its track (including the case where the declaration was removed entirely)."""
+    if run.get("mode") != "isolated" or run.get("variant") != "tuned":
+        return False
+    params = {k: str(v) for k, v in (run.get("params") or {}).items()}
+    declared = declared_tuned(run.get("slug", ""), run.get("track", "sim"))
+    return not (params and all(declared.get(k) == v for k, v in params.items()))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--index", type=Path, default=ROOT / "results" / "index.json")
+    ap.add_argument("--check", action="store_true", help="report stale runs and exit 1; do not write")
+    args = ap.parse_args()
+
+    doc = json.loads(args.index.read_text())
+    runs = doc.get("runs", [])
+    stale = [r for r in runs if is_stale(r)]
+
+    if not stale:
+        print("no stale tuned runs — index.json is consistent with the declarations")
+        return
+    for r in stale:
+        print(f"  stale: {r['id']:28} track={r.get('track')} params={r.get('params')}")
+    if args.check:
+        print(f"{len(stale)} stale tuned run(s)")
+        sys.exit(1)
+
+    doc["runs"] = [r for r in runs if not is_stale(r)]
+    args.index.write_text(json.dumps(doc, indent=2) + "\n")
+    print(f"pruned {len(stale)} stale tuned run(s); wrote {args.index} ({len(doc['runs'])} runs)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -6,11 +6,21 @@ artifact(s) its stage consumes, exactly like scripts/pipeline.py isolated), scor
 xSIM against ground truth with the same valid-mask logic as the pipeline, and reports the best grid
 point per algorithm against its current default.
 
-  python scripts/sweep.py --dataset data/sim/dev [--only tgv,tkd] [--jobs 4]
+  python scripts/sweep.py --dataset data/sim/scoring [--only tgv,tkd] [--jobs 4]
+
+The χ-separation stage is supported too: those methods emit TWO source maps (χ+ and χ−), each scored
+with `--kind chisep`, and the sweep's objective is the mean of the two xSIMs (both are reported so a
+human can favour χ+ or χ− when picking a tuned value). Point it at the chisep dataset and restrict to
+the chisep slugs:
+
+  python scripts/sweep.py --dataset data/sim/chisep --only wavesep,chi-sep-medi,chi-sep-ilsqr
 
 Writes results/sweep.json (every grid point) and prints a per-algorithm best-vs-baseline table.
 Only regularisation / threshold knobs are swept — pure convergence knobs (tol, max_iter) are held at
 their defaults, since they change convergence, not the over-/under-regularisation we're tuning for.
+The two χ-separation deep nets are intentionally NOT swept: susep-net exposes no knob, and χ-sepnet's
+only knob (Dr) is baked into its trained weights, so moving it feeds off-distribution inputs rather
+than tuning accuracy.
 """
 from __future__ import annotations
 
@@ -32,7 +42,7 @@ sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "scripts"))
 from qsm_ci.scoring import cli_run_argv, gt_sources, eval_argv  # noqa: E402  shared primitives
 from pipeline import (  # noqa: E402  reuse the exact isolated-scoring machinery
-    ARTIFACT_FILE, discover_algorithms, prepare_input, _valid_mask,
+    ARTIFACT_FILE, ARTIFACT_KIND, discover_algorithms, prepare_input, _valid_mask,
 )
 
 # Grid of {param: [values]} per slug. itertools.product expands to one run per combination.
@@ -56,6 +66,16 @@ GRIDS: dict[str, dict[str, list]] = {
     # --- unwrap+bfr ---
     "harperella":  {"radius": [3.0, 5.0, 8.0]},
     "iharperella": {"radius": [3.0, 5.0, 8.0]},
+    # --- chi-separation (iterative only; run with --dataset data/sim/chisep) ---
+    # wavesep: wavelet-L1 sparsity weight (primary knob) x proximal-gradient step. Dr is left at the
+    # phantom's known kernel (137) — sweeping a physical constant on the phantom that defines it is
+    # circular, and it's exposed for callers who want it. max_iter (convergence) held at default.
+    "wavesep":       {"lambda": [0.005, 0.01, 0.02, 0.04, 0.08], "alpha": [0.1, 0.2, 0.4]},
+    # chi-sep-medi: MEDI data-fidelity/morphology regularisation weight (params.lambda).
+    "chi-sep-medi":  {"lambda": [0.1, 0.3, 1.0, 3.0, 10.0]},
+    # chi-sep-ilsqr: padding for the in-house QSM_iLSQR step (boundary/wrap artifacts). A numerical
+    # knob rather than a regularisation one, but it's the only lever the black-box toolbox exposes.
+    "chi-sep-ilsqr": {"pad_size": [8, 12, 16, 20]},
 }
 
 # Round-2 refinement: extend the axes where round-1's best sat on a grid edge, so the true optimum
@@ -97,30 +117,78 @@ def score_xsim(recon: Path, artifact: str, gt: Path, mask: Path, work: Path) -> 
     return json.loads(out_json.read_text())["metrics"]
 
 
-def run_one(algo: dict, override: dict, src: dict, work: Path) -> dict:
+def is_chisep(algo: dict) -> bool:
+    """A χ-separation run: >1 produced artifact, all of kind 'chisep' (χ+ and χ−) — same test the
+    pipeline uses to route to its two-output scorer."""
+    prods = algo["produces"]
+    return len(prods) > 1 and all(ARTIFACT_KIND.get(p) == "chisep" for p in prods)
+
+
+def score_chisep(odir: Path, gt: Path, mask: Path, work: Path) -> dict:
+    """Score a χ-separation run's two source maps (χ+ = chi-para, χ− = chi-dia) against ground truth,
+    each with `--kind chisep`, using the same valid-mask logic as the QSM path. Returns
+    {para_xsim, dia_xsim, para_nrmse, dia_nrmse}. seg (dseg) is passed when present so the recorded
+    metrics include the region-specific leakage, matching pipeline.score."""
+    seg = gt / "dseg.nii.gz"
+    out: dict = {}
+    for art, comp in (("chi-para", "para"), ("chi-dia", "dia")):
+        recon = odir / ARTIFACT_FILE[art]
+        sm = _valid_mask(recon, mask, work.with_suffix(f".{comp}.scoremask.nii.gz"))
+        out_json = work.with_suffix(f".{comp}.score.json")
+        cmd = eval_argv(sys.executable, EVAL, recon, gt / ARTIFACT_FILE[art], "chisep", sm,
+                        art, out_json, stage="sweep", name="sweep", track="chisep",
+                        seg=seg if seg.exists() else None, component=comp)
+        subprocess.run(cmd, check=True, capture_output=True)
+        m = json.loads(out_json.read_text())["metrics"]
+        out[f"{comp}_xsim"] = m.get("xsim")
+        out[f"{comp}_nrmse"] = m.get("nrmse")
+    return out
+
+
+def _f4(v) -> str:
+    return f"{v:.4f}" if isinstance(v, (int, float)) else "n/a"
+
+
+def run_one(algo: dict, override: dict, src: dict, gt_dir: Path, work: Path) -> dict:
     slug = algo["slug"]
     tag = "__".join(f"{k}-{fmt(v)}" for k, v in override.items()) or "default"
     idir = work / f"{slug}__{tag}__in"
     odir = work / f"{slug}__{tag}__out"
-    produced = algo["produces"][0]
     prepare_input(algo["consumes"], src, idir)  # stage GT inputs under canonical names
     # Shared argv builder — `fmt=fmt` reproduces the sweep's grid-value formatting (a swept float like
     # 8.0 renders as `8`, this script's long-standing behaviour), so the emitted argv is unchanged.
+    # For a χ-separation (multi-output) method it hands the CLI the output DIR, not a single file.
     argv = cli_run_argv(algo, idir, odir, ARTIFACT_FILE, RUNNER, override, fmt=fmt)
     rec = {"slug": slug, "stage": algo["stage"], "override": override, "tag": tag}
+    chisep = is_chisep(algo)
     try:
         odir.mkdir(parents=True, exist_ok=True)
         t0 = time.time()
         subprocess.run(argv, check=True, capture_output=True, text=True)
-        m = score_xsim(odir / ARTIFACT_FILE[produced], produced,
-                       Path(src["chimap"]).parent, src["mask"], work / f"{slug}__{tag}")
-        rec.update(status="ok", xsim=m.get("xsim"), nrmse=m.get("nrmse"), runtime=time.time() - t0)
+        if chisep:
+            m = score_chisep(odir, gt_dir, src["mask"], work / f"{slug}__{tag}")
+            xs = [m[k] for k in ("para_xsim", "dia_xsim") if m.get(k) is not None]
+            # Objective: mean of the two source xSIMs (both are also recorded so a human can favour one).
+            rec.update(status="ok", xsim=(sum(xs) / len(xs) if xs else None),
+                       para_xsim=m.get("para_xsim"), dia_xsim=m.get("dia_xsim"),
+                       para_nrmse=m.get("para_nrmse"), dia_nrmse=m.get("dia_nrmse"),
+                       runtime=time.time() - t0)
+        else:
+            produced = algo["produces"][0]
+            m = score_xsim(odir / ARTIFACT_FILE[produced], produced,
+                           gt_dir, src["mask"], work / f"{slug}__{tag}")
+            rec.update(status="ok", xsim=m.get("xsim"), nrmse=m.get("nrmse"), runtime=time.time() - t0)
     except subprocess.CalledProcessError as e:
         rec.update(status="DNF", error=(e.stderr or "")[-400:])
     except Exception as e:  # noqa: BLE001
         rec.update(status="DNF", error=str(e)[-400:])
     with _print_lock:
-        x = f"xsim={rec['xsim']:.4f}" if rec.get("xsim") is not None else f"DNF"
+        if rec.get("xsim") is None:
+            x = "DNF"
+        elif chisep:
+            x = f"xsim={rec['xsim']:.4f} (χ+={_f4(rec.get('para_xsim'))} χ−={_f4(rec.get('dia_xsim'))})"
+        else:
+            x = f"xsim={rec['xsim']:.4f}"
         print(f"  {slug:<14} {tag:<28} {x}", flush=True)
     return rec
 
@@ -139,6 +207,7 @@ def main() -> None:
     RUNNER = args.runner
 
     src = gt_sources(args.dataset)
+    gt_dir = args.dataset / "groundtruth"   # scored artifacts (chimap / chi-para / chi-dia / dseg) live here
     algos = {a["slug"]: a for a in discover_algorithms()}
     grids = REFINE if args.refine else GRIDS
     want = args.only.split(",") if args.only else list(grids)
@@ -157,7 +226,7 @@ def main() -> None:
 
     # MATLAB MCR runs are memory-heavy; keep the whole sweep at the given cap (default 4).
     with cf.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as ex:
-        results = list(ex.map(lambda t: run_one(t[0], t[1], src, args.work), tasks))
+        results = list(ex.map(lambda t: run_one(t[0], t[1], src, gt_dir, args.work), tasks))
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(results, indent=2) + "\n")
@@ -169,8 +238,12 @@ def main() -> None:
             print(f"{slug:<14} all DNF"); continue
         rs.sort(key=lambda r: r["xsim"], reverse=True)
         best, worst = rs[0], rs[-1]
+        # χ-separation optimises the mean of χ+/χ− xSIM — show both components on the winning point so
+        # a reviewer can still favour one source before writing the tuned value into algorithm.yml.
+        extra = (f"  [χ+={_f4(best.get('para_xsim'))} χ−={_f4(best.get('dia_xsim'))}]"
+                 if best.get("para_xsim") is not None else "")
         print(f"{slug:<14} best xsim={best['xsim']:.4f} @ {best['tag']:<26} "
-              f"(range {worst['xsim']:.4f}–{best['xsim']:.4f} over {len(rs)} pts)")
+              f"(range {worst['xsim']:.4f}–{best['xsim']:.4f} over {len(rs)} pts){extra}")
     print(f"\nwrote {args.out}")
 
 

--- a/scripts/sweep.py
+++ b/scripts/sweep.py
@@ -89,6 +89,14 @@ REFINE: dict[str, dict[str, list]] = {
     "harperella": {"radius": [1.0, 2.0, 3.0]},
     # λ climbs to 0.546 at 450 but diverges hard by 600 — pin the peak in the pre-cliff window.
     "matlab-medi": {"lambda": [460, 480, 500, 520, 540, 560], "smv_radius": [5]},
+    # --- chi-separation round-2 (PROVISIONAL: re-center on round-1's best before use) ---
+    # Finer log-brackets around each method's primary regularisation knob. Unlike the entries above —
+    # which were narrowed to where round-1 actually peaked — these are seeded from the round-1 grid's
+    # interesting middle because the χ-sep sweep hasn't been run yet (no containers/data in this env).
+    # Once round-1 exists, re-center on its best (and pin wavesep's alpha to round-1's best alpha, not
+    # the 0.2 default assumed here). pad_size (ilsqr) is already dense in round-1, so it has no round-2.
+    "wavesep":      {"lambda": [0.008, 0.012, 0.016, 0.02, 0.028, 0.04, 0.06], "alpha": [0.2]},
+    "chi-sep-medi": {"lambda": [0.3, 0.5, 0.7, 1.0, 1.5, 2.0, 3.0]},
 }
 
 _print_lock = threading.Lock()

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -154,7 +154,13 @@
         "Jingu Lee",
         "Jongho Lee"
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "pad_size",
+          "default": 12,
+          "description": "Zero-padding (voxels, applied on each axis as [pad pad pad]) for the in-house STI-Suite QSM_iLSQR step that reconstructs the QSM fed to chi_sep_iLSQR. Larger padding reduces dipole-inversion boundary/wrap artifacts at higher memory/runtime. (chi_sep_iLSQR's own internals are a black-box .p toolbox and expose no further knobs here; the Bunya diagnostic found N_std/CSF had no effect.)\n"
+        }
+      ],
       "ci_notes": []
     },
     {
@@ -184,7 +190,13 @@
         "Jingu Lee",
         "Jongho Lee"
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "lambda",
+          "default": 1,
+          "description": "MEDI data-fidelity / morphology regularisation weight passed to chi_sep_MEDI (params.lambda) \u2014 the method's primary regularisation knob. Larger = smoother/more-regularised source maps. (lambda_CSF is held at 0: the isolated-eval stage contract provides no CSF mask.)\n"
+        }
+      ],
       "ci_notes": []
     },
     {
@@ -212,7 +224,13 @@
         "Hyeong-Geol Shin",
         "Jongho Lee"
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "Dr",
+          "default": 114.0,
+          "description": "Relaxivity (Hz/ppm) used to scale R2' into the network's R2'/Dr input channel. The network was trained at Dr=114 (its COSMOS-referenced value), so moving it feeds off-distribution inputs \u2014 this is a research knob, not an accuracy-tuning target. (No patch/overlap knob: the ONNX graph fixes the 192\u00d7192\u00d7128 input, and the weights fix everything else.)\n"
+        }
+      ],
       "ci_notes": []
     },
     {
@@ -2062,7 +2080,33 @@
         "Xu Li",
         "Jeremias Sulam"
       ],
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "Dr",
+          "default": 137.0,
+          "description": "Static-dephasing relaxivity kernel (Hz/ppm) tying R2' to the source magnitude (R2' = Dr\u00b7(|\u03c7+|+|\u03c7\u2212|)). 137 is the qsm-forward phantom's kernel (Shin 2022); WaveSep assumes Dr_pos == Dr_neg. Overriding here takes precedence over $WAVESEP_DR and params.json \"Dr\".\n"
+        },
+        {
+          "name": "lambda",
+          "default": 0.02,
+          "description": "wavelet-domain L1 (soft-thresholding) sparsity weight \u2014 the primary regularisation knob."
+        },
+        {
+          "name": "alpha",
+          "default": 0.2,
+          "description": "proximal-gradient step / data-consistency weight."
+        },
+        {
+          "name": "wavelet",
+          "default": "db4",
+          "description": "PyWavelets wavelet basis for the sparsity transform (e.g. db2, db4, db6, sym4)."
+        },
+        {
+          "name": "max_iter",
+          "default": 100,
+          "description": "maximum proximal-gradient iterations (early-stops on convergence, ~12 on the phantom). A pure convergence knob, not a regularisation target.\n"
+        }
+      ],
       "ci_notes": []
     },
     {

--- a/web/results.html
+++ b/web/results.html
@@ -825,6 +825,13 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           <p class="mt-2 text-sm text-gray-600 leading-relaxed">In-vivo structural similarity (xSIM vs COSMOS) against wall-clock runtime on a log scale. <span style="color:#10b981" class="font-semibold">Green</span> points are Pareto-optimal (nothing is both faster and more accurate); grey points are dominated.</p>
           <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivParetoSVG"></div>
         </div>
+        <template x-if="ivTuningRows.rows.length">
+          <div class="mt-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h3 class="text-lg font-semibold text-gray-900">Tuning rescues classical methods in vivo</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">Isolated dipole xSIM vs COSMOS at default parameters (grey) versus tuned on the in-vivo data (green), ordered by gain. At their defaults the classical iterative methods look far weaker than the pretrained networks; tuned, several leap most of the way to the <span style="color:#6366f1" class="font-semibold">best learned method</span> (dashed). The payoff dwarfs the phantom's — medi and l1-qsm each gain roughly +0.3&nbsp;xSIM — because their defaults are mistuned for real-data noise. Tuning on the scored data is a mild form of overfitting, and only some methods are tunable, so defaults stays the fair cross-method ranking.</p>
+            <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="ivTuningSVG"></div>
+          </div>
+        </template>
       </div><!-- /in-vivo findings -->
 
       <!-- In vivo · Info -->
@@ -873,6 +880,14 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           <p class="mt-2 text-sm text-gray-600 leading-relaxed">Mean xSIM per method family on each dataset. Deep-learning methods barely drop from phantom to in-vivo; classical iterative and direct methods lose far more — tuned to the idealised phantom, they generalise worse to real 3 T data.</p>
           <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="crossBarsSVG"></div>
         </div>
+        <template x-if="optShiftRows.length">
+          <div class="mt-8 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h3 class="text-lg font-semibold text-gray-900">The tuned optimum moves with the data</h3>
+            <p class="mt-2 text-sm text-gray-600 leading-relaxed">For every dipole method tuned on <em>both</em> datasets, its optimal regularisation strength on the in-silico phantom (left) versus in vivo (right), on a log scale. The in-vivo optimum sits roughly 10–30× higher almost everywhere: real 3&nbsp;T data — with acquisition noise and forward-model mismatch — needs far heavier regularisation than the idealised phantom, so a single &ldquo;recommended&rdquo; value can't serve both. Coloured by family; hover for the shift.</p>
+            <div class="mt-2" x-html="familyLegend"></div>
+            <div class="mt-5 overflow-x-auto text-gray-700 dark:text-gray-200" x-html="optShiftSVG"></div>
+          </div>
+        </template>
       </div>
     </section>
   </main>
@@ -1241,6 +1256,103 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           const iv = {}; this._ivDip().forEach((r) => { iv[r.slug] = r; });
           return this._isoDip().filter((r) => iv[r.slug] && val(r, "xsim") != null && val(iv[r.slug], "xsim") != null)
             .map((r) => ({ slug: r.slug, name: this.algoName(r.slug), si: val(r, "xsim"), iv: val(iv[r.slug], "xsim"), fam: this._fam(r.slug) }));
+        },
+
+        // In-vivo · what tuning buys on real data: default -> tuned xSIM, ordered by gain, with the best
+        // pretrained network as a ceiling. Classical methods look weak at defaults and leap toward the
+        // learned ceiling once tuned — the payoff is far larger in vivo than on the phantom.
+        get ivTuningRows() {
+          return _cache("ivtune", this.runs.length, () => {
+            const by = {};
+            this._invivo().filter((r) => r.mode === "isolated" && r.stage === "dipole" && val(r, "xsim") != null)
+              .forEach((r) => { (by[r.slug] ||= {})[r.variant || "default"] = val(r, "xsim"); });
+            const rows = Object.entries(by).filter(([, v]) => v.default != null && v.tuned != null)
+              .map(([slug, v]) => ({ slug, name: this.algoName(slug), fam: this._fam(slug), def: v.default, tuned: v.tuned }))
+              .sort((a, b) => (b.tuned - b.def) - (a.tuned - a.def));
+            const dl = this._invivo().filter((r) => r.mode === "isolated" && r.stage === "dipole" && this._fam(r.slug) === "dl" && (r.variant || "default") === "default" && val(r, "xsim") != null).map((r) => val(r, "xsim"));
+            return { rows, ceil: dl.length ? Math.max(...dl) : null };
+          });
+        },
+        get ivTuningSVG() {
+          const E = this._esc, data = this.ivTuningRows, rows = data.rows;
+          if (!rows.length) return "<svg></svg>";
+          const w = 620, rh = 38, top = 34, padL = 132, padR = 56, h = top + rows.length * rh + 20;
+          const all = rows.flatMap((r) => [r.def, r.tuned]).concat(data.ceil != null ? [data.ceil] : []);
+          const lo = Math.max(0, Math.min(...all) - 0.04), hi = Math.min(1, Math.max(...all) + 0.04);
+          const X = (v) => padL + (v - lo) / (hi - lo || 1) * (w - padL - padR);
+          let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+          s += `<text x="${padL}" y="18" fill="currentColor" opacity="0.5" style="font-size:10px">xSIM vs COSMOS (higher is better) →</text>`;
+          if (data.ceil != null) {
+            const xc = X(data.ceil);
+            s += `<line x1="${xc}" y1="${top - 6}" x2="${xc}" y2="${h - 22}" stroke="#6366f1" stroke-dasharray="4 4" opacity="0.6"/>`;
+            s += `<text x="${xc}" y="${h - 8}" text-anchor="middle" fill="#6366f1" opacity="0.85" style="font-size:9px">best learned method</text>`;
+          }
+          rows.forEach((r, i) => {
+            const y = top + i * rh + rh / 2, xd = X(r.def), xt = X(r.tuned);
+            s += `<text x="${padL - 12}" y="${y + 3}" text-anchor="end" fill="currentColor" opacity="0.8" style="font-size:11px">${E(r.name)}</text>`;
+            s += `<g ${this._ptIv(r.slug, `${r.name} — default ${r.def.toFixed(3)} → tuned ${r.tuned.toFixed(3)} xSIM (+${(r.tuned - r.def).toFixed(3)})`)}>`;
+            s += `<line x1="${xd}" y1="${y}" x2="${xt}" y2="${y}" stroke="currentColor" opacity="0.25" stroke-width="2"/>`;
+            s += `<circle cx="${xd}" cy="${y}" r="4.5" fill="#94a3b8"/>`;
+            s += `<circle cx="${xt}" cy="${y}" r="4.5" fill="#10b981"/></g>`;
+            s += `<text x="${Math.max(xd, xt) + 8}" y="${y + 3}" fill="#10b981" style="font-size:10px;font-weight:600">+${(r.tuned - r.def).toFixed(2)}</text>`;
+          });
+          s += `<g transform="translate(${w - 150},14)" style="font-size:10px"><circle cx="0" cy="-3" r="4" fill="#94a3b8"/><text x="8" y="0" fill="currentColor" opacity="0.6">default</text><circle cx="66" cy="-3" r="4" fill="#10b981"/><text x="74" y="0" fill="currentColor" opacity="0.6">tuned</text></g>`;
+          return s + "</svg>";
+        },
+
+        // Cross-dataset · the tuned optimum moves with the data. For each dipole method tuned on BOTH
+        // datasets (same single knob), its in-silico optimum vs its in-vivo optimum on a log axis —
+        // in vivo sits systematically higher (heavier regularisation for real-data noise).
+        get optShiftRows() {
+          return _cache("optshift", this.runs.length, () => {
+            const pick = (inv) => {
+              const by = {};
+              this.runs.filter((r) => r.mode === "isolated" && r.stage === "dipole" && r.variant === "tuned" && this._isInvivo(r) === inv && r.params && Object.keys(r.params).length === 1)
+                .forEach((r) => { const k = Object.keys(r.params)[0], v = parseFloat(r.params[k]); if (isFinite(v) && v > 0) by[r.slug] = { k, v }; });
+              return by;
+            };
+            const sim = pick(false), iv = pick(true);
+            return Object.keys(sim).filter((s) => iv[s] && iv[s].k === sim[s].k)
+              .map((s) => ({ slug: s, name: this.algoName(s), key: sim[s].k, sim: sim[s].v, iv: iv[s].v, fam: this._fam(s) }))
+              .sort((a, b) => (b.iv / b.sim) - (a.iv / a.sim));
+          });
+        },
+        get optShiftSVG() {
+          const E = this._esc, rows = this.optShiftRows;
+          if (!rows.length) return "<svg></svg>";
+          const w = 620, h = 420, top = 46, bot = 30, xL = 200, xR = 430;
+          const vals = rows.flatMap((r) => [r.sim, r.iv]);
+          const lo = Math.log10(Math.min(...vals)), hi = Math.log10(Math.max(...vals));
+          const pad = (hi - lo) * 0.14 || 0.4, L0 = lo - pad, L1 = hi + pad;
+          const Y = (v) => top + (L1 - Math.log10(v)) / (L1 - L0 || 1) * (h - top - bot);
+          // de-collide the column labels (several methods share an in-silico optimum, and the in-vivo
+          // ratio labels stack where lines cross): greedily push each down to keep a minimum gap.
+          const declutter = (key) => {
+            const out = {}; let prev = -1e9;
+            rows.map((r, i) => ({ i, y: Y(r[key]) })).sort((a, b) => a.y - b.y)
+              .forEach((o) => { const y = Math.max(o.y, prev + 13); out[o.i] = y; prev = y; });
+            return out;
+          };
+          const ly = declutter("sim"), ry = declutter("iv");
+          let s = `<svg width="${w}" height="${h}" style="max-width:100%;height:auto">`;
+          for (let d = Math.ceil(L0); d <= Math.floor(L1); d++) {
+            const y = Y(Math.pow(10, d));
+            s += `<line x1="${xL}" y1="${y}" x2="${xR}" y2="${y}" stroke="currentColor" opacity="0.1"/>`;
+            s += `<text x="34" y="${y + 3}" fill="currentColor" opacity="0.4" style="font-size:9px">1e${d}</text>`;
+          }
+          s += `<text x="${xL}" y="24" text-anchor="middle" fill="currentColor" opacity="0.6" style="font-size:11px;font-weight:600">in-silico (2019)</text>`;
+          s += `<text x="${xR}" y="24" text-anchor="middle" fill="currentColor" opacity="0.6" style="font-size:11px;font-weight:600">in-vivo (2016)</text>`;
+          s += `<text x="14" y="${(top + h - bot) / 2}" text-anchor="middle" fill="currentColor" opacity="0.5" style="font-size:10px" transform="rotate(-90 14 ${(top + h - bot) / 2})">tuned parameter value (log) →</text>`;
+          rows.forEach((r, i) => {
+            const yS = Y(r.sim), yI = Y(r.iv), c = FAM[r.fam].c;
+            s += `<g data-tip="${E(`${r.name} — ${r.key}: ${r.sim} (in-silico) → ${r.iv} (in-vivo), ${(r.iv / r.sim).toFixed(0)}× heavier`)}">`;
+            s += `<line x1="${xL}" y1="${yS}" x2="${xR}" y2="${yI}" stroke="${c}" stroke-width="1.6" opacity="0.6"/>`;
+            s += `<circle cx="${xL}" cy="${yS}" r="3.6" fill="${c}"/><circle cx="${xR}" cy="${yI}" r="3.6" fill="${c}"/>`;
+            s += `<text x="${xL - 9}" y="${ly[i] + 3}" text-anchor="end" fill="currentColor" opacity="0.8" style="font-size:11px">${E(r.name)}</text>`;
+            s += `<text x="${xR + 12}" y="${ry[i] + 3}" text-anchor="start" fill="${c}" opacity="0.9" style="font-size:10px;font-weight:600">${(r.iv / r.sim).toFixed(0)}×</text>`;
+            s += `</g>`;
+          });
+          return s + "</svg>";
         },
 
         // In-vivo · COSMOS vs STI reference agreement (points below the diagonal = STI is the harder target).


### PR DESCRIPTION
## Summary

Exposes the scientifically-defensible tunable parameters of the χ-separation methods in the CLI, extends the parameter sweep to score the two-output χ-separation stage, and adds two new findings figures about tuned-vs-untuned parameters — plus a data-consistency fix for stale tuned runs.

## Changes

**1. Expose χ-separation knobs in the CLI** — add `parameters:` blocks to each `algorithm.yml` and wire each recon to read `--set` overrides from `/input/config.json`, matching the existing convention. Every knob maps to a value already used as a literal in the recon, so defaults are behaviour-preserving.

| method | knobs | default |
|---|---|---|
| wavesep | `Dr`, `lambda`, `alpha`, `wavelet`, `max_iter` | 137, 0.02, 0.2, db4, 100 |
| chi-sep-medi | `lambda` (MEDI reg. weight) | 1 |
| chi-sep-ilsqr | `pad_size` | 12 |
| chi-sepnet | `Dr` (preprocessing relaxivity) | 114 |
| susep-net | *(none — fixed weights)* | — |

**2. Sweep support for the χ-separation stage** — `scripts/sweep.py` could only score single-output stages. It now scores both source maps (χ+/χ−) with `--kind chisep`, optimises the mean of the two xSIMs (reporting both), and has `GRIDS`/`REFINE` entries for the iterative methods. The two deep nets are intentionally excluded (fixed weights).

**3. Two new findings figures** (live from `index.json`):
- *The tuned optimum moves with the data* (cross-dataset): the in-vivo optimum sits ~10–33× higher than the in-silico one for every method tuned on both datasets.
- *Tuning rescues classical methods in vivo* (in-vivo findings): default→tuned xSIM ordered by gain, with the best pretrained network as a ceiling — medi/l1-qsm gain ~+0.3.

**4. Prune stale tuned runs** — a new reproducible `scripts/prune_stale_tuned.py` drops 3 orphaned tuned runs from `results/index.json` whose parameters are no longer declared in `algorithm.yml` (in-vivo tsvd/tikhonov, sim sharp); the two in-vivo ones were rendering as tuned-worse-than-default on the leaderboard.

## Validation

CLI override validation, both Python recon config-readers, the sweep's chisep routing/argv/objective, and the two figures (headless Chromium render, zero page errors) were all verified. The MATLAB recon readers use the canonical `jsondecode(fileread(config.json))` pattern from `qsm_ci/templates.py`; an actual sweep couldn't run in the dev environment (no containers/models/phantom data), so `tuned:` χ-sep values are left for a real sweep run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018XcxFVJownpXNch49Rq4Rn)_