### PR TITLE
Record per-method tuning provenance (metadata-only)

### DIFF
--- a/algorithms/amp-pe/algorithm.yml
+++ b/algorithms/amp-pe/algorithm.yml
@@ -50,3 +50,9 @@ parameters:
 - name: max_linearization_ite
   default: 25
   description: linearization steps per reconstruction stage (preliminary and final)
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept wave_pec/simulated_TE on invivo (MATLAB; invivo-only, sim pending image rebuild). Tuned invivo: 0.6 / 0.002."

--- a/algorithms/bfrnet/algorithm.yml
+++ b/algorithms/bfrnet/algorithm.yml
@@ -47,3 +47,9 @@ ci_notes:
   overlapping 128^3 patches (Hann-blended, onnxruntime CPU arena disabled) — ~5.3 GB peak, local field
   within corr 0.992 of the whole-volume result — which scores on the standard hosted runner. Patch
   size is tunable via the patch_size parameter (0 = whole volume).
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept patch overlap on sim (sim-only); best beat default by only +0.002 (noise). Left at default."

--- a/algorithms/fansi-tgv/algorithm.yml
+++ b/algorithms/fansi-tgv/algorithm.yml
@@ -35,3 +35,9 @@ parameters:
   - name: tol_update
     default: 0.1
     description: convergence threshold on the solution update (percent)
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept alpha1/alpha0 on sim+invivo (2026-08). Tuned both."

--- a/algorithms/fansi/algorithm.yml
+++ b/algorithms/fansi/algorithm.yml
@@ -29,3 +29,9 @@ parameters:
   - name: tol_update
     default: 0.1
     description: convergence threshold on the solution update (percent)
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept alpha1 on sim+invivo (2026-08). Tuned both: sim 3e-5, invivo 4e-4."

--- a/algorithms/harperella/algorithm.yml
+++ b/algorithms/harperella/algorithm.yml
@@ -32,3 +32,9 @@ parameters:
   - name: tol
     default: 1e-4
     description: tolerance
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept radius on sim (sim-only). Tuned sim: radius 3."

--- a/algorithms/hd-qsm/algorithm.yml
+++ b/algorithms/hd-qsm/algorithm.yml
@@ -29,3 +29,9 @@ parameters:
   - name: max_iter_l2
     default: 80
     description: stage-2 (L2) iterations
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept alpha_l2 on sim+invivo (2026-08). Tuned both: sim 1e-5, invivo 3e-4."

--- a/algorithms/iharperella/algorithm.yml
+++ b/algorithms/iharperella/algorithm.yml
@@ -30,3 +30,9 @@ parameters:
   - name: tol
     default: 1e-4
     description: tolerance
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept radius on sim (sim-only); default already optimal. Left at default."

--- a/algorithms/ilsqr/algorithm.yml
+++ b/algorithms/ilsqr/algorithm.yml
@@ -30,3 +30,9 @@ parameters:
   - name: max_iter
     default: 1000
     description: iterations
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept max_iter (truncated-LSQR early stop) on sim+invivo (2026-08); default already optimal. Left at default."

--- a/algorithms/inr-qsm/algorithm.yml
+++ b/algorithms/inr-qsm/algorithm.yml
@@ -68,3 +68,9 @@ parameters:
 - name: gd_weight
   default: 1.0
   description: Weight of the gradient-domain data-consistency regularizer (reference default 1.0).
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept TV_weight on sim+invivo (GPU, 2026-08). Deterministic (reruns identical) -> tuned: sim 0.01, invivo 0.02."

--- a/algorithms/ismv/algorithm.yml
+++ b/algorithms/ismv/algorithm.yml
@@ -29,3 +29,9 @@ parameters:
   - name: radius_factor
     default: 2.0
     description: × max voxel size
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept radius_factor on sim (sim-only); non-default grid points DNF'd, default retained."

--- a/algorithms/l1-qsm/algorithm.yml
+++ b/algorithms/l1-qsm/algorithm.yml
@@ -32,3 +32,9 @@ parameters:
   - name: tol_update
     default: 1.0
     description: convergence threshold on the solution update (percent)
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept alpha1 on sim+invivo (2026-08, 3 rounds). Tuned both: sim 8e-4, invivo 0.02 (+0.31)."

--- a/algorithms/matlab-medi/algorithm.yml
+++ b/algorithms/matlab-medi/algorithm.yml
@@ -44,3 +44,9 @@ parameters:
 - name: merit
   default: 0
   description: model-error reduction (iterative reweighting); 1 enables
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept lambda/smv_radius on sim (span; sim-only). Tuned sim: lambda 520; smv_radius best == default (5), not set."

--- a/algorithms/medi/algorithm.yml
+++ b/algorithms/medi/algorithm.yml
@@ -36,3 +36,9 @@ parameters:
       sim: 3e-4
       invivo: 0.01
     description: regularization
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept lambda on sim+invivo (2026-08). Tuned both: sim 3e-4, invivo 0.01 (+0.35 xSIM)."

--- a/algorithms/modip/algorithm.yml
+++ b/algorithms/modip/algorithm.yml
@@ -52,3 +52,9 @@ parameters:
   description: >
     Base channel count of the DIP U-Net (reference default 32). Lower reduces memory/compute
     (the reference README suggests decreasing base and increasing iterations under memory pressure).
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: not-tunable
+  note: "Swept lr on sim+invivo (GPU, 2026-08). NOT tuned: stochastic deep image prior - run-to-run xSIM variance (0.01-0.15) exceeds the lr effect and the best lr flips between identical reruns, so any tuned lr would encode noise. Left at default."

--- a/algorithms/nltv/algorithm.yml
+++ b/algorithms/nltv/algorithm.yml
@@ -27,3 +27,9 @@ parameters:
   - name: max_iter
     default: 1000
     description: iterations
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept lambda on sim+invivo (2026-08). Tuned both: 3e-3 (in-vivo xSIM low in absolute terms)."

--- a/algorithms/resharp/algorithm.yml
+++ b/algorithms/resharp/algorithm.yml
@@ -27,3 +27,9 @@ parameters:
     tuned:
       sim: 1e-4
     description: Tikhonov regularization
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept radius/tik_reg on sim (bfr; sim-only). Tuned sim: radius 12, tik_reg 1e-4."

--- a/algorithms/rts/algorithm.yml
+++ b/algorithms/rts/algorithm.yml
@@ -27,3 +27,9 @@ parameters:
   - name: max_iter
     default: 1000
     description: iterations
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept delta on sim+invivo (2026-08); no grid point beat the default on either. Left at default."

--- a/algorithms/sharp/algorithm.yml
+++ b/algorithms/sharp/algorithm.yml
@@ -25,3 +25,9 @@ parameters:
   - name: radius_factor
     default: 0.5
     description: × min voxel size
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept threshold on sim (sim-only); sweep best equals the documented default (0.02). Left at default."

--- a/algorithms/tfi/algorithm.yml
+++ b/algorithms/tfi/algorithm.yml
@@ -32,3 +32,9 @@ parameters:
 - name: precond
   default: 30
   description: preconditioner — susceptibility scaling outside the brain mask (Liu 2017 uses ~30 for in-vivo air)
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept lambda on sim (span; sim-only). Tuned sim: 1e-5."

--- a/algorithms/tgv/algorithm.yml
+++ b/algorithms/tgv/algorithm.yml
@@ -37,3 +37,9 @@ parameters:
   - name: alpha0
     default: 0.0015
     description: second-order weight
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept alpha1/alpha0 on sim (bfr+dipole span; sim-only). Tuned sim: alpha1 1.5e-4."

--- a/algorithms/tikhonov/algorithm.yml
+++ b/algorithms/tikhonov/algorithm.yml
@@ -27,3 +27,9 @@ parameters:
     tuned:
       sim: 3e-4
     description: L2 regularization
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: partial
+  note: "Swept lambda on sim+invivo (2026-08). sim tuned (3e-4); invivo default optimal."

--- a/algorithms/tkd/algorithm.yml
+++ b/algorithms/tkd/algorithm.yml
@@ -26,3 +26,9 @@ parameters:
     tuned:
       invivo: 0.4
     description: k-space threshold
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: partial
+  note: "Swept threshold on sim+invivo (2026-08). invivo tuned (0.4); sim default optimal (grid gain negligible, +0.001)."

--- a/algorithms/tsvd/algorithm.yml
+++ b/algorithms/tsvd/algorithm.yml
@@ -23,3 +23,9 @@ parameters:
     tuned:
       sim: 0.05
     description: singular-value threshold
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: partial
+  note: "Swept threshold on sim+invivo (2026-08). sim tuned (0.05); invivo default optimal (+0.002 negligible)."

--- a/algorithms/tv/algorithm.yml
+++ b/algorithms/tv/algorithm.yml
@@ -35,3 +35,9 @@ parameters:
   - name: max_iter
     default: 1000
     description: iterations
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: tuned
+  note: "Swept lambda on sim+invivo (2026-08). Tuned both: sim 3e-5, invivo 3e-4."

--- a/algorithms/vsharp/algorithm.yml
+++ b/algorithms/vsharp/algorithm.yml
@@ -28,3 +28,9 @@ parameters:
   - name: min_radius_factor
     default: 0.0
     description: × max voxel size
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: default-optimal
+  note: "Swept threshold on sim (sim-only); best beat default by only +0.002 (noise). Left at default."

--- a/algorithms/wh-qsm/algorithm.yml
+++ b/algorithms/wh-qsm/algorithm.yml
@@ -33,3 +33,9 @@ parameters:
   - name: tol_update
     default: 0.1
     description: convergence threshold on the solution update (percent)
+
+# Parameter-tuning provenance (from the Bunya sweep) - so this method is not re-swept later.
+tuning:
+  date: 2026-08
+  status: partial
+  note: "Swept alpha1/beta on sim+invivo (2026-08). sim tuned (alpha1 3e-5, beta 75); invivo default optimal (+0.006 negligible)."

--- a/scripts/ci_eval_targets.py
+++ b/scripts/ci_eval_targets.py
@@ -36,6 +36,7 @@ import yaml
 COSMETIC_KEYS = {
     "name", "language", "family", "learning", "engine", "description", "citation", "doi",
     "authors", "license", "code_url", "domain", "ci_notes", "tags", "notes", "references", "tuned",
+    "tuning",
 }
 
 


### PR DESCRIPTION
## Record tuning provenance so swept methods aren't re-swept later

The parameter sweep sorted each method into: **tuned** (per-dataset params set),
**default-optimal** (swept, but the default already won), or **not-tunable**
(e.g. `modip` — a stochastic deep image prior whose lr "optimum" flips between
identical reruns, so any tuned value is noise). For the last two, `algorithm.yml`
was indistinguishable from a method nobody ever investigated — an invitation to
redo days of sweeping.

Adds a top-level `tuning:` block to every swept method:
```yaml
tuning:
  date: 2026-08
  status: tuned | partial | default-optimal | not-tunable
  note: "what was swept + why it was / wasn't tuned"
```
`tuning` is added to `COSMETIC_KEYS`, so it's **metadata-only** — `ci_eval_targets.py`
returns `[]` for these edits and the method-evaluate matrix is skipped. Manifest
unchanged (not a manifest field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
