### PR TITLE
Rebuild amp-pe with wavelet fix + smoke_box for heavy methods

### DIFF
--- a/algorithms/amp-pe/algorithm.yml
+++ b/algorithms/amp-pe/algorithm.yml
@@ -19,8 +19,9 @@ doi: 10.1002/mrm.29722
 citation: Huang et al., Magn Reson Med 2023;90(4):1414-1430
 code_url: https://github.com/EmoryCN2L/QSM_AMP_PE
 license: MIT
-image: ghcr.io/astewartau/qsm-ci/amp-pe:v1
+image: ghcr.io/astewartau/qsm-ci/amp-pe:v2
 run: bash run.sh
+smoke_box: 32   # PR --smoke gate fits a 32^3 central box (fast); full score.yml run is unaffected
 matlab:
   entry: recon.m
   runtime: r2026a

--- a/algorithms/inr-qsm/algorithm.yml
+++ b/algorithms/inr-qsm/algorithm.yml
@@ -33,6 +33,7 @@ code_url: https://github.com/AMRI-Lab/INR-QSM
 license: none declared (no LICENSE in repo); academic use, cite the paper
 image: ghcr.io/astewartau/qsm-ci/inr-qsm:v2
 run: bash run.sh
+smoke_box: 32   # PR --smoke gate fits a 32^3 central box (fast); full score.yml run is unaffected
 # Route to QSM-CI's 31 GB self-hosted runner: the full-size CPU optimization OOMs GitHub's 16 GB
 # hosted box and needs more than the hosted 180-min budget. Only 2 self-hosted jobs run at once.
 runner: self-hosted

--- a/algorithms/modip/algorithm.yml
+++ b/algorithms/modip/algorithm.yml
@@ -29,6 +29,7 @@ code_url: https://github.com/sunhongfu/MoDIP
 license: none declared (no LICENSE in repo); academic use, cite the paper
 image: ghcr.io/astewartau/qsm-ci/modip:v2
 run: bash run.sh
+smoke_box: 32   # PR --smoke gate fits a 32^3 central box (fast); full score.yml run is unaffected
 # Runs on the public runner but with the full 6-h GitHub cap (not the 180-min default) and its own
 # container, since the per-subject CPU optimization (epoch_num iterations) exceeds 180 min but fits
 # the 16 GB hosted box at base=32. Avoids depending on the private self-hosted runners.


### PR DESCRIPTION
## Rebuild amp-pe (wavelet fix) + smoke_box for the heavy methods

### amp-pe was broken on in-silico
`amp-pe` scored **~4366% NRMSE** on the in-silico phantom — worse than doing
nothing. Cause: its wavelet transform needs each dimension divisible by
`2^nlevel`, but the challenge phantom is **164×205×205** (none divisible by 8),
so the sparsifying transform produced garbage. The `recon.m` padding fix (pad →
reconstruct → crop) was merged earlier **but the image was never rebuilt**.

Recompiled `recon.m` (`mcc`, R2026a + Wavelet Toolbox), pushed **`amp-pe:v2`**, and
verified on the full 164×205×205 volume: output is finite and **NRMSE drops
4366% → 187%**. `algorithm.yml` now points at `:v2`.

### smoke_box for amp-pe / modip / inr-qsm
These three (MATLAB / 500-epoch DIP / SIREN) take 2–3 h on CPU even on the smoke
crop, so they time out the PR `evaluate` gate (they only "passed" #131 because
`main` isn't branch-protected). Add **`smoke_box: 32`** (same mechanism
`decompose-qsm` uses) so the gate fits a 32³ central box and finishes in minutes.
**Affects the PR smoke gate only — `score.yml` full scoring is unchanged.**

This PR is execution-relevant, so `evaluate` will smoke these three on the small
box — which also confirms amp-pe:v2 runs and emits a valid output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
