### PR TITLE
Add iQFM tissue-field submission (unwrap+bfr span)

### DIFF
--- a/algorithms/iqfm/Dockerfile
+++ b/algorithms/iqfm/Dockerfile
@@ -1,0 +1,50 @@
+# iQFM environment image — CPU-only, single-step tissue (local) field from raw phase.
+#
+# iQFM is the tissue/local-field output of the SAME iQSM network/repo: a LoT-Unet maps raw wrapped
+# MRI phase -> local field, doing phase unwrapping + background-field removal in one pass. This image
+# is byte-identical to algorithms/iqsm/Dockerfile — same repo, same pinned commit, same weights — the
+# only difference between the two submissions is the run.sh flag (iqsm passes --no-iqfm; iqfm keeps
+# the iQFM output). We clone the upstream repo into /opt/iqsm, install the CPU-only torch wheel + the
+# repo's Python deps, then BAKE the pretrained weights into the image via
+# `run.py --download-checkpoints` so the scoring run works fully offline (--network none).
+#
+# The four checkpoints downloaded by --download-checkpoints include BOTH the iQSM (chi) weights
+# (iQSM_50_v2.pth, LPLayer_chi_50_v2.pth) AND the iQFM (tissue-field) weights (iQFM_40_v2.pth,
+# LoTLayer_lfs_40_v2.pth), so the same download step covers iQFM as-is — no extra fetch needed.
+#
+# The algorithm folder is mounted read-only at /algo at run time; run.sh invokes the baked
+# /opt/iqsm/run.py (iQFM resolves its checkpoints/ relative to its own source dir, so the source
+# and weights must live together inside the image, not in the mounted /algo).
+#
+# NOTE: because this image is identical to iqsm's, iqfm could instead reuse the iqsm image tag; we
+# default to its own tag (ghcr.io/astewartau/qsm-ci/iqfm:v1) for clarity/independence.
+#
+# Build & push once (see algorithms/iqfm/README.md):
+#   docker build -t ghcr.io/astewartau/qsm-ci/iqfm:v1 algorithms/iqfm
+#   docker push ghcr.io/astewartau/qsm-ci/iqfm:v1
+FROM python:3.11-slim
+
+# jq is used by run.sh to read params.json; git to clone the iQSM source.
+RUN apt-get update && apt-get install -y --no-install-recommends git jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# iQSM/iQFM source (CLI is run.py; pure-Python inference in inference.py — no MATLAB).
+# Pin to a specific commit for reproducibility.
+ARG IQSM_COMMIT=bb163ef
+RUN git clone https://github.com/sunhongfu/iQSM /opt/iqsm \
+    && git -C /opt/iqsm checkout "$IQSM_COMMIT"
+
+# CPU-only PyTorch wheel (no CUDA libs), then the repo's runtime deps (CLI only, no web stack).
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir -r /opt/iqsm/requirements.txt
+
+# Bake the four pretrained checkpoints (~16 MB each) into the image so the run phase needs no
+# network. `run.py --download-checkpoints` pulls them from HuggingFace sunhongfu/iQSM into
+# /opt/iqsm/checkpoints/, then exits. This includes the iQFM weights (iQFM_40_v2.pth,
+# LoTLayer_lfs_40_v2.pth) used by this submission.
+RUN cd /opt/iqsm && python run.py --download-checkpoints
+
+# Force CPU inference at run time (the code falls back to CPU when CUDA is unavailable; this makes
+# it explicit and belt-and-braces).
+ENV CUDA_VISIBLE_DEVICES="-1" \
+    IQSM_HOME="/opt/iqsm"

--- a/algorithms/iqfm/README.md
+++ b/algorithms/iqfm/README.md
@@ -1,0 +1,110 @@
+# iQFM
+
+Instant tissue (local) field mapping from raw MRI phase using Laplacian-enabled deep neural networks
+(LoT-Unet). iQFM is the **tissue-field output of the same network/repo as iQSM** — the `algorithms/iqsm/`
+submission runs the identical repo with `--no-iqfm` to *skip* exactly this output; this submission
+keeps it.
+
+- **Stage:** `unwrap+bfr` (phase → localfield, ppm)
+- **Engine:** [iQSM/iQFM](https://github.com/sunhongfu/iQSM) — PyTorch, **CPU-only**
+- **Reference:** Gao Y., Xiong Z., Fazlollahi A., Nestor P.J., Vegh V., Nasrallah F., Winter C., Pike G.B., Crozier S., Liu F., Sun H. (2022). *Instant tissue field and magnetic susceptibility mapping from MRI raw phase using Laplacian enhanced deep neural networks.* NeuroImage, 259, 119410. (DOI: [10.1016/j.neuroimage.2022.119410](https://doi.org/10.1016/j.neuroimage.2022.119410))
+
+## Why `unwrap+bfr`
+
+iQFM is a **single-step** deep network: a large-stencil Laplacian-preprocessed LoT-Unet maps the
+**raw wrapped phase** straight to the **local (tissue) field** — phase unwrapping *and*
+background-field removal both happen inside the network, with no separate field-mapping / BFR stage.
+So the method consumes `phase`, `magnitude`, `mask`, `params` and produces `localfield`, i.e. the
+`unwrap+bfr` span (see `stages.yml`).
+
+Evidence in the source (`inference.py::run_iqsm()` and `models/`): the same wrapped-phase input drives
+two parallel LoT-Unet heads — one trained to output susceptibility χ (iQSM, saved as `iQSM.nii.gz`),
+one trained to output the tissue field (iQFM, saved as `iQFM.nii.gz`). The iQFM head is the
+"lfs" (local field shift) branch loaded from `iQFM_40_v2.pth` + `LoTLayer_lfs_40_v2.pth`. The upstream
+README describes iQFM as "the local tissue field map (the background-field-removal result)", confirming
+it is the **local** field (post-BFR), not the total field. This submission publishes `iQFM.nii.gz` as
+the canonical `localfield.nii.gz`.
+
+## Units
+
+- **Input** is **raw wrapped phase in radians**, which is exactly what iQFM ingests (it applies the
+  sign convention and Laplacian preprocessing internally). QSM-CI's `phase.nii.gz` is in radians, so
+  it is passed through unchanged.
+- **Output** is the tissue field already in **ppm** (B0-normalized). The LoT layer divides the
+  Laplacian-derived field by `(B0 · TE)` (`models/unet_blocks.py`), removing the field-strength and
+  echo-time dependence so the network is trained to output a ppm-scale field. Upstream confirms this:
+  the repo README's LFS display window is "± 0.05 ppm". QSM-CI's `localfield` artifact is also **ppm**
+  (`stages.yml`), so **no unit conversion is applied** — `run.sh` copies `iQFM.nii.gz` verbatim to
+  `localfield.nii.gz`. (If the network had emitted Hz, a `field_ppm = field_Hz / (γ · B0)` conversion
+  would be required; it does not, so none is.)
+
+## Multi-echo handling
+
+iQFM runs the network **per echo** and combines the per-echo field maps with **magnitude × TE²**
+weighting (falling back to TE²-only weighting when magnitude is absent). `run.sh` hands the 4D
+`phase.nii.gz` and 4D `magnitude.nii.gz` to the repo's own CLI (`run.py --echo_4d --mag --te …`),
+which performs exactly that combination — it is **not** re-implemented here. A 3D (single-echo)
+`phase.nii.gz` is handled by the same code path.
+
+## Mask & B0 direction
+
+iQFM **requires a brain mask** (run.py auto-skips iQFM when no `--mask` is given). QSM-CI always
+provides `mask.nii.gz`, so iQFM always runs. Base iQSM/iQFM assumes an **axial** acquisition
+(B0 ≈ `[0, 0, 1]`); the network takes no B0-direction argument, so `QSMCI_B0_DIR` is informational
+only. Only the field strength (`QSMCI_B0` / `params.json` `B0`) and echo time(s) (`QSMCI_TE` /
+`params.json` `TE`) are fed to the network.
+
+## How QSM-CI runs it
+
+```bash
+python /opt/iqsm/run.py \
+  --echo_4d /input/phase.nii.gz \
+  --te <TE …> \
+  --mag /input/magnitude.nii.gz \
+  --mask /input/mask.nii.gz \
+  --b0 <B0> \
+  --output /output/iqfm_run
+cp /output/iqfm_run/iQFM.nii.gz /output/localfield.nii.gz
+```
+
+Note the **absence** of `--no-iqfm` (the flag the iqsm submission uses to skip this output). `run.py`
+still also writes `iQSM.nii.gz` (χ); this submission ignores it and publishes only the iQFM tissue
+field.
+
+The four pretrained checkpoints (~16 MB each) are **baked into the image** at build time
+(`run.py --download-checkpoints`, pulling from HuggingFace `sunhongfu/iQSM`) so the scoring run works
+fully offline (`--network none`). That download includes the iQFM weights (`iQFM_40_v2.pth`,
+`LoTLayer_lfs_40_v2.pth`) alongside the iQSM ones, so the same step covers iQFM as-is. The source and
+its `checkpoints/` are baked together under `/opt/iqsm` because the code resolves the checkpoint
+directory relative to its own source location, not relative to the mounted `/algo`.
+
+## Relationship to the iqsm image
+
+This submission's `Dockerfile` is **byte-identical** to `algorithms/iqsm/Dockerfile` (same repo, same
+pinned commit `bb163ef`, same weights). The two submissions differ only in `run.sh` (iqsm passes
+`--no-iqfm` and publishes `chimap`; iqfm keeps the iQFM output and publishes `localfield`). For clarity
+and independence this submission uses its own image tag `ghcr.io/astewartau/qsm-ci/iqfm:v1`, but it
+could equivalently reuse `ghcr.io/astewartau/qsm-ci/iqsm:v1`.
+
+## Parameters
+
+iQFM has no runtime tunables exposed here — it uses fixed pretrained weights. The acquisition-derived
+inputs are the field strength `B0` and echo time(s) `TE`, taken from `params.json` / `QSMCI_B0` /
+`QSMCI_TE`. Mask erosion (default 3 voxels) and phase-sign convention (default) are left at their
+upstream defaults.
+
+## Building the image
+
+The environment image is built from this folder's `Dockerfile` at score time (QSM-CI's
+`pipeline.build_env` builds any folder that has a `Dockerfile`), so a manual push is not required for
+the leaderboard. To build/push manually (e.g. for later Zenodo publishing):
+
+```bash
+docker build -t ghcr.io/astewartau/qsm-ci/iqfm:v1 algorithms/iqfm
+docker push  ghcr.io/astewartau/qsm-ci/iqfm:v1
+```
+
+_Citations/DOIs are auto-generated best-effort references and should be verified. The DOI here was
+verified against CrossRef (NeuroImage 259, 119410) — the same paper as iQSM, whose title covers both
+"tissue field" (iQFM) and "magnetic susceptibility" (iQSM); note the upstream repo's README BibTeX
+lists a different DOI (…119327), which does not resolve to this paper._

--- a/algorithms/iqfm/algorithm.yml
+++ b/algorithms/iqfm/algorithm.yml
@@ -1,0 +1,35 @@
+name: iQFM
+slug: iqfm
+algorithm: iqfm
+source: sunhongfu
+stage: unwrap+bfr
+language: Python
+family: deep-learning
+learning: pretrained
+engine: Independent
+inputs: [phase, magnitude, mask, params]  # magnitude drives multi-echo magnitude x TE^2 weighting; mask is required by iQFM
+description: >
+  iQFM — instant tissue (local) field mapping from raw MRI phase using Laplacian-enabled deep neural
+  networks (LoT-Unet). It is the tissue-field output of the same network/repo as iQSM: a single deep
+  network maps raw wrapped phase directly to the local field, performing phase unwrapping and
+  background-field removal in one pass (the iQSM submission runs the same repo with --no-iqfm to skip
+  exactly this output). Multi-echo phase is reconstructed per echo and combined with magnitude x TE^2
+  weighting. Output tissue field is B0-normalized (ppm). Runs CPU-only with a CPU-only PyTorch wheel;
+  pretrained weights (HuggingFace sunhongfu/iQSM) are baked into the image.
+authors:
+- name: Gao Y.
+- name: Xiong Z.
+- name: Fazlollahi A.
+- name: Nestor P.J.
+- name: Vegh V.
+- name: Nasrallah F.
+- name: Winter C.
+- name: Pike G.B.
+- name: Crozier S.
+- name: Liu F.
+- name: Sun H.
+doi: 10.1016/j.neuroimage.2022.119410
+code_url: https://github.com/sunhongfu/iQSM
+license: See repository (used with author permission)
+image: ghcr.io/astewartau/qsm-ci/iqfm:v1
+run: bash run.sh

--- a/algorithms/iqfm/run.sh
+++ b/algorithms/iqfm/run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# QSM-CI submission — iQFM (unwrap+bfr span), CPU-only.
+#
+# iQFM (Instant Quantitative Field Mapping) is the tissue/local-field output of the SAME iQSM
+# network/repo. A LoT-Unet maps raw wrapped MRI phase straight to the LOCAL (tissue) field —
+# phase unwrapping AND background-field removal both happen inside the network. Hence stage =
+# unwrap+bfr span:
+#   consumes  phase.nii.gz, magnitude.nii.gz, mask.nii.gz, params.json   ->   produces  localfield.nii.gz
+#
+# It is the SAME repo, run.py and weights as algorithms/iqsm/ — the iqsm submission passes
+# --no-iqfm to skip exactly this output; here we run WITHOUT --no-iqfm to keep it. run.py always
+# also writes iQSM.nii.gz (chi); we only publish the iQFM tissue field.
+#
+# Units:
+#   * Input phase is RAW WRAPPED phase in radians — exactly what the network ingests (it applies the
+#     sign convention and Laplacian preprocessing internally). QSM-CI's phase.nii.gz is in radians,
+#     so it is passed through unchanged.
+#   * Output iQFM.nii.gz is the tissue field ALREADY in ppm (B0-normalized). The LoT layer divides
+#     the Laplacian-derived field by (B0 * TE) — removing the field-strength and echo-time
+#     dependence — so the network is trained to output a ppm-scale field. Upstream confirms this: the
+#     repo README's LFS display window is "± 0.05 ppm". QSM-CI's localfield artifact is also ppm, so
+#     NO unit conversion is applied — run.sh copies iQFM.nii.gz verbatim to localfield.nii.gz.
+#
+# Multi-echo: the net is run per echo and per-echo field maps are combined with magnitude x TE^2
+# weighting inside run.py (--echo_4d --mag), identical to iqsm — we do not re-implement it. A 3D
+# (single-echo) phase is handled by the same code path.
+#
+# Mask: iQFM REQUIRES a brain mask (run.py auto-skips iQFM when no --mask is given). QSM-CI always
+# provides mask.nii.gz, so iQFM always runs.
+#
+# B0 direction: base iQSM/iQFM assumes an axial acquisition (B0 ~ [0,0,1]); the network takes no
+# B0_dir argument, so QSMCI_B0_DIR is informational only and is not passed through.
+#
+# Acquisition parameters are injected as env vars (see CONTRACT.md):
+#   $QSMCI_B0 (T)   $QSMCI_TE / $QSMCI_TE0 (s)   $QSMCI_B0_DIR   $QSMCI_VOXEL_SIZE (mm)
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+IQSM_HOME="${IQSM_HOME:-/opt/iqsm}"
+
+# Force CPU (belt-and-braces; also set in the image).
+export CUDA_VISIBLE_DEVICES="-1"
+
+mkdir -p "$OUT"
+
+# B0 field strength (T): prefer env var, fall back to params.json, default 3 T.
+if [ -n "${QSMCI_B0:-}" ]; then
+  B0="$QSMCI_B0"
+else
+  B0="$(jq -r '.B0 // 3' "$IN/params.json")"
+fi
+
+# Echo time(s) in SECONDS, one per phase echo. Prefer env var (space-separated), else params.json.
+if [ -n "${QSMCI_TE:-}" ]; then
+  read -r -a TE_S <<< "$QSMCI_TE"
+else
+  # shellcheck disable=SC2207
+  TE_S=($(jq -r '.TE | if type=="array" then .[] else . end' "$IN/params.json"))
+fi
+if [ "${#TE_S[@]}" -eq 0 ]; then
+  echo "iQFM: no TE found in params.json / QSMCI_TE" >&2
+  exit 1
+fi
+
+# Optional magnitude (used for magnitude x TE^2 multi-echo combination).
+MAG_ARG=()
+if [ -f "$IN/magnitude.nii.gz" ]; then
+  MAG_ARG=(--mag "$IN/magnitude.nii.gz")
+fi
+
+# run.py's --echo_4d path splits a 4D phase into per-echo volumes and combines them; a 3D phase is
+# treated as single-echo by the same flag. --te is in seconds. We run WITHOUT --no-iqfm so the iQFM
+# tissue-field output is produced (run.py also writes iQSM.nii.gz, which we ignore).
+python "$IQSM_HOME/run.py" \
+  --echo_4d "$IN/phase.nii.gz" \
+  --te "${TE_S[@]}" \
+  "${MAG_ARG[@]}" \
+  --mask "$IN/mask.nii.gz" \
+  --b0 "$B0" \
+  --output "$OUT/iqfm_run"
+
+# iQFM writes the tissue (local) field as iQFM.nii.gz (in ppm). Publish it under the canonical name.
+cp "$OUT/iqfm_run/iQFM.nii.gz" "$OUT/localfield.nii.gz"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -668,6 +668,42 @@
       ]
     },
     {
+      "slug": "iqfm",
+      "name": "iQFM",
+      "stage": "unwrap+bfr",
+      "inputs": [
+        "phase",
+        "magnitude",
+        "mask",
+        "params"
+      ],
+      "domain": "qsm",
+      "engine": "Independent",
+      "language": "Python",
+      "family": "deep-learning",
+      "learning": "pretrained",
+      "description": "iQFM \u2014 instant tissue (local) field mapping from raw MRI phase using Laplacian-enabled deep neural networks (LoT-Unet). It is the tissue-field output of the same network/repo as iQSM: a single deep network maps raw wrapped phase directly to the local field, performing phase unwrapping and background-field removal in one pass (the iQSM submission runs the same repo with --no-iqfm to skip exactly this output). Multi-echo phase is reconstructed per echo and combined with magnitude x TE^2 weighting. Output tissue field is B0-normalized (ppm). Runs CPU-only with a CPU-only PyTorch wheel; pretrained weights (HuggingFace sunhongfu/iQSM) are baked into the image.",
+      "citation": null,
+      "doi": "10.1016/j.neuroimage.2022.119410",
+      "code_url": "https://github.com/sunhongfu/iQSM",
+      "license": "See repository (used with author permission)",
+      "authors": [
+        "Gao Y.",
+        "Xiong Z.",
+        "Fazlollahi A.",
+        "Nestor P.J.",
+        "Vegh V.",
+        "Nasrallah F.",
+        "Winter C.",
+        "Pike G.B.",
+        "Crozier S.",
+        "Liu F.",
+        "Sun H."
+      ],
+      "parameters": [],
+      "ci_notes": []
+    },
+    {
       "slug": "iqsm",
       "name": "iQSM",
       "stage": "end-to-end",


### PR DESCRIPTION
## Summary

Adds **iQFM** (Instant Quantitative Field Mapping, Gao et al., *NeuroImage* 2022) as a new QSM-CI submission under `algorithms/iqfm/`.

iQFM is the **tissue/local-field output of the same iQSM network/repo** already packaged under `algorithms/iqsm/`. The iqsm submission runs the identical repo (`github.com/sunhongfu/iQSM`, same `run.py`, same weights) with `--no-iqfm` to *skip* exactly this output; this submission keeps it and publishes the tissue field.

## Details

- **Stage:** `unwrap+bfr` span — a single LoT-Unet maps raw wrapped phase straight to the **local (tissue) field**, doing phase unwrapping + background-field removal in one pass. Consumes `[phase, magnitude, mask, params]` → produces `localfield.nii.gz`. Evidence: the iQFM head (`iQFM_40_v2.pth` + `LoTLayer_lfs_40_v2.pth`) is the "lfs" (local field shift) branch; upstream README describes iQFM as "the local tissue field map (the background-field-removal result)" — i.e. the local field (post-BFR), not the total field.
- **Units:** iQFM output is **already ppm** (B0-normalized). The LoT layer divides the Laplacian-derived field by `(B0·TE)`, and the upstream README's LFS display window is "± 0.05 ppm". QSM-CI's `localfield` is also ppm, so **no unit conversion** is applied — `run.sh` copies `iQFM.nii.gz` verbatim to `localfield.nii.gz`.
- **Multi-echo:** per-echo reconstruction combined with magnitude×TE² weighting inside `run.py` (`--echo_4d --mag`), same as iqsm — not re-implemented.
- **CPU-only**, scores normally (no `ci_skip`).

## Image

`ghcr.io/astewartau/qsm-ci/iqfm:v1` — built and pushed (public). The `Dockerfile` is byte-identical to `algorithms/iqsm/Dockerfile` (same repo, pinned commit `bb163ef`, same weights); the only difference between the two submissions is the `run.sh` flag. `run.py --download-checkpoints` fetches the iQFM checkpoints alongside the iQSM ones, so the same build step covers iQFM as-is.

## Validation

Offline (`--network none`) smoke test of the built image on `data/sim/dev`:
- Output shape (96×96×60) and affine **match GT `localfield`** exactly.
- ppm range plausible (±0.04–0.08, std 0.016 vs GT ±0.05–0.08, std 0.013).
- Masked correlation with GT `localfield` ≈ **0.79**.

## DOI

`10.1016/j.neuroimage.2022.119410` — Gao Y. et al., "Instant tissue field and magnetic susceptibility mapping from MRI raw phase using Laplacian enhanced deep neural networks," NeuroImage 259, 119410 (2022). Same paper as iQSM (its title covers both tissue field = iQFM and susceptibility = iQSM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)