### PR TITLE
fix(iqfm): route focused rescore to self-hosted runner

### DIFF
--- a/algorithms/iqfm/algorithm.yml
+++ b/algorithms/iqfm/algorithm.yml
@@ -33,3 +33,9 @@ code_url: https://github.com/sunhongfu/iQSM
 license: See repository (used with author permission)
 image: ghcr.io/astewartau/qsm-ci/iqfm:v1
 run: bash run.sh
+# iQFM is unwrap+bfr (produces a local field), so its focused rescore composes the field against the
+# whole dipole set (~27 CPU methods, incl. slow MEDI/FANSI/MATLAB). That row doesn't fit the hosted
+# 180-min cap at 2 containers — the unsharded focus job timed out mid-MEDI (run 31077670193). Route to
+# the 31 GB self-hosted runners (360-min cap, 4 concurrent containers) so the full row completes. Only
+# 2 self-hosted jobs run at once.
+runner: self-hosted


### PR DESCRIPTION
## Problem

The iQFM focused rescore ([run 31077670193](https://github.com/QSMxT/QSM-CI/actions/runs/31077670193)) timed out at the hosted 3-hour cap and published nothing — iQFM's row is missing from the leaderboard.

iQFM is `stage: unwrap+bfr`, so it produces a local field, not a chimap. To score it, the pipeline (`--mode both`) composes that field against **every dipole method** — ~27 CPU methods including the slow iterative/MATLAB ones (MEDI, FANSI, matlab-sti-*). In a full `scope=all` run this row is column-sharded across 12 runners and fits; but a **focused per-slug** rescore (what a single-algorithm push triggers) runs the whole unsharded row on one `ubuntu-latest` runner at 2 containers. In 3h it got through ~16 of ~27 methods and was killed mid-MEDI.

## Fix

Route iQFM to the self-hosted runners (`runner: self-hosted`): 360-min cap, 4 concurrent containers, 31 GB RAM — enough for the full row to complete. Same pattern already used for `inr-qsm` / `decompose-qsm`. `hosted-long` was rejected: it doubles the time but halves parallelism (`jobs: 1`), and this is throughput-bound, so it would still time out.

Merging this triggers a focused iQFM rescore on the self-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)