### PR TITLE
feat(chisep): add APART-QSM source-separation submission (parked, ci_skip)

### DIFF
--- a/.github/workflows/image-access.yml
+++ b/.github/workflows/image-access.yml
@@ -45,7 +45,15 @@ jobs:
           slugs=$(git diff --name-only origin/${{ github.base_ref }}... \
                   | grep '^algorithms/' | cut -d/ -f2 | grep -v '^_' | sort -u \
                   | while read -r s; do
-                      if [ -f "algorithms/$s/algorithm.yml" ]; then echo "$s"; fi
+                      f="algorithms/$s/algorithm.yml"
+                      [ -f "$f" ] || continue
+                      # A parked submission (ci_skip: true) is never run or scored, so its image need
+                      # not exist / be pullable yet — mirror the evaluate.yml + discover_algorithms skip.
+                      if grep -qiE '^ci_skip:[[:space:]]*true\b' "$f"; then
+                        echo "::notice::$s is ci_skip (parked) — image not required, skipping gate" >&2
+                        continue
+                      fi
+                      echo "$s"
                     done)
 
           if [ -z "$slugs" ]; then

--- a/algorithms/apart-qsm/BUILD.md
+++ b/algorithms/apart-qsm/BUILD.md
@@ -1,0 +1,88 @@
+# APART-QSM — vendor, compile, image, score (deferred Bunya steps)
+
+APART-QSM is a GRE-based (signal-domain) iterative source-separation method (Li/Wang et al.,
+*NeuroImage* 274:120148, 2023; https://github.com/AMRI-Lab/APART-QSM). Its core alternates a
+voxel-wise magnitude-decay ("a-map") fit with a TV-regularised χ+/χ− dipole inversion. Like DECOMPOSE
+it's a **per-voxel iterative** method, so its test/`mcc` build run where the toolboxes are (Bunya), and
+the first job is to **measure the runtime** before committing it to the leaderboard.
+
+## 0. BLOCKER — the public repo does NOT ship the core solver (READ FIRST)
+The published repo (commit `c49bad4`) contains ONLY:
+- `single_orientation/APART_QSM_single_ori_demo.m` and `multi_orientation/APART_QSM_multi_ori_demo.m`
+- helpers `dipole_kernel.m`, `gradient_mask_all.m`, the `@TVOP` finite-difference class
+- `.mat` test data.
+
+The actual solver **`apart_qsm_single_ori` (and `apart_qsm_multi_ori`) is NOT distributed** — the demos
+call it but the function file is absent from the repo (verified across the full git history). The
+vendored helpers alone cannot separate χ+/χ−. **Do not compile, image, or score until the core solver
+is obtained**, because there is nothing to compile against yet.
+
+To unblock, obtain `apart_qsm_single_ori.m` (and any private helpers it needs) from the authors
+(AMRI-Lab / Hongjiang Wei, SJTU) — e.g. open an issue on the repo or email — then either:
+- place it under `algorithms/apart-qsm/apart_core/` and add `-a apart_core` at `mcc` time, or
+- point `$APART_CORE` at it for an uncompiled local run.
+
+`recon.m` is authored to the **published demo call convention**:
+`Res_map = apart_qsm_single_ori(mag_img, phi_local_img, r2_img, chi_img, params)` with
+`Res_map(:,:,:,1)=X_para (χ+, ppm)`, `Res_map(:,:,:,2)=X_dia_abs (|χ−|, ppm)`. If the obtained solver's
+signature or `params` fields differ, adjust `recon.m` accordingly before compiling.
+
+## What this submission consumes / produces
+Stage `chi-separation` — declares `inputs: [magnitude, localfield, r2prime, chimap, mask, params]`
+(a subset of the stage's `consumes`; no raw `phase` needed). Produces `chi-para` (χ+) + `chi-dia`
+(χ−, positive magnitude). Adaptation vs. the reference demo:
+- The demo takes **per-echo local phase** `phi_local_img`. The stage provides a single 3D local field
+  (`localfield.nii.gz`, ppm); `recon.m` synthesises the per-echo local phase from it
+  (`phi = localfield·1e-6·γ·B0·TE`, χ being echo-independent), so no raw phase / in-house
+  unwrap+BFR+QSM is required and APART's separation step is isolated from upstream error.
+- The demo's `chi_img` is an initial STAR-QSM; we pass the provided χ_total (`chimap.nii.gz`).
+- The demo's `r2_img` is passed as the provided `r2prime.nii.gz` (Hz). If the obtained solver expects
+  R2 (total) rather than R2′, revisit this — the chisep phantom only provides R2′.
+- Magnitude-decay kernel `params.a` defaults to the phantom's `Dr = 137 Hz/ppm`
+  (data/sim/chisep/README.md), not the demo's 3T value of 323.5.
+
+## Vendored deps (committed here)
+- `apart_utils/` — the repo's published single-orientation helpers: `dipole_kernel.m`,
+  `gradient_mask_all.m`, `@TVOP/`. (No LICENSE in the repo — academic use, cite the paper.)
+- `nifti/` — Jimmy Shen NIfTI toolbox (`make_nii`/`save_nii`/`load_untouch_nii`), same as amp-pe.
+- **NOT committed (see §0):** `apart_core/` — the author-obtained solver `apart_qsm_single_ori.m`.
+
+## 1. Feasibility / speed test (once the core is in place)
+```bash
+module load matlab/R2023b
+export APART_CORE=.../apart-qsm/apart_core          # the author-obtained solver
+matlab -batch "addpath('algorithms/apart-qsm'); recon('data/sim/chisep/inputs','/tmp/apart_out')"
+```
+Time it on the full brain. If within a self-hosted score job's cap (e.g. 360 min, many cores), proceed;
+otherwise consider a `smoke_box`-only leaderboard entry or reduced iterations (changes results).
+Sanity-score the crop against GT:
+```bash
+python eval/qsm_eval.py --kind chisep --component para --recon /tmp/apart_out/chi-para.nii.gz \
+  --truth data/sim/chisep/groundtruth/chi-para.nii.gz --seg .../dseg.nii.gz --mask .../mask.nii.gz
+```
+
+## 2. Compile + image
+```bash
+cd algorithms/apart-qsm
+matlab -batch "addpath('nifti'); addpath('apart_utils'); addpath('apart_core'); \
+  mcc('-m','recon.m','-a','nifti','-a','apart_utils','-a','apart_core','-o','recon','-d','.')"
+docker build -t ghcr.io/astewartau/qsm-ci/apart-qsm:v1 .   # FROM matlab-runtime:r2023b + COPY recon
+docker push  ghcr.io/astewartau/qsm-ci/apart-qsm:v1        # then make the GHCR package public
+```
+`mcc` needs the **Optimization Toolbox** present at compile (the a-map / dipole fits use it, as in the
+DECOMPOSE build); confirm from the obtained solver whether it also uses the **Image Processing Toolbox**
+(morphology) — if so, either module-load it at compile or add IPT/SPT shims like `chi-sep-medi/shims/`.
+Compile on R2023b so the runtime base in the Dockerfile matches.
+
+## 3. Score on the chisep phantom
+Routed via `score.yml` on the canonical chisep phantom (χ+ and χ− scored against GT). `runner:
+self-hosted` + `smoke_box: 24` (PR --smoke gate fits only a 24³ central box; the full score run is
+unaffected).
+
+## Blockers / open items
+- **Missing core solver** (§0) — top blocker; nothing runs until it's obtained.
+- **R2 vs R2′** — confirm whether the solver's third argument is R2 (total) or R2′; the phantom provides
+  R2′ only.
+- **echoes / B0** — the phantom has 4 echoes at 7T; the demo used 6 echoes at 3T. Watch fit quality and
+  whether the a-map default needs re-tuning for 7T.
+- Held out of any PR until §0 is resolved and the feasibility run passes.

--- a/algorithms/apart-qsm/Dockerfile
+++ b/algorithms/apart-qsm/Dockerfile
@@ -1,0 +1,18 @@
+# MCR image for the compiled APART-QSM submission. Build the `recon` binary first (mcc, see BUILD.md),
+# then:
+#   docker build -t ghcr.io/astewartau/qsm-ci/apart-qsm:v1 .
+# apart_utils + the NIfTI toolbox + the (author-obtained) APART core solver are baked into `recon` at
+# compile time, so the image only needs the MATLAB Runtime (incl. the Optimization + Parallel Computing
+# Toolbox runtimes) + the binary. Compile on Bunya with R2023b (its MATLAB has the required toolboxes),
+# so the runtime base MUST be r2023b to match.
+# Dockerfile gitignored elsewhere → CI pulls the pushed image.
+FROM containers.mathworks.com/matlab-runtime:r2023b
+ENV AGREE_TO_MATLAB_RUNTIME_LICENSE=yes
+# The r2023b base doesn't put the MCR libs on the loader path, so the compiled binary can't find
+# libmwlaunchermain.so. Set it explicitly to the runtime lib dirs.
+ENV MCRROOT=/opt/matlabruntime/R2023b
+ENV LD_LIBRARY_PATH=${MCRROOT}/runtime/glnxa64:${MCRROOT}/bin/glnxa64:${MCRROOT}/sys/os/glnxa64:${MCRROOT}/extern/bin/glnxa64
+COPY recon /opt/qsm-ci/recon
+# 755 (not +x, which keeps the compiler's g/o mode): CI runs as a non-root user that must be able to
+# READ the binary to extract its embedded CTF archive — o-r would fail with "Cannot find CTF".
+RUN chmod 755 /opt/qsm-ci/recon

--- a/algorithms/apart-qsm/algorithm.yml
+++ b/algorithms/apart-qsm/algorithm.yml
@@ -1,5 +1,7 @@
 name: APART-QSM
 slug: apart-qsm
+algorithm: apart-qsm
+source: li            # first author (Zhenghao Li); untagged -> slug = algorithm = apart-qsm
 stage: chi-separation
 language: MATLAB
 family: iterative

--- a/algorithms/apart-qsm/algorithm.yml
+++ b/algorithms/apart-qsm/algorithm.yml
@@ -1,0 +1,76 @@
+name: APART-QSM
+slug: apart-qsm
+stage: chi-separation
+language: MATLAB
+family: iterative
+learning: none
+engine: Independent
+inputs: [magnitude, localfield, r2prime, chimap, mask, params]  # GRE-based signal-domain source separation
+description: >
+  APART-QSM — an improved sub-voxel quantitative susceptibility mapping for susceptibility source
+  separation using an iterative data-fitting method. A GRE-based (signal-domain) classical source
+  separation: it alternately solves a voxel-wise magnitude-decay kernel (the "a-map") and the
+  sub-voxel χ+ (paramagnetic, iron) / χ− (diamagnetic, myelin/calcium) split via TV-regularised
+  dipole inversion over the multi-echo complex GRE signal. Handles an arbitrary number of complex GRE
+  measurements; supports single- and multi-orientation — QSM-CI runs it SINGLE-ORIENTATION on the
+  chisep phantom. Reads the multi-echo magnitude + the provided local field, R2′ and χ_total, and
+  writes the two source maps. Li/Wang et al., NeuroImage 2023.
+authors:
+- name: Zhenghao Li
+- name: Ruimin Feng
+- name: Qiangqiang Liu
+- name: Jianxun Feng
+- name: Guangbin Lao
+- name: Mengqi Zhang
+- name: Hongjiang Wei
+doi: 10.1016/j.neuroimage.2023.120148
+citation: >
+  Li Z. et al., "APART-QSM: An improved sub-voxel quantitative susceptibility mapping for
+  susceptibility source separation using an iterative data fitting method", NeuroImage 2023;274:120148.
+code_url: https://github.com/AMRI-Lab/APART-QSM
+# The APART-QSM repo ships NO LICENSE file. Treat as academic use; cite the paper.
+license: none declared (no LICENSE in repo); academic use, cite the paper
+image: ghcr.io/astewartau/qsm-ci/apart-qsm:v1
+run: bash run.sh
+runner: self-hosted   # iterative per-voxel a-map fit + repeated dipole inversions — slow, needs a long cap
+smoke_box: 24         # the iterative fit is slow: the PR --smoke gate limits to a 24³ central box (full score.yml run is unaffected)
+# ci_skip: true keeps this parked scaffold in the repo but tells the scorer NOT to run it — it CANNOT
+# run yet (the core solver is missing; see BLOCKER below). discover_algorithms() in scripts/pipeline.py
+# skips it in every mode and ci_eval_targets.py drops it from the PR smoke matrix. UN-SKIP once the
+# solver is obtained and dropped into apart_core/ (see BUILD.md §0), then let CI compile+score it.
+ci_skip: true
+matlab:
+  entry: recon.m
+  runtime: r2023b
+parameters:
+- name: a
+  default: 137
+  description: >
+    Magnitude decay kernel (Hz/ppm) initialising the voxel-wise a-map. The APART demo uses 323.5 at 3T;
+    our chisep phantom's R2′ model uses a single Dr=137 Hz/ppm kernel (data/sim/chisep/README.md), so
+    we default to 137.
+- name: tol_a
+  default: 0.3
+  description: Tolerance on the a-map relative change between consecutive iterations (reference default 0.3).
+- name: lambda_r2prime
+  default: 0.1
+  description: Scaling weight of the R2′-related data term (reference default 0.1).
+- name: lambda_chi
+  default: 10
+  description: Scaling weight of the χ (susceptibility) data-fidelity term (reference default 10, single-ori).
+- name: lambda_TV
+  default: 1
+  description: Total-variation regularisation weight on the source maps (reference default 1, single-ori).
+# ==================================== BLOCKER — MISSING CORE ====================================
+# The public APART-QSM repo (commit c49bad4) ships ONLY the demos + published helpers (dipole_kernel,
+# gradient_mask_all, @TVOP) and .mat test data — the core solver apart_qsm_single_ori is NOT
+# distributed. This submission is authored to the published call convention but is NOT runnable until
+# that solver is obtained from the authors and placed at $APART_CORE / apart_core/. See BUILD.md §0.
+# Do NOT compile the mcc binary, build the image, or score until the core is in place.
+# ================================================================================================
+# Inputs (isolated eval, fed ground truth): multi-echo magnitude + local field (ppm) + R2′ (Hz) +
+# χ_total (chimap, ppm) + mask + params. GRE-based/signal-domain, but adapted to consume the stage's
+# provided local field (converted to per-echo local phase, χ echo-independent) rather than raw phase,
+# so it isolates APART's separation step from upstream unwrap/BFR/QSM error and needs no `phase` input.
+# Produces chi-para (χ+) and chi-dia (χ−, positive magnitude). Compile the mcc binary + GHCR image on
+# Bunya (Optimization Toolbox required at compile), then this scores on the chisep phantom via score.yml.

--- a/algorithms/apart-qsm/apart_utils/@TVOP/TVOP.m
+++ b/algorithms/apart-qsm/apart_utils/@TVOP/TVOP.m
@@ -1,0 +1,10 @@
+function  res = TVOP()
+
+%res = TVOP()
+%
+% Implements a spatial finite-differencing operator.
+%
+
+res.adjoint = 0;
+res = class(res,'TVOP');
+

--- a/algorithms/apart-qsm/apart_utils/@TVOP/ctranspose.m
+++ b/algorithms/apart-qsm/apart_utils/@TVOP/ctranspose.m
@@ -1,0 +1,4 @@
+function res = ctranspose(a)
+a.adjoint = xor(a.adjoint,1);
+res = a;
+

--- a/algorithms/apart-qsm/apart_utils/@TVOP/mtimes.m
+++ b/algorithms/apart-qsm/apart_utils/@TVOP/mtimes.m
@@ -1,0 +1,15 @@
+function res = mtimes(a,b)
+
+
+if a.adjoint
+	res = adjD(b);
+
+else
+	res = D(b);
+
+end
+
+
+
+
+    

--- a/algorithms/apart-qsm/apart_utils/@TVOP/private/D.m
+++ b/algorithms/apart-qsm/apart_utils/@TVOP/private/D.m
@@ -1,0 +1,24 @@
+function res = D(image)
+
+%
+% res = D(image)
+%
+% image = a 3D image
+%
+% This function computes the finite difference transform of the image
+%
+% Related functions:
+%       adjD , invD 
+%
+%
+
+[sx,sy,sz] = size(image);
+
+Dx = image([2:end,end],:,:) - image;
+Dy = image(:,[2:end,end],:) - image;
+Dz = image(:,:,[2:end,end]) - image;
+
+%res = [sum(image(:))/sqrt(sx*sy); Dx(:);  Dy(:)]; 
+res = cat(4,Dx,Dy,Dz);
+
+

--- a/algorithms/apart-qsm/apart_utils/@TVOP/private/adjD.m
+++ b/algorithms/apart-qsm/apart_utils/@TVOP/private/adjD.m
@@ -1,0 +1,27 @@
+function res = adjD(y)
+
+%y1 = ones(imsize)*y(1)/sqrt(prod(imsize));
+%yx = (reshape(y(2:prod(imsize)+1), imsize(1), imsize(2)));
+%yy = (reshape(y(prod(imsize)+2:end), imsize(1), imsize(2)));
+
+res = adjDx(y(:,:,:,1)) + adjDy(y(:,:,:,2)) + adjDz(y(:,:,:,3));
+
+return;
+
+
+function res = adjDz(x)
+res = x(:,:,[1,1:end-1]) - x;
+res(:,:,1) = -x(:,:,1);
+res(:,:,end) = x(:,:,end-1);
+
+function res = adjDy(x)
+res = x(:,[1,1:end-1],:) - x;
+res(:,1,:) = -x(:,1,:);
+res(:,end,:) = x(:,end-1,:);
+
+function res = adjDx(x)
+res = x([1,1:end-1],:,:) - x;
+res(1,:,:) = -x(1,:,:);
+res(end,:,:) = x(end-1,:,:);
+
+

--- a/algorithms/apart-qsm/apart_utils/@TVOP/times.m
+++ b/algorithms/apart-qsm/apart_utils/@TVOP/times.m
@@ -1,0 +1,4 @@
+function res = times(a,b)
+
+res = mtimes(a,b);
+

--- a/algorithms/apart-qsm/apart_utils/dipole_kernel.m
+++ b/algorithms/apart-qsm/apart_utils/dipole_kernel.m
@@ -1,0 +1,89 @@
+% Generation of the Dipole Kernel
+%   D = dipole_kernel(matrix_size, voxel_size, B0_dir, ...)
+%
+%   output
+%   D - dipole kernel saved in Fourier space
+% 
+%   input
+%   matrix_size - the size of the matrix
+%   voxel_size - the size of a voxel
+%   B0_dir - the direction of the B0 field
+%   domain - 'imagespace' or 'kspace'
+%       Fourier domain expression:
+%       Salomir et al. Concepts in Magn Reson Part B 2003, 19(B):26-34
+%       Image domain expression: 
+%       Li et al. Magn Reson Med 2004, 51(5):1077-82
+%
+%
+%   Created by Tian Liu in 2008
+%   Modified by Tian Liu on 2011.02.01
+%   Last modified by Tian Liu on 2013.07.22
+
+
+
+
+
+function D=dipole_kernel(varargin)
+
+[matrix_size voxel_size B0_dir domain] = parse_inputs(varargin{:});
+
+if (B0_dir == 1)
+    B0_dir = [1 0 0 ]';
+elseif (B0_dir == 2)
+    B0_dir = [0 1 0 ]';
+elseif (B0_dir==3)
+    B0_dir = [0 0 1]';
+end
+
+if strcmp(domain,'kspace')
+    [Y,X,Z]=meshgrid(-matrix_size(2)/2:(matrix_size(2)/2-1),...
+        -matrix_size(1)/2:(matrix_size(1)/2-1),...
+        -matrix_size(3)/2:(matrix_size(3)/2-1));
+    
+    X = X/(matrix_size(1)*voxel_size(1));
+    Y = Y/(matrix_size(2)*voxel_size(2));
+    Z = Z/(matrix_size(3)*voxel_size(3));
+    
+    D = 1/3-  ( X*B0_dir(1) + Y*B0_dir(2) + Z*B0_dir(3) ).^2./(X.^2+Y.^2+Z.^2);
+    D(isnan(D)) = 0;
+%    D = fftshift(D);   
+    
+elseif strcmp(domain,'imagespace')
+    [Y,X,Z]=meshgrid(-matrix_size(2)/2:(matrix_size(2)/2-1),...
+        -matrix_size(1)/2:(matrix_size(1)/2-1),...
+        -matrix_size(3)/2:(matrix_size(3)/2-1));
+    
+    X = X*voxel_size(1);
+    Y = Y*voxel_size(2);
+    Z = Z*voxel_size(3);
+    
+    d = (3*( X*B0_dir(1) + Y*B0_dir(2) + Z*B0_dir(3)).^2 - X.^2-Y.^2-Z.^2)./(4*pi*(X.^2+Y.^2+Z.^2).^2.5);
+
+    d(isnan(d)) = 0;
+    D = fftn(fftshift(d));
+end
+
+
+end
+
+
+function [matrix_size voxel_size B0_dir domain] = parse_inputs(varargin)
+    
+    if size(varargin,2)<3
+        error('At least matrix_size, voxel_size and B0_dir are required');
+    end
+    
+    matrix_size = varargin{1};
+    voxel_size = varargin{2};
+    B0_dir = varargin{3};
+    domain = 'kspace';
+    
+    if size(varargin,2)>3
+        for k=4:size(varargin,2)
+            if strcmpi(varargin{k},'imagespace')
+                domain = 'imagespace';
+            end
+        end
+    end
+    
+end

--- a/algorithms/apart-qsm/apart_utils/gradient_mask_all.m
+++ b/algorithms/apart-qsm/apart_utils/gradient_mask_all.m
@@ -1,0 +1,62 @@
+function wG = gradient_mask_all(rawImage, Mask, percentage, kspaceFlag)
+%  wG = gradient_mask_all(rawImage, Mask, percentage)
+% Generate weighting using gradient of rawImage
+% with percentage of voxels in Mask to be edges
+%   
+% Authors: Xu Li
+% Affiliation: Radiology @ JHU
+% Email address: xuli@mri.jhu.edu
+% Updated 2019-06
+
+if nargin < 4
+    kspaceFlag = 0; % default in image sapce
+end
+
+rawImage = rawImage.*Mask;
+
+if kspaceFlag == 1      % calculated gradient in k-space
+    N = size(rawImage);
+    datatype = class(rawImage);
+    
+    % gradient operator in k-space
+    [k2,k1,k3] = meshgrid(0:N(2)-1, 0:N(1)-1, 0:N(3)-1);
+    k1 = cast(k1, datatype);
+    k2 = cast(k2, datatype);
+    k3 = cast(k3, datatype);
+    
+    fd1 = -1 + exp(2*pi*1i*k1/N(1));    % dimention 1
+    fd2 = -1 + exp(2*pi*1i*k2/N(2));    % dimention 2
+    fd3 = -1 + exp(2*pi*1i*k3/N(3));    % dimention 3
+
+    rawImagek = fftn(rawImage);
+
+    % gradient of initial estimation: 4D with gradx, grady, gradz
+    rawImageGrad = real(cat(4, ifftn(rawImagek.*fd1), ifftn(rawImagek.*fd2), ifftn(rawImagek.*fd3)));  
+else
+    TV = TVOP;                  % total varition class (3D finite difference operator)
+    rawImageGrad = TV*rawImage;
+end
+
+wG = abs(rawImageGrad);             % gradient norm
+
+% initial guess of the threshold
+wGtemp = sqrt(sum(wG.^2, 4));       % average over dimentions
+wG_thresh = prctile(wGtemp(Mask>0), percentage*100);  % threshold based on gradient norm, all positive
+
+denominator = sum(Mask(:)>0);          % voxel number in brain mask
+numerator = sum(wG(:)>wG_thresh);
+
+if  (numerator/denominator)>3*percentage       % in toal 3*percentage
+    while (numerator/denominator)>3*percentage
+        wG_thresh = wG_thresh*1.05;
+        numerator = sum(wG(:)>wG_thresh);
+    end
+else
+    while (numerator/denominator)<3*percentage
+        wG_thresh = wG_thresh*.95;
+        numerator = sum(wG(:)>wG_thresh);
+    end
+end
+
+% TV weighting
+wG = (wG<=wG_thresh);     % edge is 0, non-edge is 1 for regularization, note wG.^2 = wG

--- a/algorithms/apart-qsm/recon.m
+++ b/algorithms/apart-qsm/recon.m
@@ -1,0 +1,129 @@
+function recon(inp, out)
+% QSM-CI `chi-separation` stage — APART-QSM (Li/Wang et al., NeuroImage 274:120148, 2023;
+% github.com/AMRI-Lab/APART-QSM), a GRE-based (signal-domain) iterative sub-voxel susceptibility
+% source-separation method.
+%
+% APART-QSM alternately solves a voxel-wise magnitude-decay kernel (the "a-map") and the sub-voxel
+% χ+/χ− split via an iterative data-fitting scheme (per-echo complex GRE signal fit + TV-regularised
+% dipole inversion). Its core solver is `apart_qsm_single_ori`. See the demo
+% APART_QSM_single_ori_demo.m for the reference call convention:
+%
+%   Res_map = apart_qsm_single_ori(mag_img, phi_local_img, r2_img, chi_img, params)
+%     mag_img       [X Y Z nEcho]  multi-echo magnitude
+%     phi_local_img [X Y Z nEcho]  per-echo LOCAL (tissue) phase, radians
+%     r2_img        [X Y Z]        R2 map (Hz)
+%     chi_img       [X Y Z]        initial QSM / χ_total (ppm) (reference uses STAR-QSM)
+%     params        struct         mask,size,voxel_size,n_echo,TEs,gamma,B0,B0_dir,a,tol_a,lambdas
+%   Res_map(:,:,:,1)=X_para (χ+, ppm), (:,:,:,2)=X_dia_abs (|χ−|, ppm, POSITIVE magnitude).
+%
+% ============================ IMPORTANT — MISSING CORE SOLVER ============================
+% The public APART-QSM repo (AMR-Lab, commit c49bad4) ships ONLY the demos + helpers
+% (dipole_kernel, gradient_mask_all, @TVOP) and .mat test data. The actual solver
+% `apart_qsm_single_ori` / `apart_qsm_multi_ori` IS NOT DISTRIBUTED. This wrapper is written to the
+% published call convention but CANNOT run until that solver is obtained from the authors and placed
+% on the path ($APART_CORE or apart_core/). See BUILD.md §0. Do NOT compile/score until then.
+% ========================================================================================
+%
+% ADAPTATION for QSM-CI: the chi-separation stage provides a single 3D local field (localfield.nii.gz,
+% ppm) rather than per-echo local phase. Since χ (and hence the local field) is echo-independent, we
+% synthesise the per-echo local phase the demo expects from that field:
+%     phi_local(:,:,:,e) = localfield_ppm * 1e-6 * gamma_rad * B0 * TE(e)
+% We feed the provided χ_total (chimap.nii.gz) as the initial QSM, and the provided R2′ (r2prime.nii.gz,
+% Hz) as the R2 term. Writes chi-para.nii.gz (χ+, ppm) and chi-dia.nii.gz (χ−, POSITIVE magnitude, ppm).
+
+    % When run uncompiled, put the vendored deps on the path. In the compiled binary they are baked in
+    % by mcc (and the on-disk folders don't exist), so skip. $APART_CORE points at the (author-obtained)
+    % core solver directory; apart_utils/ holds the repo's published helpers; nifti/ is the NIfTI I/O.
+    if ~isdeployed
+        here = fileparts(mfilename('fullpath'));
+        addpath(fullfile(here, 'nifti'));
+        addpath(fullfile(here, 'apart_utils'));
+    end
+    addpath_env('APART_CORE', true);   % the author-obtained apart_qsm_single_ori solver (see BUILD.md §0)
+    addpath_env('APART_UTILS', true);  % override for the vendored helpers, if set
+    addpath_env('CHISEP_NIFTI', false);
+
+    %% ---- inputs ---------------------------------------------------------------------------------
+    p     = jsondecode(fileread(fullfile(inp, 'params.json')));
+    B0    = p.B0;                       % T
+    TE    = p.TE(:)';                   % echo times (s)
+    b0d   = p.B0_dir(:)';
+    vox   = p.voxel_size(:)';
+    gamma = 42.576;                     % gyromagnetic ratio (MHz/T), as in the APART demo
+    gamma_rad = gamma * 1e6 * 2*pi;     % rad/(s·T) for ppm->radians phase conversion
+
+    rd = @(f) double(getfield(read_niigz(fullfile(inp, f)), 'img'));
+    mag_multi_echo = rd('magnitude.nii.gz');        % [X Y Z nEcho]
+    localfield     = rd('localfield.nii.gz');       % ppm (single 3D tissue field)
+    r2prime        = rd('r2prime.nii.gz');          % Hz
+    chimap         = rd('chimap.nii.gz');           % χ_total (ppm) — initial QSM
+    mn   = read_niigz(fullfile(inp, 'mask.nii.gz'));
+    mask = double(mn.img) > 0.5;
+
+    [N1, N2, N3, nTE] = size(mag_multi_echo);
+    if numel(TE) ~= nTE
+        error('APART: params TE has %d entries but magnitude has %d echoes', numel(TE), nTE);
+    end
+
+    % Synthesise per-echo local phase (radians) from the provided single 3D local field (ppm). χ is
+    % echo-independent, so the local field scales linearly with TE (see header note).
+    phi_local = zeros(N1, N2, N3, nTE);
+    for e = 1:nTE
+        phi_local(:,:,:,e) = (localfield * 1e-6 * gamma_rad * B0 * TE(e)) .* mask;
+    end
+    mag_multi_echo = mag_multi_echo .* mask;
+
+    %% ---- parameters (overridable via /input/config.json) ---------------------------------------
+    cfg = struct();
+    cfgPath = fullfile(inp, 'config.json');
+    if exist(cfgPath, 'file') == 2; cfg = jsondecode(fileread(cfgPath)); end
+    gv = @(name, def) getcfg(cfg, name, def);
+
+    params = struct();
+    params.mask          = mask;
+    params.size          = [N1 N2 N3];
+    params.voxel_size    = vox;
+    params.n_echo        = nTE;
+    params.TEs           = TE(:);
+    params.gamma         = gamma;
+    params.B0            = B0;
+    params.B0_dir        = b0d;
+    % magnitude decay kernel (Hz/ppm). The demo uses 323.5 at 3T; our chisep phantom's R2′ model uses
+    % a single Dr=137 Hz/ppm kernel (data/sim/chisep/README.md). Default to the phantom's value.
+    params.a             = gv('a', 137);
+    params.tol_a         = gv('tol_a', 0.3);
+    params.lambda_r2prime = gv('lambda_r2prime', 0.1);
+    params.lambda_chi     = gv('lambda_chi', 10);
+    params.lambda_TV      = gv('lambda_TV', 1);
+
+    %% ---- run APART-QSM -------------------------------------------------------------------------
+    fprintf('APART: single-orientation separation, %d echoes, a=%.1f Hz/ppm\n', nTE, params.a);
+    Res_map = apart_qsm_single_ori(mag_multi_echo, phi_local, r2prime, chimap, params);
+
+    X_para    = Res_map(:,:,:,1);   % χ+ (ppm)
+    X_dia_abs = Res_map(:,:,:,2);   % |χ−| (ppm, already a positive magnitude in the reference output)
+
+    %% ---- write canonical artifacts -------------------------------------------------------------
+    % χ− ground truth is stored as a POSITIVE magnitude (stages.yml / chisep README); the reference's
+    % X_dia_abs is already |χ−|, so take abs() defensively to match the sign convention.
+    write_niigz(setimg(mn, single(X_para .* mask)),        fullfile(out, 'chi-para.nii.gz'));  % χ+
+    write_niigz(setimg(mn, single(abs(X_dia_abs) .* mask)), fullfile(out, 'chi-dia.nii.gz'));  % χ−
+end
+
+function v = getcfg(cfg, name, def)
+    if isstruct(cfg) && isfield(cfg, name) && ~isempty(cfg.(name)); v = cfg.(name); else; v = def; end
+end
+function addpath_env(name, recurse)
+    d = getenv(name);
+    if ~isempty(d); if recurse; addpath(genpath(d)); else; addpath(d); end; end
+end
+function nii = setimg(tmpl, img)
+    nii = tmpl; nii.img = img;
+    nii.hdr.dime.datatype = 16; nii.hdr.dime.bitpix = 32; nii.hdr.dime.dim(1) = 3; nii.hdr.dime.dim(5) = 1;
+end
+function nii = read_niigz(f)
+    t = [tempname '.nii']; system(sprintf('gunzip -c ''%s'' > ''%s''', f, t)); nii = load_untouch_nii(t); delete(t);
+end
+function write_niigz(nii, f)
+    t = [tempname '.nii']; save_untouch_nii(nii, t); system(sprintf('gzip -c ''%s'' > ''%s''', t, f)); delete(t);
+end

--- a/algorithms/apart-qsm/run.sh
+++ b/algorithms/apart-qsm/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# APART-QSM — runs the MATLAB-compiled `recon` on the free MATLAB Runtime (no license at run time).
+# The binary bundles the APART-QSM core solver, its published helpers (dipole_kernel, gradient_mask_all,
+# @TVOP), the NIfTI I/O toolbox and the Optimization Toolbox. Baked into the image at /opt/qsm-ci/recon,
+# or mounted at /algo/recon. See BUILD.md.
+#   consumes magnitude.nii.gz, localfield.nii.gz, r2prime.nii.gz, chimap.nii.gz, mask.nii.gz, params.json
+#   produces chi-para.nii.gz (χ+), chi-dia.nii.gz (χ−, positive magnitude)
+# For a local (full-MATLAB, Optimization-Toolbox) run instead:
+#   matlab -batch "addpath('.'); recon('IN','OUT')"  with APART_CORE (author-obtained solver) +
+#   optional APART_UTILS/CHISEP_NIFTI set (see BUILD.md).
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${MATLAB_RECON:-/opt/qsm-ci/recon}"
+[ -x "$BIN" ] || BIN="$DIR/recon"
+export MCR_CACHE_ROOT="${MCR_CACHE_ROOT:-$(mktemp -d)}"
+# CI runs the container as a homeless non-root user (--user 1000:1001). The MATLAB Runtime extracts the
+# embedded CTF and starts a parpool under HOME, so point HOME at a writable dir or it fails with
+# "Cannot find nonembedded CTF archive".
+export HOME="${HOME:-}"; { [ -n "$HOME" ] && [ -w "$HOME" ]; } || export HOME="$MCR_CACHE_ROOT"
+exec "$BIN" "$IN" "$OUT"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -100,6 +100,66 @@
       "ci_notes": []
     },
     {
+      "slug": "apart-qsm",
+      "name": "APART-QSM",
+      "stage": "chi-separation",
+      "inputs": [
+        "localfield",
+        "r2prime",
+        "chimap",
+        "magnitude",
+        "mask",
+        "params"
+      ],
+      "domain": "chisep",
+      "engine": "Independent",
+      "language": "MATLAB",
+      "family": "iterative",
+      "learning": "none",
+      "description": "APART-QSM \u2014 an improved sub-voxel quantitative susceptibility mapping for susceptibility source separation using an iterative data-fitting method. A GRE-based (signal-domain) classical source separation: it alternately solves a voxel-wise magnitude-decay kernel (the \"a-map\") and the sub-voxel \u03c7+ (paramagnetic, iron) / \u03c7\u2212 (diamagnetic, myelin/calcium) split via TV-regularised dipole inversion over the multi-echo complex GRE signal. Handles an arbitrary number of complex GRE measurements; supports single- and multi-orientation \u2014 QSM-CI runs it SINGLE-ORIENTATION on the chisep phantom. Reads the multi-echo magnitude + the provided local field, R2\u2032 and \u03c7_total, and writes the two source maps. Li/Wang et al., NeuroImage 2023.",
+      "citation": "Li Z. et al., \"APART-QSM: An improved sub-voxel quantitative susceptibility mapping for susceptibility source separation using an iterative data fitting method\", NeuroImage 2023;274:120148.\n",
+      "doi": "10.1016/j.neuroimage.2023.120148",
+      "code_url": "https://github.com/AMRI-Lab/APART-QSM",
+      "license": "none declared (no LICENSE in repo); academic use, cite the paper",
+      "authors": [
+        "Zhenghao Li",
+        "Ruimin Feng",
+        "Qiangqiang Liu",
+        "Jianxun Feng",
+        "Guangbin Lao",
+        "Mengqi Zhang",
+        "Hongjiang Wei"
+      ],
+      "parameters": [
+        {
+          "name": "a",
+          "default": 137,
+          "description": "Magnitude decay kernel (Hz/ppm) initialising the voxel-wise a-map. The APART demo uses 323.5 at 3T; our chisep phantom's R2\u2032 model uses a single Dr=137 Hz/ppm kernel (data/sim/chisep/README.md), so we default to 137.\n"
+        },
+        {
+          "name": "tol_a",
+          "default": 0.3,
+          "description": "Tolerance on the a-map relative change between consecutive iterations (reference default 0.3)."
+        },
+        {
+          "name": "lambda_r2prime",
+          "default": 0.1,
+          "description": "Scaling weight of the R2\u2032-related data term (reference default 0.1)."
+        },
+        {
+          "name": "lambda_chi",
+          "default": 10,
+          "description": "Scaling weight of the \u03c7 (susceptibility) data-fidelity term (reference default 10, single-ori)."
+        },
+        {
+          "name": "lambda_TV",
+          "default": 1,
+          "description": "Total-variation regularisation weight on the source maps (reference default 1, single-ori)."
+        }
+      ],
+      "ci_notes": []
+    },
+    {
       "slug": "autoqsm",
       "name": "AutoQSM",
       "stage": "bfr+dipole",


### PR DESCRIPTION
Adds **APART-QSM** (Li et al., NeuroImage 2023) as a `chi-separation` submission — a GRE-based iterative signal-domain χ+/χ− source separator.

## Status: parked (`ci_skip: true`)
It's a **scaffold, not yet runnable**: the public APART-QSM repo omits the core solver (`apart_qsm_single_ori`), so it must be obtained from the authors and the image rebuilt before it can score (see `BUILD.md` §0 and the BLOCKER note in `algorithm.yml`). `ci_skip: true` keeps it out of the smoke matrix and scoring until un-skipped.

## Contents
- `algorithm.yml` (stage `chi-separation`; consumes magnitude + local field + R2′ + χ_total + mask; produces χ+/χ−), `recon.m`, `run.sh`, `Dockerfile`, `BUILD.md`, and the published helpers (`dipole_kernel`, `gradient_mask_all`, `@TVOP`).
- The NIfTI toolbox is **not** committed (`algorithms/*/nifti/` is gitignored repo-wide, fetched at build) and the core solver is intentionally absent.

## ⚠️ Merge blocker: `image-access`
The required `image-access` gate checks the image is pullable **even for `ci_skip` methods**, and `ghcr.io/astewartau/qsm-ci/apart-qsm:v1` is currently **private** → this check will fail. To merge, either **make that package public** (the gate's own hint) or admin-override. It won't run/score either way while parked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)