### PR TITLE
fix(chisep): fetch the chi-sep scoring dataset as pre-flattened (like invivo)

### DIFF
--- a/scripts/fetch_dataset.sh
+++ b/scripts/fetch_dataset.sh
@@ -16,19 +16,20 @@
 #        OSF_ZIP       (optional) — persistent path for the download. If it exists it's reused (no
 #                      download); if not, the download is saved there. Point CI's cache at it.
 #
-# Tracks: sim / chisep ship as qsm-forward BIDS trees (flattened here by pack_dataset.py). The
-# invivo track (2016 QSM Reconstruction Challenge) ships ALREADY FLATTENED (inputs/ + groundtruth/
-# at the zip root, built by scripts/make_invivo_zip.py), so it skips the BIDS-find + pack step and
-# just unzips straight into $DEST.
+# Tracks: sim ships as a qsm-forward BIDS tree (flattened here by pack_dataset.py). The chisep and
+# invivo tracks ship ALREADY FLATTENED (inputs/ + groundtruth/ at the zip root — chisep built by
+# gen_chisep.py / pack_dataset.py, invivo by scripts/make_invivo_zip.py), so they skip the BIDS-find
+# + pack step and just unzip straight into $DEST.
 set -euo pipefail
 
 TRACK="${1:?track required}"
 DEST="${2:?dest dir required}"
 OSF_PROJECT="${OSF_PROJECT:-y8adf}"
-# bids.zip file id per track. The χ-separation phantom is a SEPARATE bids (χ+/χ− sources + R2'
-# derivatives), so it lives in its own OSF file — set OSF_FILE_CHISEP (or override OSF_FILE).
+# Dataset zip file id per track. The χ-separation phantom (χ+/χ− sources + R2' derivatives) lives in
+# its own OSF file — set OSF_FILE_CHISEP (or override OSF_FILE). It ships pre-flattened, so PACK_FLAGS
+# is unused for it (kept only for the sim track's BIDS flatten).
 case "$TRACK" in
-  chisep) OSF_FILE="${OSF_FILE:-${OSF_FILE_CHISEP:?set OSF_FILE_CHISEP to the χ-sep bids.zip OSF file id}}"; PACK_FLAGS="--chisep" ;;
+  chisep) OSF_FILE="${OSF_FILE:-${OSF_FILE_CHISEP:?set OSF_FILE_CHISEP to the χ-sep dataset OSF file id}}"; PACK_FLAGS="--chisep" ;;
   invivo) OSF_FILE="${OSF_FILE:-${OSF_FILE_INVIVO:-hw9rn}}"; PACK_FLAGS="" ;;   # invivo_qsm2016.zip (osf.io/hw9rn), pre-flattened
   *)      OSF_FILE="${OSF_FILE:-698ac9aecae88916d1e24f69}"; PACK_FLAGS="" ;;   # QSM bids
 esac
@@ -56,9 +57,10 @@ else
   curl -fS --location-trusted -H "Authorization: Bearer ${OSF_TOKEN}" "$url" -o "$zip"
 fi
 
-# The invivo zip is ALREADY flattened (inputs/ + groundtruth/ at its root, built by
-# scripts/make_invivo_zip.py) — no BIDS tree, no pack step. Just unzip it straight into $DEST.
-if [ "$TRACK" = "invivo" ]; then
+# The chisep and invivo zips are ALREADY flattened (inputs/ + groundtruth/ at the zip root — chisep
+# from gen_chisep.py/pack_dataset.py, invivo from scripts/make_invivo_zip.py). No BIDS tree, no pack
+# step: just unzip straight into $DEST.
+if [ "$TRACK" = "invivo" ] || [ "$TRACK" = "chisep" ]; then
   rm -rf "$DEST"
   mkdir -p "$DEST"
   unzip -q "$zip" -d "$DEST"


### PR DESCRIPTION
## Bug
Every chi-sep method DNF'd in the last rescore at **step 5, "Fetch dataset"** — before the method or scorer ran. Root cause: the chisep OSF `chisep_bids.zip` is **pre-flattened** (`inputs/` + `groundtruth/` at the root, produced by `gen_chisep.py`/`pack_dataset.py`), but `fetch_dataset.sh`'s chisep path expected a qsm-forward **BIDS tree** and ran `pack_dataset.py --chisep` on it → `could not find raw phase under the zip` → exit 1.

## Fix
Route the `chisep` track through the same **pre-flattened branch** the `invivo` track already uses (unzip straight into `$DEST`, no BIDS-find, no pack). This matches what `gen_chisep.py` actually outputs.

## Verified end-to-end
Ran `fetch_dataset.sh chisep` against the real uploaded zip (via the `OSF_ZIP` bypass) → produces the complete expected layout:
- `inputs/{localfield, r2prime, chimap, magnitude, phase, se_magnitude, mask, params.json}`
- `groundtruth/{chi-para, chi-dia, chimap, dseg}`

`bash -n` clean. After merge, a focused chi-sep rescore will refresh the leaderboard against the new phantom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)