### PR TITLE
fix(decompose-qsm): raise self-hosted score cap to 720 min (was hitting 360)

### DIFF
--- a/algorithms/decompose-qsm/algorithm.yml
+++ b/algorithms/decompose-qsm/algorithm.yml
@@ -29,6 +29,7 @@ license: GPL-3.0
 image: ghcr.io/astewartau/qsm-ci/decompose-qsm:v2
 run: bash run.sh
 runner: self-hosted   # per-voxel non-linear fit (parfor); ~31 min on 48 cores — needs a many-core runner + long cap
+timeout_minutes: 720  # full runs have taken 114–342 min on the shared self-hosted box and hit the 360 default; give ample headroom (cf. modip)
 smoke_box: 24         # per-voxel fit is slow: the PR --smoke gate fits only a 24³ central box (full score.yml run is unaffected)
 matlab:
   entry: recon.m


### PR DESCRIPTION
## Why
`decompose-qsm`'s per-voxel `parfor` fit is a multi-hour job on the shared self-hosted runner. History of the `f-decompose-qsm` focus job:

| run | outcome | duration |
|---|---|---|
| 07-30 | ✅ success | 114 min |
| 07-31 | ✅ success | 179 min |
| 08-05 | ✅ success | 322 min |
| 07-31 | ✅ success | **342 min** (18 min under the cap) |
| 07-29 | ⏹ cancelled | **360 min (hit the cap)** |

It legitimately runs 2–6 h and sits right at the **360-min `SELFHOSTED` default**, so it intermittently times out.

## Fix
Add `timeout_minutes: 720` to `algorithms/decompose-qsm/algorithm.yml` (12 h, same as modip). `score.yml` already honors a per-method `timeout_minutes` override on the self-hosted tier, so no workflow change is needed and no other method is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)