### PR TITLE
feat(chisep): chisep-null — closed-form analytic null baseline

### DIFF
--- a/algorithms/chisep-null/algorithm.yml
+++ b/algorithms/chisep-null/algorithm.yml
@@ -1,0 +1,28 @@
+name: Null baseline (closed-form)
+slug: chisep-null
+algorithm: "null"
+source: qsmci
+stage: chi-separation
+language: Python
+family: direct
+learning: none
+engine: Independent
+inputs: [chimap, r2prime, mask, params]  # the artifacts this method actually reads (a subset of the stage's inputs)
+description: >
+  The closed-form analytic null baseline for χ-separation: per voxel it solves the benchmark's own
+  two source-model equations (χ+ + χ- = χ_total; Dr+·χ+ + Dr-·|χ-| = R2') exactly from the two
+  provided inputs — no dipole inversion, no regularisation, no learning. Relaxivities are the
+  field-scaled literature calibration (Dr+ = 137·B0/3 Hz/ppm, Shin 2021; Dr- via the
+  Yablonskiy-Haacke cylinder/sphere static-dephasing ratio). On an isotropic single-kernel phantom
+  this inverts the phantom's own arithmetic and is EXACT; wherever tissue physics departs from that
+  arithmetic (e.g. mechanistic, orientation-dependent white-matter R2') it fails in a structured
+  way. Its score is the benchmark's honest floor: a real method demonstrates separation skill only
+  by beating it.
+authors:
+- name: QSM-CI
+doi: 10.1016/j.neuroimage.2021.118371
+citation: model equations from Shin et al., NeuroImage 2021; kernel ratio from Yablonskiy & Haacke, MRM 1994 (10.1002/mrm.1910320610)
+code_url: https://github.com/QSMxT/QSM-CI
+license: MIT
+image: ghcr.io/astewartau/qsm-ci/py-ref:v1
+run: bash run.sh

--- a/algorithms/chisep-null/recon.py
+++ b/algorithms/chisep-null/recon.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""chisep-null — the closed-form analytic null baseline for χ-separation.
+
+Solves the two source-model equations that define the benchmark's forward model,
+
+    χ+  +  χ-  =  χ_total                (χ- signed, <= 0)
+    Dr+·χ+  +  Dr-·|χ-|  =  R2'
+
+exactly, per voxel, from the two provided inputs (χ_total and R2'). No dipole
+inversion, no regularisation, no learning — a few array operations. On an
+isotropic single-kernel phantom this inverts the phantom's own arithmetic and is
+EXACT; on a phantom whose white-matter R2' carries mechanistic (multi-compartment,
+orientation-dependent) physics it is not. Its score is therefore the benchmark's
+honest floor: any real method must beat it to demonstrate separation skill.
+
+Relaxivity assumptions (stated, field-scaled from the literature):
+    Dr+ = 137 * (B0 / 3) Hz/ppm   (Shin et al. 2021 empirical calibration,
+                                   scaled linearly with field)
+    Dr- = (133.77 / 107.84) * Dr+ (the static-dephasing cylinder/sphere ratio,
+                                   Yablonskiy & Haacke 1994)
+
+Usage: recon.py <input-dir> <output-dir>
+Consumes: chimap.nii.gz (ppm), r2prime.nii.gz (Hz), mask.nii.gz, params.json (B0)
+Produces: chi-para.nii.gz (χ+ >= 0), chi-dia.nii.gz (|χ-| >= 0)
+"""
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import nibabel as nib
+
+DR_POS_3T = 137.0            # Hz/ppm, empirical single-kernel calibration at 3 T
+DR_RATIO = 133.77 / 107.84   # cylindrical vs spherical static-dephasing kernels
+
+
+def main() -> None:
+    inp, out = Path(sys.argv[1]), Path(sys.argv[2])
+    out.mkdir(parents=True, exist_ok=True)
+
+    params = json.loads((inp / "params.json").read_text())
+    b0 = float(params.get("B0", 3.0))
+    dr_pos = DR_POS_3T * (b0 / 3.0)
+    dr_neg = DR_RATIO * dr_pos
+
+    chi_nii = nib.load(str(inp / "chimap.nii.gz"))
+    chi = np.nan_to_num(chi_nii.get_fdata())
+    r2p = np.clip(np.nan_to_num(nib.load(str(inp / "r2prime.nii.gz")).get_fdata()), 0, None)
+    mask = nib.load(str(inp / "mask.nii.gz")).get_fdata() > 0
+
+    # Exact two-kernel solve of the linear system above (chi- signed negative):
+    #   chi+ = (Dr-*chi_total + R2') / (Dr+ + Dr-),  chi- = chi_total - chi+
+    pos = (dr_neg * chi + r2p) / (dr_pos + dr_neg)
+    neg_signed = chi - pos
+    pos = np.clip(pos, 0, None) * mask
+    dia = np.clip(-neg_signed, 0, None) * mask
+
+    for name, data in (("chi-para", pos), ("chi-dia", dia)):
+        nib.save(nib.Nifti1Image(data.astype(np.float32), chi_nii.affine, chi_nii.header),
+                 str(out / f"{name}.nii.gz"))
+    print(f"chisep-null: B0={b0} T, Dr+={dr_pos:.1f}, Dr-={dr_neg:.1f} Hz/ppm -> chi-para/chi-dia")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/chisep-null/run.sh
+++ b/algorithms/chisep-null/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+python3 "$(dirname "$0")/recon.py" "$IN" "$OUT"

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -298,6 +298,32 @@
       "ci_notes": []
     },
     {
+      "slug": "chisep-null",
+      "name": "Null baseline (closed-form)",
+      "stage": "chi-separation",
+      "inputs": [
+        "r2prime",
+        "chimap",
+        "mask",
+        "params"
+      ],
+      "domain": "chisep",
+      "engine": "Independent",
+      "language": "Python",
+      "family": "direct",
+      "learning": "none",
+      "description": "The closed-form analytic null baseline for \u03c7-separation: per voxel it solves the benchmark's own two source-model equations (\u03c7+ + \u03c7- = \u03c7_total; Dr+\u00b7\u03c7+ + Dr-\u00b7|\u03c7-| = R2') exactly from the two provided inputs \u2014 no dipole inversion, no regularisation, no learning. Relaxivities are the field-scaled literature calibration (Dr+ = 137\u00b7B0/3 Hz/ppm, Shin 2021; Dr- via the Yablonskiy-Haacke cylinder/sphere static-dephasing ratio). On an isotropic single-kernel phantom this inverts the phantom's own arithmetic and is EXACT; wherever tissue physics departs from that arithmetic (e.g. mechanistic, orientation-dependent white-matter R2') it fails in a structured way. Its score is the benchmark's honest floor: a real method demonstrates separation skill only by beating it.",
+      "citation": "model equations from Shin et al., NeuroImage 2021; kernel ratio from Yablonskiy & Haacke, MRM 1994 (10.1002/mrm.1910320610)",
+      "doi": "10.1016/j.neuroimage.2021.118371",
+      "code_url": "https://github.com/QSMxT/QSM-CI",
+      "license": "MIT",
+      "authors": [
+        "QSM-CI"
+      ],
+      "parameters": [],
+      "ci_notes": []
+    },
+    {
       "slug": "chisepnet",
       "name": "\u03c7-sepnet",
       "stage": "chi-separation",


### PR DESCRIPTION
Adds `algorithms/chisep-null`: the closed-form analytic null solve as a scored leaderboard baseline.

## What it is
Per voxel it solves the benchmark's own two source-model equations exactly from the two provided inputs:

    chi+ + chi- = chi_total
    Dr+*chi+ + Dr-*|chi-| = R2'

with field-scaled literature relaxivities (Dr+ = 137·B0/3 Hz/ppm from Shin 2021; Dr- via the Yablonskiy–Haacke cylinder/sphere static-dephasing ratio). No dipole inversion, no regularisation, no learning — a few array ops on `chimap` + `r2prime`.

## Why score a 'cheat'
It is the benchmark's honest floor. On an isotropic single-kernel phantom it inverts the phantom's own arithmetic — error identically zero. Wherever the phantom carries physics beyond the closed-form recipe (the mechanistic, orientation-dependent WM R2' of the upcoming phantom revision), it fails in a structured way. Putting it on the board makes 'does a method beat the null?' a visible, first-class comparison instead of a footnote.

## Numbers (local, upcoming mechanistic phantom)
para detrended NRMSE 30.1 / dia 56.7 / avg **43.4** — matching the independent `validate_phantom` null-attack floor exactly.

## Mechanics
- Uses the existing public `py-ref:v1` deps image — no new image to build/push.
- `stage: chi-separation` → evaluate/score routing is automatic.
- `web/algorithms.json` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)