### PR TITLE
Multi-phantom χ-separation: Ridani reproduction + multicompartment, MSPE/MEV metrics

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -65,21 +65,27 @@ jobs:
           pip install --upgrade setuptools setuptools_scm wheel   # runner's build tools are too old for setuptools-scm
           pip install --no-build-isolation .                       # build the CLI with the upgraded tools
 
-      # Route each method to the right phantom by its stage: χ-separation methods need the chisep
+      # Route each method to the right phantom by its stage: χ-separation methods need a chisep-track
       # dataset (χ+/χ− ground truth + R2'/χ_total inputs), everything else the QSM scoring phantom.
+      # The PR smoke only ever runs on the track's DEFAULT phantom (scripts/datasets.json `default`) —
+      # score.yml fans the real scoring out across every active phantom on merge.
       - name: Route dataset by stage
         id: route
+        env:
         run: |
           stage=$(sed -nE 's/^stage:[[:space:]]*//p' "algorithms/${{ matrix.slug }}/algorithm.yml" | head -1)
-          if [ "$stage" = "chi-separation" ]; then
-            echo "fetch_track=chisep"          >> "$GITHUB_OUTPUT"
-            echo "dataset=data/chisep/scoring" >> "$GITHUB_OUTPUT"
-            echo "zipkey=osf-chisep-${{ secrets.OSF_FILE_CHISEP }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "fetch_track=sim"             >> "$GITHUB_OUTPUT"
-            echo "dataset=data/sim/scoring"    >> "$GITHUB_OUTPUT"
-            echo "zipkey=osf-bids-698ac9aecae88916d1e24f69" >> "$GITHUB_OUTPUT"
-          fi
+          track=sim; [ "$stage" = "chi-separation" ] && track=chisep
+          STAGE_TRACK="$track" python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          reg = json.load(open('scripts/datasets.json'))
+          track = os.environ['STAGE_TRACK']
+          ph = next(k for k, v in reg.items() if v.get('track') == track and v.get('default'))
+          d = reg[ph]
+          osf = (os.environ.get(d['osf_env']) if d.get('osf_env') else None) or d.get('osf_file') or ''
+          print(f"fetch_track={ph}")
+          print(f"dataset={d['path']}")
+          print(f"zipkey=osf-{ph}-{osf}")
+          PY
           # Dipole methods are the only stage scored on the in-vivo track, so only they get the extra
           # invivo smoke leg below.
           echo "is_dipole=$([ "$stage" = dipole ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
@@ -92,7 +98,6 @@ jobs:
       - name: Fetch dataset (public inputs + held-out ground truth)
         env:
           OSF_TOKEN: ${{ secrets.OSF_TOKEN }}
-          OSF_FILE_CHISEP: ${{ secrets.OSF_FILE_CHISEP }}   # χ-sep bids.zip OSF file id (set once uploaded)
           OSF_ZIP: .osfcache/${{ steps.route.outputs.fetch_track }}.zip
         run: scripts/fetch_dataset.sh "${{ steps.route.outputs.fetch_track }}" "${{ steps.route.outputs.dataset }}"
 

--- a/.github/workflows/score.yml
+++ b/.github/workflows/score.yml
@@ -97,6 +97,16 @@ jobs:
           TASKS=$(python3 - <<'PY'
           import json, os, re, glob
           full = os.environ['FULL'] == 'true'
+          # Dataset/phantom registry — single source of truth for the scoring datasets. A method
+          # family (track) can have several ACTIVE phantoms (e.g. chisep + the ridani variants), and
+          # each gets its own task; the track's default phantom keeps the legacy task/run ids while
+          # the others are namespaced with the phantom id.
+          REG = json.load(open('scripts/datasets.json'))
+          def track_phantoms(track):
+              ph = [k for k, v in REG.items() if v.get('track') == track and v.get('active')]
+              return sorted(ph, key=lambda k: (not REG[k].get('default'), k))  # default first
+          def task_id(prefix, slug, ph):
+              return prefix + slug + ('' if REG[ph].get('default') else '-' + ph)
           # Per-task runner routing, chosen by each method's `runner:` field in its algorithm.yml:
           #   (unset)      -> HOSTED:      ubuntu-latest, 180-min cap, 2 concurrent containers. Default;
           #                   scored inside the parallel shard sweep.
@@ -142,10 +152,16 @@ jobs:
               # `-invivo` id namespace (pipeline.py id_suffix), so they never collide with sim runs.
               return [{'id': 'iv-' + s, 'focus': s, 'phantom': 'invivo', 'track': 'invivo', **route(s)}
                       for s in sorted(slugs) if is_dipole(s) and not s.startswith('_')]
-          def phantom(slug):
-              # Which phantom this method scores on: χ-separation methods use the chisep dataset (χ+/χ−
-              # GT + R2'/χ_total inputs); everything else the QSM sim phantom.
-              return 'chisep' if is_chisep(slug) else 'sim'
+          def phantoms(slug):
+              # Which phantom(s) this method scores on: χ-separation methods run on EVERY active
+              # chisep-track phantom (χ+/χ− GT + R2'/χ_total inputs) — one task per method × phantom;
+              # everything else the QSM sim phantom.
+              return track_phantoms('chisep') if is_chisep(slug) else ['sim']
+          def focus_tasks(slugs):
+              # One focused task per (method, phantom). The default phantom keeps the legacy
+              # 'f-<slug>' task id; extra phantoms get 'f-<slug>-<phantom>'.
+              return [{'id': task_id('f-', s, ph), 'focus': s, 'phantom': ph, **route(s)}
+                      for s in slugs for ph in phantoms(s)]
           def dedicated():
               # Methods that run as their own focused job (not the shard sweep): a non-HOSTED runner OR a
               # χ-separation method (scored on a SEPARATE phantom, isolated-only — can't ride the QSM shard
@@ -164,13 +180,13 @@ jobs:
               ded = dedicated()
               excl = ','.join(ded)
               tasks = [{'id': 's%02d' % i, 'shard': '%d/%d' % (i, N), 'exclude': excl, 'phantom': 'sim', **HOSTED} for i in range(N)]
-              tasks += [{'id': 'f-' + s, 'focus': s, 'phantom': phantom(s), **route(s)} for s in ded]
+              tasks += focus_tasks(ded)
               # In-vivo leaderboard: an extra isolated invivo run of EVERY dipole method.
               all_slugs = [p.split('/')[1] for p in sorted(glob.glob('algorithms/*/algorithm.yml'))]
               tasks += invivo_tasks(all_slugs)
           else:
               slugs = json.loads(os.environ['SLUGS'])
-              tasks = [{'id': 'f-' + s, 'focus': s, 'phantom': phantom(s), **route(s)} for s in slugs]
+              tasks = focus_tasks(slugs)
               # A changed dipole method also re-scores on the in-vivo track.
               tasks += invivo_tasks(slugs)
           print(json.dumps(tasks))
@@ -201,31 +217,58 @@ jobs:
           pip install --upgrade setuptools setuptools_scm wheel
           pip install --no-build-isolation .
 
-      # Per-phantom OSF zip cache key: chisep and invivo each ship their own OSF file (a separate
-      # secret); the QSM sim phantom is the shared bids.zip.
+      # Resolve the task's phantom against the dataset registry (scripts/datasets.json): the
+      # per-phantom OSF zip cache key (osf-<phantom>-<file-id>), the local dataset path, and the
+      # scoring mode. Workflows can't index `secrets` dynamically, so each per-phantom OSF_FILE_*
+      # secret is passed into env here and the registry entry's `osf_env` picks the right one by
+      # name — adding a phantom = a scripts/datasets.json entry + one OSF_FILE_* env line here
+      # and on the fetch step below (named OSF_FILE_<PHANTOM-ID, uppercased, dashes→underscores>).
+      - name: Resolve dataset (scripts/datasets.json)
+        id: ds
+        env:
+          PHANTOM: ${{ matrix.task.phantom || 'sim' }}
+          OSF_FILE_INVIVO: ${{ secrets.OSF_FILE_INVIVO }}   # invivo_qsm2016.zip OSF file id (pre-flattened)
+          OSF_FILE_RIDANI_3T_ISO: ${{ secrets.OSF_FILE_RIDANI_3T_ISO }}      # Ridani 3T isotropic (pre-flattened)
+          OSF_FILE_RIDANI_3T_ANISO: ${{ secrets.OSF_FILE_RIDANI_3T_ANISO }}  # Ridani 3T anisotropic (pre-flattened)
+          OSF_FILE_RIDANI_7T_ANISO: ${{ secrets.OSF_FILE_RIDANI_7T_ANISO }}  # Ridani 7T anisotropic (pre-flattened)
+          OSF_FILE_CHISEP_MC: ${{ secrets.OSF_FILE_CHISEP_MC }}              # χ-sep multicompartment (pre-flattened)
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          ph = os.environ['PHANTOM']
+          d = json.load(open('scripts/datasets.json'))[ph]
+          osf = (os.environ.get(d['osf_env']) if d.get('osf_env') else None) or d.get('osf_file') or ''
+          print(f"zipkey=osf-{ph}-{osf}")
+          print(f"path={d['path']}")
+          # χ-separation and in-vivo phantoms are isolated-only (no composed matrix); sim runs both.
+          print("mode=" + ("both" if d['track'] == 'sim' else "isolated"))
+          PY
       - name: Cache OSF dataset zip
         uses: actions/cache@v6
         with:
           path: .osfcache/${{ matrix.task.phantom || 'sim' }}.zip
-          key: ${{ matrix.task.phantom == 'chisep' && format('osf-chisep-{0}', secrets.OSF_FILE_CHISEP) || (matrix.task.phantom == 'invivo' && format('osf-invivo-{0}', secrets.OSF_FILE_INVIVO) || 'osf-bids-698ac9aecae88916d1e24f69') }}
+          key: ${{ steps.ds.outputs.zipkey }}
       - name: Fetch dataset (public inputs + held-out ground truth)
         env:
           OSF_TOKEN: ${{ secrets.OSF_TOKEN }}
-          OSF_FILE_CHISEP: ${{ secrets.OSF_FILE_CHISEP }}   # χ-sep bids.zip OSF file id
           OSF_FILE_INVIVO: ${{ secrets.OSF_FILE_INVIVO }}   # invivo_qsm2016.zip OSF file id (pre-flattened)
+          OSF_FILE_RIDANI_3T_ISO: ${{ secrets.OSF_FILE_RIDANI_3T_ISO }}      # Ridani 3T isotropic (pre-flattened)
+          OSF_FILE_RIDANI_3T_ANISO: ${{ secrets.OSF_FILE_RIDANI_3T_ANISO }}  # Ridani 3T anisotropic (pre-flattened)
+          OSF_FILE_RIDANI_7T_ANISO: ${{ secrets.OSF_FILE_RIDANI_7T_ANISO }}  # Ridani 7T anisotropic (pre-flattened)
+          OSF_FILE_CHISEP_MC: ${{ secrets.OSF_FILE_CHISEP_MC }}              # χ-sep multicompartment (pre-flattened)
           OSF_ZIP: .osfcache/${{ matrix.task.phantom || 'sim' }}.zip
-        run: scripts/fetch_dataset.sh "${{ matrix.task.phantom || 'sim' }}" "data/${{ matrix.task.phantom || 'sim' }}/scoring"
+        run: scripts/fetch_dataset.sh "${{ matrix.task.phantom || 'sim' }}" "${{ steps.ds.outputs.path }}"
 
       - name: Score task ${{ matrix.task.id }}
         run: |
           PH="${{ matrix.task.phantom || 'sim' }}"
-          DS="data/$PH/scoring"
-          # χ-separation and in-vivo are isolated-only (no composed matrix); sim runs both modes.
-          MODE=both; { [ "$PH" = chisep ] || [ "$PH" = invivo ]; } && MODE=isolated
+          DS="${{ steps.ds.outputs.path }}"
+          MODE="${{ steps.ds.outputs.mode }}"
           # Track defaults to $TRACK (sim); an invivo task overrides it so pipeline.py scores against
-          # COSMOS + STI and namespaces its run ids with `-invivo`.
+          # COSMOS + STI and namespaces its run ids with `-invivo`. --phantom namespaces the run ids
+          # of a NON-default phantom with -<phantom-id> (the default phantoms keep the legacy ids).
           TRK="${{ matrix.task.track || '' }}"; [ -z "$TRK" ] && TRK="$TRACK"
-          ARGS="--dataset $DS --mode $MODE --runner docker --track $TRK --emit-volumes --runs-out runs-${{ matrix.task.id }}.json"
+          ARGS="--dataset $DS --phantom $PH --mode $MODE --runner docker --track $TRK --emit-volumes --runs-out runs-${{ matrix.task.id }}.json"
           [ -n "${{ matrix.task.shard }}" ] && ARGS="$ARGS --shard ${{ matrix.task.shard }}"
           [ -n "${{ matrix.task.focus }}" ] && ARGS="$ARGS --focus ${{ matrix.task.focus }}"
           [ -n "${{ matrix.task.exclude }}" ] && ARGS="$ARGS --exclude ${{ matrix.task.exclude }}"

--- a/algorithms/r2star-qsm/Dockerfile
+++ b/algorithms/r2star-qsm/Dockerfile
@@ -1,0 +1,9 @@
+# Self-contained image for the r2star-qsm submission (recon baked; also runs with the repo dir mounted).
+# Build & push: docker build -t ghcr.io/astewartau/qsm-ci/r2star-qsm:v1 algorithms/r2star-qsm
+FROM python:3.12-slim
+LABEL org.opencontainers.image.authors="Ashley Stewart" \
+      org.opencontainers.image.source="https://github.com/QSMxT/QSM-CI" \
+      org.opencontainers.image.description="QSM-CI chi-separation submission: r2star-qsm (Dimov et al. 2022)" \
+      org.opencontainers.image.licenses="MIT"
+RUN pip install --no-cache-dir numpy scipy nibabel
+COPY run.sh recon.py /opt/qsm-ci/

--- a/algorithms/r2star-qsm/algorithm.yml
+++ b/algorithms/r2star-qsm/algorithm.yml
@@ -1,0 +1,33 @@
+name: R2*-QSM
+slug: r2star-qsm
+algorithm: r2star-qsm
+source: dimov
+stage: chi-separation
+language: Python
+family: direct
+learning: none
+engine: Independent
+inputs: [magnitude, chimap, mask, params]  # signal-domain: R2* from multi-echo magnitude + provided χ_total
+description: >
+  Susceptibility source separation from gradient-echo data alone (Dimov et al. 2022). R2* is fit
+  from the multi-echo GRE magnitude and combined with the QSM (χ_total) under a single-relaxometric-
+  constant model, R2* = 𝓇·(|χ+| + |χ−|) with χ_total = χ+ + χ−, solved per voxel in closed form
+  (χ+ = (χ_total + R2*/𝓇)/2, |χ−| = (R2*/𝓇 − χ_total)/2) with the physical constraints χ+ ≥ 0,
+  χ− ≤ 0. Unlike the R2'-based methods it needs no separate R2/R2' measurement — the trade-off is
+  that R2* carries the irreversible tissue R2 baseline, which the single constant 𝓇 absorbs
+  (Dimov's empirical 𝓇 = 274 Hz/ppm at 3 T is below the theoretic 321 for this reason). 𝓇 is
+  field-scaled to the acquisition (274·B0/3 Hz/ppm), the method's own assumption rather than a fit
+  to this phantom. This reference implementation is the paper's voxel-level solve; the full method
+  adds a field data-consistency term (auto-satisfied when χ_total is provided) and an edge-masked L1
+  regularisation, omitted here. Pure Python on CPU — no weights, no network.
+authors:
+- name: QSM-CI (implementation of Dimov et al. 2022)
+doi: 10.1111/jon.13014
+citation: >
+  Dimov A.V. et al., "Magnetic Susceptibility Source Separation Solely from Gradient Echo Data:
+  Histological Validation", Tomography 2022;8(3):1544-1551 (and J Neuroimaging 2022,
+  doi:10.1111/jon.13014). R2* susceptibility model: Yablonskiy & Haacke, Magn Reson Med 1994.
+code_url: https://github.com/QSMxT/QSM-CI
+license: MIT
+image: ghcr.io/astewartau/qsm-ci/r2star-qsm:v1
+run: bash run.sh

--- a/algorithms/r2star-qsm/recon.py
+++ b/algorithms/r2star-qsm/recon.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""R2*-QSM — susceptibility source separation from gradient-echo data (Dimov et al. 2022).
+
+Dimov et al. ("Magnetic Susceptibility Source Separation Solely from Gradient Echo Data",
+Tomography 2022; J Neuroimaging 2022, doi:10.1111/jon.13014) separate paramagnetic (χ+, iron)
+and diamagnetic (χ−, myelin) susceptibility from GRE data alone — R2* from the multi-echo
+magnitude plus a QSM (χ_total) from the phase — with NO separate R2/R2' measurement. The model,
+per voxel, is
+
+    R2*  =  𝓇·(|χ+| + |χ−|)          (a single relaxometric constant for both sources)
+    χ_total = χ+ + χ−                 (χ+ ≥ 0, χ− ≤ 0)
+
+which inverts in closed form to
+
+    χ+  = (χ_total + R2*/𝓇) / 2 ,   |χ−| = (R2*/𝓇 − χ_total) / 2
+
+with the physical constraints χ+ ≥ 0, |χ−| ≥ 0 enforced by clipping (the paper's voxel-level
+initialisation and physical-constraint reset). This is R2*-QSM's core; the full method adds a
+field data-consistency term (auto-satisfied here — we take the provided χ_total) and an
+edge-masked L1 regularisation that this reference implementation omits.
+
+Relaxometric constant. Dimov calibrated 𝓇 = 274 Hz/ppm at 3 T (a single value for both sources,
+"close to the theoretic 321 Hz/ppm"). R2* susceptibility-induced decay scales linearly with B0
+while χ does not, so applying the method at the acquisition field uses 𝓇 = 274·(B0/3) Hz/ppm —
+the method's own assumption, not retuned to this phantom (its mismatch with the phantom's Dr is a
+real, informative model error).
+
+Inputs  (QSM-CI χ-separation contract; a subset): magnitude.nii.gz (4D multi-echo GRE),
+        chimap.nii.gz (χ_total, ppm), mask.nii.gz, params.json (TE list in s, B0 in T).
+Outputs: chi-para.nii.gz (χ+ ≥ 0), chi-dia.nii.gz (|χ−| ≥ 0, positive magnitude).
+
+Usage: recon.py <input-dir> <output-dir>
+"""
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import nibabel as nib
+
+R_CONST_3T = 274.0   # Hz/ppm, Dimov et al. 2022 empirical relaxometric constant (both sources)
+
+
+def fit_r2star(mag, tes):
+    """R2* (Hz) by weighted log-linear least squares over echoes (mag: X,Y,Z,E; tes: E, seconds).
+    Magnitude-weighted so noisy late echoes don't dominate; a robust stand-in for the paper's ARLO."""
+    mag = np.clip(np.asarray(mag, np.float64), 1e-9, None)
+    t = np.asarray(tes, np.float64)
+    w = mag ** 2                                   # weight ∝ magnitude² (SNR)
+    logm = np.log(mag)
+    sw = w.sum(-1)
+    tbar = (w * t).sum(-1) / sw
+    lbar = (w * logm).sum(-1) / sw
+    cov = (w * (t - tbar[..., None]) * (logm - lbar[..., None])).sum(-1)
+    var = (w * (t - tbar[..., None]) ** 2).sum(-1)
+    slope = np.divide(cov, var, out=np.zeros_like(cov), where=var > 0)
+    return np.clip(-slope, 0, None)                # R2* = −slope of log-magnitude vs TE
+
+
+def main() -> None:
+    inp, out = Path(sys.argv[1]), Path(sys.argv[2])
+    out.mkdir(parents=True, exist_ok=True)
+
+    p = json.loads((inp / "params.json").read_text())
+    b0 = float(p.get("B0", 3.0))
+    tes = np.asarray(p["TE"], np.float64)          # seconds
+    r = R_CONST_3T * (b0 / 3.0)                     # field-scaled relaxometric constant (Hz/ppm)
+
+    chi_nii = nib.load(str(inp / "chimap.nii.gz"))
+    chi = np.nan_to_num(chi_nii.get_fdata())
+    mask = nib.load(str(inp / "mask.nii.gz")).get_fdata() > 0
+    mag = np.nan_to_num(nib.load(str(inp / "magnitude.nii.gz")).get_fdata())
+    if mag.ndim != 4 or mag.shape[-1] != len(tes):
+        raise SystemExit(f"magnitude {mag.shape} inconsistent with {len(tes)} TEs")
+
+    r2s = fit_r2star(mag, tes)                      # R2* (Hz) from the multi-echo magnitude
+    s = r2s / r                                     # R2*/𝓇 (ppm) = |χ+| + |χ−|
+    pos = np.clip((chi + s) / 2.0, 0, None) * mask  # χ+  = (χ_total + R2*/𝓇)/2
+    dia = np.clip((s - chi) / 2.0, 0, None) * mask  # |χ−| = (R2*/𝓇 − χ_total)/2
+
+    for name, data in (("chi-para", pos), ("chi-dia", dia)):
+        nib.save(nib.Nifti1Image(data.astype(np.float32), chi_nii.affine, chi_nii.header),
+                 str(out / f"{name}.nii.gz"))
+    print(f"r2star-qsm: B0={b0} T, 𝓇={r:.1f} Hz/ppm, R2* mean {r2s[mask].mean():.1f} Hz "
+          f"-> chi-para/chi-dia")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/r2star-qsm/run.sh
+++ b/algorithms/r2star-qsm/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+python3 "$(dirname "$0")/recon.py" "$IN" "$OUT"

--- a/algorithms/ridani-null-qsmci/Dockerfile
+++ b/algorithms/ridani-null-qsmci/Dockerfile
@@ -1,0 +1,9 @@
+# Self-contained image for the ridani-null-qsmci submission (recon baked; also runs with the repo dir mounted).
+# Build & push: docker build -t ghcr.io/astewartau/qsm-ci/ridani-null-qsmci:v1 algorithms/ridani-null-qsmci
+FROM python:3.12-slim
+LABEL org.opencontainers.image.authors="Ashley Stewart" \
+      org.opencontainers.image.source="https://github.com/QSMxT/QSM-CI" \
+      org.opencontainers.image.description="QSM-CI chi-separation submission: ridani-null-qsmci" \
+      org.opencontainers.image.licenses="MIT"
+RUN pip install --no-cache-dir numpy scipy nibabel
+COPY run.sh recon.py /opt/qsm-ci/

--- a/algorithms/ridani-null-qsmci/algorithm.yml
+++ b/algorithms/ridani-null-qsmci/algorithm.yml
@@ -1,0 +1,38 @@
+name: Ridani null baseline (region-disjoint closed-form)
+slug: ridani-null-qsmci
+algorithm: ridani-null
+source: qsmci
+stage: chi-separation
+language: Python
+family: direct
+learning: none
+engine: Independent
+inputs: [chimap, r2prime, mask, dseg, params]  # + fiber_angle if the dataset ships it (see description)
+description: >
+  The closed-form analytic null baseline for the Ridani et al. (2026) phantom family. It inverts the
+  phantom's own region-disjoint, theoretical field-scaled forward model: paramagnetic relaxivity
+  Dr+ = (2π)²·γ·B0/(9√3) (~107.84·B0 Hz/ppm) applied outside white matter, diamagnetic relaxivity
+  Dr-(θ) = ½·γ·2π·B0·sin²θ (~133.77·B0·sin²θ) inside white matter (a field-scaled constant when no
+  fibre orientation is available). The white-matter region is read from the provided segmentation
+  (dseg, label 8), and each region is solved with its own closed form (χ+ = R2'/Dr+ outside WM;
+  |χ-| = R2'/Dr- inside WM), so on the isotropic phantom it is EXACT. On the anisotropic phantom,
+  lacking per-voxel θ, it assumes a constant WM Dr- and mis-estimates WM χ- by the orientation
+  modulation — that residual is the anisotropy signal the benchmark measures. Where an optional
+  fibre-angle input (fiber_angle.nii.gz) is shipped, it uses the orientation-dependent Dr-(θ) and
+  its WM χ- becomes near-exact, quantifying how much that DTI input gives away. Its score is the
+  honest floor for this dataset family: a real method demonstrates separation skill only by beating
+  it without the held-out segmentation. Distinct from chisep-null (which inverts the co-located
+  single-kernel Dr+=137·B0/3 model); this baseline pairs with the Ridani datasets, as chisep-null
+  pairs with the fixed-Dr χ-sep dataset.
+authors:
+- name: Ashley Stewart
+doi: null
+citation: >
+  Stewart A., "ridani-null: the region-disjoint closed-form null baseline for the Ridani
+  susceptibility-separation phantom", QSM-CI, 2026. Forward model: Ridani D., De Leener B.,
+  Alonso-Ortiz E., Magn Reson Med 2026, doi:10.1002/mrm.70468; relaxivities Yablonskiy & Haacke,
+  Magn Reson Med 1994, doi:10.1002/mrm.1910320610.
+code_url: https://github.com/QSMxT/QSM-CI
+license: MIT
+image: ghcr.io/astewartau/qsm-ci/ridani-null-qsmci:v1
+run: bash run.sh

--- a/algorithms/ridani-null-qsmci/recon.py
+++ b/algorithms/ridani-null-qsmci/recon.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""ridani-null — the closed-form analytic null baseline for the Ridani et al. phantom family.
+
+Where chisep-null inverts the co-located single-kernel model (Dr+ and Dr- act in every
+voxel), ridani-null inverts the *region-disjoint, theoretical field-scaled* model that the
+Ridani et al. (2026) phantom is actually built from (calculate_Dr.m / generate_dr_maps_ridani):
+
+    * Paramagnetic relaxivity (spheres), applied OUTSIDE white matter only:
+          Dr+ = (2*pi)^2 * gamma_bar * B0 / (9*sqrt(3))   ~= 107.84 * B0  Hz/ppm
+    * Diamagnetic relaxivity (parallel cylinders), applied INSIDE white matter only:
+          Dr-(theta) = 0.5 * gamma_bar * 2*pi * B0 * sin^2(theta)  ~= 133.77 * B0 * sin^2(theta)
+      with the isotropic constant Dr- = 700.8 * (B0/7) used when no fibre-orientation input
+      is provided (the reference's constant-Dr option).
+
+so the source-model equations are solved with a DIFFERENT closed form per region:
+
+    outside WM (R2' = Dr+ |chi+|):   chi+ = R2'/Dr+ ,   |chi-| = chi+ - chi_total
+    inside  WM (R2' = Dr- |chi-|):   |chi-| = R2'/Dr- ,  chi+ = chi_total + |chi-|
+
+The white-matter region is taken from the provided segmentation (dseg, label 8). This is the
+one held-out map ridani-null is granted, exactly so that it can invert the phantom's own
+region-disjoint arithmetic: on the isotropic phantom it is EXACT; on the anisotropic phantom,
+lacking per-voxel theta, it must assume a constant Dr- in WM and so mis-estimates WM chi- by
+the orientation modulation — that residual IS the anisotropy signal the benchmark measures.
+Its score is the honest floor for this dataset family: a real method demonstrates skill only by
+beating it *without* the segmentation.
+
+If a fibre-to-B0 angle map (fiber_angle.nii.gz, degrees) is provided as an input, the
+orientation-dependent Dr-(theta) is used instead of the constant — the null then also knows the
+anisotropy and its WM chi- becomes near-exact, which quantifies how much that optional DTI input
+gives away. If no segmentation is provided at all, ridani-null falls back to the co-located
+two-kernel solve (identical in form to chisep-null) so it never crashes on a non-Ridani dataset.
+
+Usage: recon.py <input-dir> <output-dir>
+Consumes: chimap.nii.gz (ppm), r2prime.nii.gz (Hz), mask.nii.gz, params.json (B0);
+          dseg.nii.gz (segmentation, WM=8) if present; fiber_angle.nii.gz (deg) if present.
+Produces: chi-para.nii.gz (chi+ >= 0), chi-dia.nii.gz (|chi-| >= 0)
+"""
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import nibabel as nib
+
+GAMMA_BAR = 42.58     # MHz/T, used in the reference's Dr constants
+WM_LABEL = 8          # white-matter label in SegmentedModel / dseg
+DR_NEG_CONST_7T = 700.8   # Hz/ppm, the reference's constant-Dr- option at 7 T
+
+
+def _load(p):
+    return np.nan_to_num(nib.load(str(p)).get_fdata())
+
+
+def main() -> None:
+    inp, out = Path(sys.argv[1]), Path(sys.argv[2])
+    out.mkdir(parents=True, exist_ok=True)
+
+    params = json.loads((inp / "params.json").read_text())
+    b0 = float(params.get("B0", 7.0))
+    dr_pos = (2 * np.pi) ** 2 * GAMMA_BAR * b0 / (9 * np.sqrt(3))   # ~107.84*B0
+
+    chi_nii = nib.load(str(inp / "chimap.nii.gz"))
+    chi = np.nan_to_num(chi_nii.get_fdata())
+    r2p = np.clip(_load(inp / "r2prime.nii.gz"), 0, None)
+    mask = _load(inp / "mask.nii.gz") > 0
+
+    seg_path = inp / "dseg.nii.gz"
+    if seg_path.exists():
+        seg = np.round(_load(seg_path)).astype(int)
+        wm = seg == WM_LABEL
+
+        # Diamagnetic relaxivity in WM: orientation-dependent if a fibre-angle map is
+        # provided, else the reference's field-scaled constant.
+        fa_path = inp / "fiber_angle.nii.gz"
+        if fa_path.exists():
+            sin2 = np.clip(np.sin(np.deg2rad(_load(fa_path))) ** 2, 1e-3, None)
+            dr_neg = 0.5 * GAMMA_BAR * 2 * np.pi * b0 * sin2           # ~133.77*B0*sin^2(theta)
+            dr_mode = "Dr-(theta) from fiber_angle"
+        else:
+            dr_neg = np.full_like(chi, DR_NEG_CONST_7T * (b0 / 7.0))
+            dr_mode = f"constant Dr- = {DR_NEG_CONST_7T * b0 / 7.0:.1f} Hz/ppm"
+
+        dr_neg_wm = np.where(dr_neg > 0, dr_neg, 1.0)
+        # Region-disjoint closed form (chi- signed <= 0):
+        pos_out = r2p / dr_pos                     # outside WM: chi+ = R2'/Dr+
+        dia_wm = r2p / dr_neg_wm                   # inside  WM: |chi-| = R2'/Dr-
+        pos = np.where(wm, chi + dia_wm, pos_out)
+        dia = np.where(wm, dia_wm, pos_out - chi)
+        mode = f"region-disjoint (WM from dseg, {int(wm.sum())} vox; {dr_mode})"
+    else:
+        # No segmentation: co-located two-kernel fallback (identical in form to chisep-null),
+        # using the theoretical field-scaled cylinder/sphere ratio for Dr-.
+        dr_neg = (133.77 / 107.84) * dr_pos
+        pos = (dr_neg * chi + r2p) / (dr_pos + dr_neg)
+        dia = -(chi - pos)
+        mode = "co-located fallback (no dseg)"
+
+    pos = np.clip(pos, 0, None) * mask
+    dia = np.clip(dia, 0, None) * mask
+    for name, data in (("chi-para", pos), ("chi-dia", dia)):
+        nib.save(nib.Nifti1Image(data.astype(np.float32), chi_nii.affine, chi_nii.header),
+                 str(out / f"{name}.nii.gz"))
+    print(f"ridani-null: B0={b0} T, Dr+={dr_pos:.1f} Hz/ppm, {mode} -> chi-para/chi-dia")
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/ridani-null-qsmci/run.sh
+++ b/algorithms/ridani-null-qsmci/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IN="${1:-/input}"; OUT="${2:-/output}"
+python3 "$(dirname "$0")/recon.py" "$IN" "$OUT"

--- a/eval/qsm_eval.py
+++ b/eval/qsm_eval.py
@@ -208,7 +208,69 @@ def calcification_metrics(recon, truth, seg) -> tuple[float, float]:
     return moment_dev, streak
 
 
-def chisep_metrics(recon, truth, mask, seg=None, component="para") -> dict:
+# χ+ MSPE is averaged over the ROIs where paramagnetic susceptibility is a meaningful
+# quantification target — the deep-gray-matter iron nuclei plus cortical gray matter. White
+# matter (label 8) is excluded: χ+ there is ~1 ppb, so the percentage error has a near-zero
+# denominator and blows up (the paper notes χ+ MSPE in WM reaches thousands of %). χ− MSPE is
+# averaged over the white-matter sub-ROIs of the fibre-bundle atlas (passed as `wm_rois`).
+MSPE_PARA_ROIS = [1, 2, 3, 4, 5, 6, 7, 9]  # CN,GP,PU,RN,DN,SN,TH,GM (dseg labels; WM=8 excluded)
+
+
+def roi_mspe(recon, truth, labels, ids, sel_mask, min_vox=50, min_mean=5e-3) -> float:
+    """Mean squared percentage error of ROI MEANS (Ridani et al., MRM 10.1002/mrm.70468).
+
+    For each ROI, ((mean_recon - mean_truth) / mean_truth)^2 * 100, averaged across ROIs. This is
+    the paper's headline separation metric — a per-region quantification-bias measure, distinct from
+    the voxelwise NRMSE. ROIs with fewer than `min_vox` voxels or a near-zero truth mean (|mean| <
+    `min_mean` ppm — an unstable percentage denominator) are skipped."""
+    vals = []
+    for lab in ids:
+        sel = (labels == lab) & sel_mask
+        if int(sel.sum()) < min_vox:
+            continue
+        gt_mean = float(truth[sel].mean())
+        if abs(gt_mean) < min_mean:
+            continue
+        vals.append(((float(recon[sel].mean()) - gt_mean) / gt_mean) ** 2 * 100.0)
+    return float(np.mean(vals)) if vals else math.nan
+
+
+def theta_binned_mspe(recon, truth, theta, wm_mask, nbins=9) -> "list[float]":
+    """Voxelwise χ− MSPE in 10° fibre-to-B0 angle bins over the white-matter voxels (Ridani et al.,
+    MRM 10.1002/mrm.70468, Fig 5). Per bin, the per-voxel squared percentage errors are IQR-filtered
+    (1.5×IQR) then averaged. Returns nbins values (bin 0 = 0–10° parallel … bin 8 = 80–90°
+    perpendicular); a bin with too few voxels is NaN."""
+    edges = np.linspace(0, 90, nbins + 1)
+    th = theta[wm_mask]
+    r, g = recon[wm_mask], truth[wm_mask]
+    ok = g != 0
+    th, r, g = th[ok], r[ok], g[ok]
+    spe = ((r - g) / g) ** 2 * 100.0
+    out = []
+    for i in range(nbins):
+        sel = (th >= edges[i]) & (th < edges[i + 1] if i < nbins - 1 else th <= edges[i + 1])
+        v = spe[sel]
+        if v.size < 50:
+            out.append(math.nan)
+            continue
+        q1, q3 = np.percentile(v, [25, 75])
+        iqr = q3 - q1
+        v = v[(v >= q1 - 1.5 * iqr) & (v <= q3 + 1.5 * iqr)]
+        out.append(float(v.mean()))
+    return out
+
+
+def mev_from_profile(profile) -> float:
+    """Maximum error variation MEV = (MSPE_parallel − MSPE_perpendicular)/MSPE_parallel × 100 (Ridani
+    et al. Eq 15): the fractional drop in χ− error from fibres parallel to B0 (first occupied bin) to
+    perpendicular (last occupied bin). Positive ⇒ parallel fibres are harder, as expected."""
+    occ = [v for v in profile if v == v]  # drop NaN bins
+    if len(occ) < 2 or occ[0] == 0:
+        return math.nan
+    return (occ[0] - occ[-1]) / occ[0] * 100.0
+
+
+def chisep_metrics(recon, truth, mask, seg=None, component="para", wm_rois=None, theta=None) -> dict:
     """Metrics for one χ-separation source map.
 
     `component` is 'para' (χ+, paramagnetic — iron in deep gray matter and venous blood) or 'dia' (χ−,
@@ -237,11 +299,31 @@ def chisep_metrics(recon, truth, mask, seg=None, component="para") -> dict:
         out["dgm_linearity"] = dgm_linearity(recon, truth, seg)
         _, out["nrmse_blood"] = nrmse_challenge(recon, truth, blood)
         out["calc_leak"] = leak(calc)
+        # Paper per-ROI MSPE over the iron nuclei + GM (χ+ quantification target).
+        out["mspe"] = roi_mspe(recon, truth, seg, MSPE_PARA_ROIS, m)
     else:  # dia — χ− is a positive magnitude; flip sign so the calcification reads negative
         dev, streak = calcification_metrics(-recon, -truth, seg)
         out["calc_moment_dev"] = dev
         out["calc_streak"] = streak
         out["iron_leak"] = leak(dgm | blood)
+        # Paper per-ROI MSPE over the fibre-bundle atlas WM sub-ROIs (χ− anisotropy target, Fig 3).
+        wm_bundles = None
+        if wm_rois is not None:
+            wr = np.rint(wm_rois).astype(np.int32)
+            ids = sorted(set(np.unique(wr[m])) - {0})
+            out["mspe"] = roi_mspe(recon, truth, wr, ids, m)
+            wm_bundles = m & (wr > 0)
+        # Orientation dependence (Fig 5): θ-binned χ− MSPE profile + MEV, over the WM fibre bundles
+        # (or all WM if no atlas). Needs the fibre-to-B0 angle map θ. Captures the paper's effect and
+        # reproduces its SNR trend; the absolute MEV differs from Fig 5 (voxelwise bins vs their
+        # bundle-averaged ROIs — a ratio of bin errors is sensitive to that granularity).
+        if theta is not None:
+            wmm = wm_bundles if wm_bundles is not None else (m & (seg == 8))
+            wmm = wmm & (theta > 0)
+            if wmm.any():
+                prof = theta_binned_mspe(recon, truth, np.asarray(theta, np.float64), wmm)
+                out["mspe_theta"] = prof
+                out["mev"] = mev_from_profile(prof)
     return out
 
 
@@ -346,6 +428,12 @@ def main() -> None:
     p.add_argument("--component", choices=["para", "dia"], default="para",
                    help="χ-separation source for kind=chisep: para=χ+ (paramagnetic), dia=χ− (diamagnetic)")
     p.add_argument("--seg", type=Path, help="segmentation (enables region metrics for kind=chi/chisep)")
+    p.add_argument("--wm-rois", type=Path, default=None,
+                   help="white-matter sub-ROI label map (fibre-bundle atlas) for the χ− per-ROI MSPE "
+                        "(kind=chisep, component=dia)")
+    p.add_argument("--theta", type=Path, default=None,
+                   help="fibre-to-B0 angle map in degrees for the χ− orientation analysis (θ-binned "
+                        "MSPE profile + MEV; kind=chisep, component=dia)")
     p.add_argument("--mask", type=Path)
     p.add_argument("--track", default="sim", choices=["sim", "invivo"], help="dataset label")
     p.add_argument("--stage", default=None, help="stage/span this run implements (recorded)")
@@ -368,7 +456,9 @@ def main() -> None:
 
     if args.kind == "chisep":
         seg = np.rint(load(args.seg)).astype(np.int32) if args.seg else None
-        metrics = chisep_metrics(recon, truth, mask, seg, args.component)
+        wm_rois = load(args.wm_rois) if args.wm_rois and args.wm_rois.exists() else None
+        theta = load(args.theta) if args.theta and args.theta.exists() else None
+        metrics = chisep_metrics(recon, truth, mask, seg, args.component, wm_rois, theta)
     elif args.kind == "field":
         metrics = field_metrics(recon, truth, mask)
     elif args.seg:  # chi with segmentation -> full challenge suite

--- a/qsm_ci/scoring.py
+++ b/qsm_ci/scoring.py
@@ -116,7 +116,8 @@ def shard_partition(items: "list", spec: "str | None") -> "list":
 
 def eval_argv(python: str, eval_path: Path, recon: Path, truth: Path, kind: str, mask: Path,
               artifact: str, out_json: Path, *, stage: str, name: str, track: str,
-              runtime=None, seg: "Path | None" = None, component: "str | None" = None) -> list[str]:
+              runtime=None, seg: "Path | None" = None, component: "str | None" = None,
+              wm_rois: "Path | None" = None, theta: "Path | None" = None) -> list[str]:
     """Build the `python qsm_eval.py …` argv the scorer subprocess runs.
 
     This is the flag-assembly the three scoring wrappers (pipeline.score, sweep.score_xsim,
@@ -137,4 +138,8 @@ def eval_argv(python: str, eval_path: Path, recon: Path, truth: Path, kind: str,
         cmd += ["--seg", str(seg)]
     if component is not None:  # χ-separation source (para=χ+, dia=χ−) for the source-specific metrics
         cmd += ["--component", component]
+    if wm_rois is not None:  # fibre-bundle atlas WM sub-ROIs for the χ− per-ROI MSPE
+        cmd += ["--wm-rois", str(wm_rois)]
+    if theta is not None:  # fibre-to-B0 angle map for the χ− orientation analysis (MEV)
+        cmd += ["--theta", str(theta)]
     return cmd

--- a/scripts/check_r2prime_consistency.py
+++ b/scripts/check_r2prime_consistency.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""check_r2prime_consistency — is the shipped R2' ground truth consistent with the shipped signal?
+
+Fits R2* from the multi-echo GRE magnitude and R2 from the multi-echo SE magnitude
+(log-linear mono-exponential fits), derives R2' = clip(R2* - R2, 0), and correlates it
+against the shipped inputs/r2prime.nii.gz within the brain mask and within WM (dseg==8).
+
+A low correlation (~0.24 on the 2026-08 phantom) indicates the GT/signal PSF mismatch
+(GT image-space-resized, signal k-space-cropped); a consistent phantom should sit near
+the noise-limited ceiling (~0.95+ at peak SNR 100, cf. QSM.rs SNR sweep).
+
+Usage:
+  python scripts/check_r2prime_consistency.py data/sim/chisep
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import nibabel as nib
+
+
+def fit_r2_loglin(mag4d: np.ndarray, tes: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Voxel-wise mono-exponential rate via log-linear least squares: ln S = ln S0 - TE*R."""
+    eps = 1e-12
+    logs = np.log(np.maximum(mag4d, eps))
+    t = tes - tes.mean()
+    denom = (t ** 2).sum()
+    slope = np.tensordot(logs, t, axes=([3], [0])) / denom
+    r = -slope
+    r[~mask] = 0.0
+    return r.astype(np.float32)
+
+
+def corr(a: np.ndarray, b: np.ndarray, m: np.ndarray) -> float:
+    x, y = a[m], b[m]
+    if x.size < 10 or x.std() == 0 or y.std() == 0:
+        return float("nan")
+    return float(np.corrcoef(x, y)[0, 1])
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("dataset", type=Path, help="dataset dir with inputs/ (magnitude, se_magnitude, r2prime, mask, params.json)")
+    ap.add_argument("--wm-label", type=int, default=8, help="WM label in groundtruth/dseg (default 8)")
+    args = ap.parse_args()
+
+    inp = args.dataset / "inputs"
+    params = json.loads((inp / "params.json").read_text())
+    tes = np.asarray(params["TE"], float)
+    se_tes = np.asarray(params["se_TE"], float)
+
+    mag = nib.load(str(inp / "magnitude.nii.gz")).get_fdata()
+    se = nib.load(str(inp / "se_magnitude.nii.gz")).get_fdata()
+    r2p_gt = nib.load(str(inp / "r2prime.nii.gz")).get_fdata()
+    mask = nib.load(str(inp / "mask.nii.gz")).get_fdata() > 0
+
+    r2star = fit_r2_loglin(mag, tes, mask)
+    r2 = fit_r2_loglin(se, se_tes, mask)
+    r2p = np.clip(r2star - r2, 0, None)
+
+    print(f"dataset: {args.dataset}")
+    print(f"  GRE TEs (ms): {(tes * 1e3).astype(int).tolist()}   SE TEs (ms): {(se_tes * 1e3).astype(int).tolist()}")
+    print(f"  brain: R2* mean {r2star[mask].mean():6.2f} Hz | R2 mean {r2[mask].mean():6.2f} Hz | "
+          f"R2' fit mean {r2p[mask].mean():5.2f} Hz vs GT {r2p_gt[mask].mean():5.2f} Hz")
+    print(f"  corr(R2'_fit, R2'_GT) brain = {corr(r2p, r2p_gt, mask):+.3f}")
+
+    dseg_p = args.dataset / "groundtruth" / "dseg.nii.gz"
+    if dseg_p.exists():
+        dseg = nib.load(str(dseg_p)).get_fdata()
+        wm = mask & (dseg == args.wm_label)
+        print(f"  corr(R2'_fit, R2'_GT) WM(dseg=={args.wm_label}, n={int(wm.sum())}) = {corr(r2p, r2p_gt, wm):+.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/datasets.json
+++ b/scripts/datasets.json
@@ -1,0 +1,56 @@
+{
+  "sim": {
+    "track": "sim",
+    "label": "In silico (2019)",
+    "osf_file": "698ac9aecae88916d1e24f69",
+    "path": "data/sim/scoring",
+    "active": true,
+    "default": true
+  },
+  "invivo": {
+    "track": "invivo",
+    "label": "In vivo (2016)",
+    "osf_env": "OSF_FILE_INVIVO",
+    "osf_file": "hw9rn",
+    "path": "data/invivo/scoring",
+    "prepacked": true,
+    "active": true,
+    "default": true
+  },
+  "ridani-3t-iso": {
+    "track": "chisep",
+    "label": "Ridani 3T isotropic",
+    "osf_env": "OSF_FILE_RIDANI_3T_ISO",
+    "prepacked": true,
+    "path": "data/ridani-3t-iso/scoring",
+    "active": true,
+    "default": false
+  },
+  "ridani-3t-aniso": {
+    "track": "chisep",
+    "label": "Ridani 3T anisotropic",
+    "osf_env": "OSF_FILE_RIDANI_3T_ANISO",
+    "prepacked": true,
+    "path": "data/ridani-3t-aniso/scoring",
+    "active": true,
+    "default": false
+  },
+  "ridani-7t-aniso": {
+    "track": "chisep",
+    "label": "Ridani 7T anisotropic",
+    "osf_env": "OSF_FILE_RIDANI_7T_ANISO",
+    "prepacked": true,
+    "path": "data/ridani-7t-aniso/scoring",
+    "active": true,
+    "default": false
+  },
+  "chisep-mc": {
+    "track": "chisep",
+    "label": "χ-sep multicompartment (7T)",
+    "osf_env": "OSF_FILE_CHISEP_MC",
+    "prepacked": true,
+    "path": "data/chisep-mc/scoring",
+    "active": true,
+    "default": true
+  }
+}

--- a/scripts/fetch_dataset.sh
+++ b/scripts/fetch_dataset.sh
@@ -9,31 +9,46 @@
 #   groundtruth/  held-out targets + isolated-mode input boundaries (totalfield, localfield,
 #                 chimap, dseg) — never committed.
 #
-# Usage: fetch_dataset.sh <track> <dest>
+# Usage: fetch_dataset.sh <phantom> <dest>
+#   <phantom> is a scripts/datasets.json registry key. The legacy track args (sim / invivo)
+#   are themselves registry keys, so existing callers keep working identically.
 # Env:   OSF_TOKEN     (required unless OSF_ZIP is set) — OSF personal access token
-#        OSF_PROJECT   (default y8adf), OSF_FILE (default the bids.zip file id)
-#        OSF_FILE_INVIVO (invivo track) — OSF file id of the pre-flattened invivo_qsm2016.zip
+#        OSF_PROJECT   (default y8adf), OSF_FILE (overrides the registry's file id)
+#        OSF_FILE_*    (per-phantom secrets) — the registry's `osf_env` names which one applies
+#                      (e.g. OSF_FILE_CHISEP_MC for the chisep-mc phantom)
 #        OSF_ZIP       (optional) — persistent path for the download. If it exists it's reused (no
 #                      download); if not, the download is saved there. Point CI's cache at it.
 #
-# Tracks: sim ships as a qsm-forward BIDS tree (flattened here by pack_dataset.py). The chisep and
-# invivo tracks ship ALREADY FLATTENED (inputs/ + groundtruth/ at the zip root — chisep built by
-# gen_chisep.py / pack_dataset.py, invivo by scripts/make_invivo_zip.py), so they skip the BIDS-find
-# + pack step and just unzip straight into $DEST.
+# Phantoms shipping qsm-forward BIDS trees are flattened here by pack_dataset.py (with the registry's
+# `pack_flags`, e.g. --chisep). A registry entry with `prepacked: true` (the 2016 invivo challenge
+# zip, built by scripts/make_invivo_zip.py) ships ALREADY FLATTENED (inputs/ + groundtruth/ at the
+# zip root), so it skips the BIDS-find + pack step and just unzips straight into $DEST.
 set -euo pipefail
 
-TRACK="${1:?track required}"
+TRACK="${1:?phantom (scripts/datasets.json key) required}"
 DEST="${2:?dest dir required}"
 OSF_PROJECT="${OSF_PROJECT:-y8adf}"
-# Dataset zip file id per track. The χ-separation phantom (χ+/χ− sources + R2' derivatives) lives in
-# its own OSF file — set OSF_FILE_CHISEP (or override OSF_FILE). It ships pre-flattened, so PACK_FLAGS
-# is unused for it (kept only for the sim track's BIDS flatten).
-case "$TRACK" in
-  chisep) OSF_FILE="${OSF_FILE:-${OSF_FILE_CHISEP:?set OSF_FILE_CHISEP to the χ-sep dataset OSF file id}}"; PACK_FLAGS="--chisep" ;;
-  invivo) OSF_FILE="${OSF_FILE:-${OSF_FILE_INVIVO:-hw9rn}}"; PACK_FLAGS="" ;;   # invivo_qsm2016.zip (osf.io/hw9rn), pre-flattened
-  *)      OSF_FILE="${OSF_FILE:-698ac9aecae88916d1e24f69}"; PACK_FLAGS="" ;;   # QSM bids
-esac
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve the phantom in the dataset registry (scripts/datasets.json): its OSF file id (an explicit
+# $OSF_FILE overrides everything; else the env secret named by the entry's `osf_env`; else the
+# literal `osf_file`), its pack_dataset.py flags, and whether the zip is prepacked.
+RESOLVED="$(python3 - "$TRACK" "$SCRIPT_DIR/datasets.json" <<'PY'
+import json, os, sys
+ph, regfile = sys.argv[1], sys.argv[2]
+d = json.load(open(regfile)).get(ph)
+if d is None:
+    sys.exit(f"[fetch_dataset] unknown phantom '{ph}' — add it to scripts/datasets.json")
+osf = os.environ.get("OSF_FILE") or (os.environ.get(d["osf_env"]) if d.get("osf_env") else None) \
+      or d.get("osf_file")
+if not osf:
+    sys.exit(f"[fetch_dataset] no OSF file id for phantom '{ph}' — "
+             f"set {d.get('osf_env', 'OSF_FILE')} (or OSF_FILE)")
+print(f"OSF_FILE={osf}")
+print(f"PACK_FLAGS={d.get('pack_flags', '')}")
+print(f"PREPACKED={'1' if d.get('prepacked') else '0'}")
+PY
+)"
+eval "$RESOLVED"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -57,10 +72,9 @@ else
   curl -fS --location-trusted -H "Authorization: Bearer ${OSF_TOKEN}" "$url" -o "$zip"
 fi
 
-# The chisep and invivo zips are ALREADY flattened (inputs/ + groundtruth/ at the zip root — chisep
-# from gen_chisep.py/pack_dataset.py, invivo from scripts/make_invivo_zip.py). No BIDS tree, no pack
-# step: just unzip straight into $DEST.
-if [ "$TRACK" = "invivo" ] || [ "$TRACK" = "chisep" ]; then
+# A prepacked zip (registry `prepacked: true`, e.g. the invivo challenge) is ALREADY flattened
+# (inputs/ + groundtruth/ at its root) — no BIDS tree, no pack step. Unzip it straight into $DEST.
+if [ "$PREPACKED" = "1" ]; then
   rm -rf "$DEST"
   mkdir -p "$DEST"
   unzip -q "$zip" -d "$DEST"

--- a/scripts/gen_chisep.py
+++ b/scripts/gen_chisep.py
@@ -8,25 +8,46 @@ white-matter anisotropy (χ- = Δχ·cos²θ + χ0, θ = fibre-to-B0 angle from 
 χ_total = χ+ + χ- is the shipped susceptibility map and drives the simulated field and multi-echo GRE
 signal. Acquisition: 7 T, 4 echoes [4,12,20,28] ms, 1 mm, peak SNR 100, seed 42.
 
+DEFAULTS REPRODUCE THE RIDANI MODEL: --dr-model scaled (their theoretical kernels), anisotropy on,
+their 7T protocol (TR 50 ms, flip 15°, TEs 4/12/20/28 ms), no multicompartment signal, and the
+V1 L-A-S→R-A-S flip (which Ridani's published phantom also uses — see V1 ORIENTATION below).
+Departures from Ridani-as-published that remain on by default: the matched spin-echo acquisition
+(additive data the benchmark needs; the SE model is plain mono-exponential R2 unless
+--multicompartment) and the native-resolution packaging.
+
+THE QSM-CI SHIPPING CONFIGURATION is explicit:
+  python scripts/gen_chisep.py --multicompartment --dr-model fixed --dr-fixed 320 \
+      --tes 3,9,15,21,27,33,39,45 --out data/sim/chisep-ship
+
 Susceptibility-to-R2' relaxivity (Dr) magnitude, selected with --dr-model (both keep the same
 orientation-dependent sin^2(theta) shape for Dr-; they differ only in absolute magnitude):
-  fixed (default): paramagnetic relaxivity anchored at Dr+ = 137 Hz/ppm (Shin et al. 2021 [3]),
-      field-independent; the diamagnetic relaxivity is scaled by the same factor. Produces R2'
-      magnitudes consistent with in-vivo χ-separation calibrations at any field strength.
-  scaled: magnitude from the static-dephasing model (Yablonskiy & Haacke 1994 [4]) as used in [1] —
-      Dr+ = 2πγB0/(9√3) for spherical sources, Dr- = ½γB0·sin²θ for cylindrical sources — which scales
-      linearly with field (Dr+ = 107.84·B0, Dr- = 133.77·sin²θ·B0 Hz/ppm).
+  scaled (default; Ridani's convention): magnitude from the static-dephasing model (Yablonskiy &
+      Haacke 1994 [4]) as used in [1] — Dr+ = 2πγB0/(9√3) for spherical sources, Dr- = ½γB0·sin²θ for
+      cylindrical sources — which scales linearly with field (Dr+ = 107.84·B0, Dr- = 133.77·sin²θ·B0
+      Hz/ppm).
+  fixed: paramagnetic relaxivity anchored at --dr-fixed Hz/ppm (default 137, Shin et al. 2021 [3];
+      the shipping config uses 320 = 137·(7/3), the field-scaled empirical calibration),
+      field-independent in B0; the diamagnetic relaxivity is scaled by the same factor.
 The χ+/χ- ground truth is identical for both; only R2' and the signal decay scale differ.
---isotropic disables anisotropy (spatially constant Dr- = 700.8 Hz/ppm).
+--isotropic disables anisotropy (spatially constant Dr-).
 
 Required inputs in the qsm-forward data dir:
   chimodel/, maps/{R1,R2star,M0,V1}, masks/{SegmentedModel,BrainMask,highgrad,white_matter_mask},
   raw/rawField.nii.gz (total field, used for the intra-tissue two-model weighting).
 
-The χ+/χ- construction wavelet-denoises R1/R2* (~5 min) and the field/signal simulation needs several
-GB of RAM; run the full path on a compute node.
+PSF consistency: the maps are built at the native 0.64 mm (the χ+/χ- texture construction needs the
+real R1/R2* maps), then ALL maps are image-space-downsampled ONCE to the scoring resolution and the
+field + GRE + SE signals are simulated NATIVELY at that resolution (no k-space crop anywhere). The
+ground truth is exactly the maps that generated the signal — the signal-derivable R2' = R2*-R2 matches
+the shipped r2prime with corr 1.000 in the noiseless limit (the historical 0.64-mm-sim +
+k-space-crop design mismatched the GT/signal PSFs, corr 0.24 — see STATUS.md). Trade-off: the
+signal carries no sub-voxel partial-volume content (a scored phantom cannot have both a clean
+parameter GT and a realistic sub-voxel PV signal).
 
-  [1] Ridani S., De Leener B., Alonso-Ortiz E. bioRxiv 2026. doi:10.64898/2026.04.07.716972
+The χ+/χ- construction wavelet-denoises R1/R2* (~5 min); the default native-resolution simulation is
+light enough to run locally.
+
+  [1] Ridani D., De Leener B., Alonso-Ortiz E. Magn Reson Med 2026. doi:10.1002/mrm.70468
   [2] Marques J.P. et al. Magn Reson Med 2021;86(1):526-542. doi:10.1002/mrm.28716
   [3] Shin H.G. et al. NeuroImage 2021;240:118371. doi:10.1016/j.neuroimage.2021.118371
   [4] Yablonskiy D.A., Haacke E.M. Magn Reson Med 1994;32(6):749-763. doi:10.1002/mrm.1910320610
@@ -34,7 +55,7 @@ GB of RAM; run the full path on a compute node.
 Usage (qsm-forward venv):
   python scripts/gen_chisep.py --maps-only --validate                        # cheap χ+/χ-/R2' check
   python scripts/gen_chisep.py --out data/sim/chisep                         # full sim (compute node)
-  python scripts/gen_chisep.py --dr-model scaled --out data/sim/chisep-scaled
+  python scripts/gen_chisep.py --dr-model fixed --dr-fixed 320 --out data/sim/chisep-empirical
   python scripts/gen_chisep.py --isotropic --out data/sim/chisep-isotropic
 """
 
@@ -51,6 +72,12 @@ import nibabel as nib
 
 SEED = 42
 B0 = 7.0
+# V1 ORIENTATION. The challenge V1.nii.gz is stored L-A-S — mirrored along the first (x) axis
+# relative to every other map (all R-A-S). np.flip(V1, axis=0) registers it; this is what
+# Ridani's published phantom used (theta from the flipped V1 reproduces their published theta
+# map exactly, max diff 0.0000 deg). No vector-component negation is needed: theta only uses
+# squared components. The historical integer shift (+5,+1,-6), chosen by mask overlap, was a
+# flip-of-an-off-center-brain in disguise and is retired.
 B0_DIR = np.array([0.0, 0.0, 1.0])
 TES = np.array([0.004, 0.012, 0.020, 0.028])
 VOXEL = np.array([1.0, 1.0, 1.0])
@@ -59,29 +86,32 @@ DR_FIXED_POS = 137.0  # Hz/ppm, paramagnetic relaxivity (Shin et al. 2021)
 SE_TR = 1.5           # s, spin-echo repetition time
 SE_TES = np.array([0.010, 0.030, 0.050, 0.070])  # s, multi-echo spin-echo (magnitude decays with R2)
 
+# As-published Ridani et al. (MRM doi:10.1002/mrm.70468) configurations. All three are
+# noiseless, GRE-only (no SE; the paper's R2' convention is R2*_fit - R2_GT, so the GT R2
+# ships as an input instead) and use the theoretical field-scaled Dr kernels. The default
+# V1 flip applies (their phantom used it — see V1 ORIENTATION above).
+# 3T protocol: TR 50 ms, FA 15, TE1/dTE/TE6 = 3/4/23 ms; 7T: TE1/dTE/TE4 = 4/8/28 ms.
+_RIDANI_COMMON = dict(dr_model="scaled", noiseless=True, no_se=True, r2_input=True, voxel=0.0,
+                      no_fiber_angle=True)
+RIDANI_PRESETS = {
+    "ridani-3t-iso":   dict(b0=3.0, tes="3,7,11,15,19,23", isotropic=True, **_RIDANI_COMMON),
+    "ridani-3t-aniso": dict(b0=3.0, tes="3,7,11,15,19,23", isotropic=False, **_RIDANI_COMMON),
+    "ridani-7t-aniso": dict(b0=7.0, tes="4,12,20,28", isotropic=False, **_RIDANI_COMMON),
+}
 
-def mask_derived_to_brain(out: Path):
-    """Restrict the derived maps and ground truth to the brain, leaving the raw
-    phase/magnitude (which carry the whole-head background field) untouched."""
-    m = nib.load(str(out / "inputs" / "mask.nii.gz")).get_fdata() > 0
-    for rel in ("inputs/chimap.nii.gz", "inputs/r2prime.nii.gz", "inputs/localfield.nii.gz",
-                "groundtruth/chi-para.nii.gz", "groundtruth/chi-dia.nii.gz", "groundtruth/chimap.nii.gz"):
-        p = out / rel
-        if p.exists():
-            im = nib.load(str(p))
-            nib.save(nib.Nifti1Image((im.get_fdata() * m).astype(np.float32), im.affine, im.header), str(p))
 
-
-def write_maps_dataset(out: Path, chi_total, r2prime, mask, chi_pos, chi_neg, affine, header):
-    def save(rel, data):
-        p = out / rel
-        p.parent.mkdir(parents=True, exist_ok=True)
-        nib.save(nib.Nifti1Image(np.asarray(data, np.float32), affine, header), str(p))
-    save("inputs/chimap.nii.gz", chi_total)
-    save("inputs/r2prime.nii.gz", r2prime)
-    save("inputs/mask.nii.gz", mask.astype(np.float32))
-    save("groundtruth/chi-para.nii.gz", chi_pos)
-    save("groundtruth/chi-dia.nii.gz", np.abs(chi_neg))
+def _ds_theta(theta, ds):
+    """Downsample a fibre-angle map whose no-fibre voxels are NaN, by normalized interpolation:
+    interpolate the NaN-zeroed values and a validity indicator separately, divide, and mark
+    voxels with less than half fibre support as NaN (spline-interpolating NaNs directly is
+    ill-defined and leaks them into neighbouring voxels)."""
+    valid = np.isfinite(theta).astype(np.float32)
+    num = ds(np.nan_to_num(theta).astype(np.float32))
+    den = ds(valid)
+    out = np.full(num.shape, np.nan, np.float32)
+    ok = den > 0.5
+    out[ok] = num[ok] / den[ok]
+    return out
 
 
 def write_fiber_angle(out: Path, v1, b0_dir, affine, header, out_shape, brain_mask):
@@ -105,6 +135,31 @@ def write_fiber_angle(out: Path, v1, b0_dir, affine, header, out_shape, brain_ma
     print(f"  wrote {p.name} (fibre-to-B0 angle in deg; optional WM-anisotropy input)")
 
 
+def mask_derived_to_brain(out: Path):
+    """Restrict the derived maps and ground truth to the brain, leaving the raw
+    phase/magnitude (which carry the whole-head background field) untouched."""
+    m = nib.load(str(out / "inputs" / "mask.nii.gz")).get_fdata() > 0
+    for rel in ("inputs/chimap.nii.gz", "inputs/r2prime.nii.gz", "inputs/localfield.nii.gz",
+                "inputs/r2.nii.gz",
+                "groundtruth/chi-para.nii.gz", "groundtruth/chi-dia.nii.gz", "groundtruth/chimap.nii.gz"):
+        p = out / rel
+        if p.exists():
+            im = nib.load(str(p))
+            nib.save(nib.Nifti1Image((im.get_fdata() * m).astype(np.float32), im.affine, im.header), str(p))
+
+
+def write_maps_dataset(out: Path, chi_total, r2prime, mask, chi_pos, chi_neg, affine, header):
+    def save(rel, data):
+        p = out / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        nib.save(nib.Nifti1Image(np.asarray(data, np.float32), affine, header), str(p))
+    save("inputs/chimap.nii.gz", chi_total)
+    save("inputs/r2prime.nii.gz", r2prime)
+    save("inputs/mask.nii.gz", mask.astype(np.float32))
+    save("groundtruth/chi-para.nii.gz", chi_pos)
+    save("groundtruth/chi-dia.nii.gz", np.abs(chi_neg))
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--qsmf-data", type=Path, default=Path.home() / "repos/qsm/qsm-forward/data")
@@ -116,24 +171,88 @@ def main() -> None:
                     help="also ship the derived maps (chimap, R2', local field) and ground truth over the "
                          "whole head; by default these are masked to the brain while the raw phase/magnitude "
                          "keep the whole-head background field")
-    ap.add_argument("--dr-model", choices=["fixed", "scaled"], default="fixed",
-                    help="Dr relaxivity magnitude (default: fixed, Dr+ = 137 Hz/ppm, field-independent; "
-                         "scaled: static-dephasing Dr+ = 107.84*B0, Dr- = 133.77*sin^2(theta)*B0)")
+    ap.add_argument("--dr-model", choices=["fixed", "scaled"], default="scaled",
+                    help="Dr relaxivity magnitude (default: scaled — Ridani's own convention, the "
+                         "theoretical static-dephasing kernels Dr+ = 107.84*B0, Dr- = 133.77*sin^2(theta)*B0 "
+                         "Hz/ppm; fixed: anchor Dr+ at --dr-fixed Hz/ppm, field-independent — the "
+                         "QSM-CI shipping config uses --dr-model fixed --dr-fixed 320)")
+    ap.add_argument("--b0", type=float, default=7.0,
+                    help="acquisition field strength in tesla (default 7.0)")
+    ap.add_argument("--dr-fixed", type=float, default=DR_FIXED_POS,
+                    help="Dr+ anchor for --dr-model fixed, Hz/ppm (default %g = Shin's 3T-empirical "
+                         "calibration; the literature-consistent 7T value is ~320 = 137*(7/3), since "
+                         "Dr scales linearly with B0)" % DR_FIXED_POS)
+    ap.add_argument("--peak-snr", type=float, default=PEAK_SNR,
+                    help="peak SNR of the simulated acquisition (default %g)" % PEAK_SNR)
+    ap.add_argument("--voxel", type=float, default=1.0,
+                    help="isotropic scoring/simulation voxel size in mm (default 1.0); 0 keeps the "
+                         "native 0.64 mm grid with no resampling at all (the Ridani presets use this, "
+                         "matching the reference's native-resolution data)")
+    ap.add_argument("--hc-b0", type=float, default=None,
+                    help="effective field strength for the hollow-cylinder pool physics only "
+                         "(default: the acquisition --b0). E.g. 1.27 evaluates the mechanistic WM "
+                         "dephasing at the field where the physical Dr equals the fixed calibration "
+                         "Dr=137. Requires qsm-forward with chisep_hc_b0 support.")
+    ap.add_argument("--multicompartment", action="store_true",
+                    help="enable the hollow-cylinder 3-pool WM GRE signal (qsm-forward PR #7): θ-dependent "
+                         "non-mono-exponential decay makes WM anisotropy recoverable from the signal. "
+                         "Native-resolution path only.")
+    ap.add_argument("--tes", default=None,
+                    help="comma-separated GRE TEs in ms (default: 4,12,20,28); e.g. a denser train for "
+                         "the multicompartment myelin-water beat")
+    ap.add_argument("--se-tes", default=None,
+                    help="comma-separated spin-echo TEs in ms (default: 10,30,50,70)")
+    ap.add_argument("--no-v1-flip", action="store_true",
+                    help="skip the V1 L-A-S -> R-A-S registration flip (see V1 ORIENTATION); reproduces "
+                         "the public PhantomCreation.m behaviour (mirrored fibres) — for comparison only")
+    ap.add_argument("--noiseless", action="store_true",
+                    help="skip acquisition noise entirely (the Ridani headline configs are noiseless)")
+    ap.add_argument("--no-se", action="store_true",
+                    help="skip the matched spin-echo acquisition (the Ridani phantom simulates GRE only)")
+    ap.add_argument("--no-fiber-angle", action="store_true",
+                    help="do not ship inputs/fiber_angle.nii.gz (the DTI orientation input); the Ridani "
+                         "reproduction datasets omit it so orientation cannot be handed to methods — a "
+                         "closed-form null with fiber_angle is near-exact on the anisotropic phantom")
+    ap.add_argument("--wm-rois-src", type=Path, default=None,
+                    help="fibre-bundle WM sub-ROI atlas (Ridani OSF 9xwhz Masks/WM_fibers_seg.nii.gz) to "
+                         "ship as groundtruth/wm_rois.nii.gz — the label map the χ- per-ROI MSPE averages over")
+    ap.add_argument("--r2-input", action="store_true",
+                    help="ship the ground-truth R2 map as inputs/r2.nii.gz (the Ridani evaluation "
+                         "convention: methods fit R2* from the GRE and use R2' = R2*_fit - R2_GT)")
+    ap.add_argument("--preset", choices=sorted(RIDANI_PRESETS),
+                    help="as-published Ridani et al. (MRM 10.1002/mrm.70468) configurations: sets B0, "
+                         "echo train, iso/aniso, scaled Dr, noiseless, GRE-only + r2 input")
     ap.add_argument("--maps-only", action="store_true", help="only build χ+/χ-/R2' (+ maps dataset), no sim")
     ap.add_argument("--validate", action="store_true", help="run validate_phantom.py on the written dataset")
     args = ap.parse_args()
+    if args.preset:
+        for k, v in RIDANI_PRESETS[args.preset].items():
+            setattr(args, k, v)
+        print(f"Preset {args.preset}: B0={args.b0}T TEs={args.tes} isotropic={args.isotropic} "
+              f"dr_model={args.dr_model} noiseless, GRE-only (+ inputs/r2)")
 
     try:
         import qsm_forward as q
     except ModuleNotFoundError:
         sys.exit("import qsm_forward failed — run with the qsm-forward venv python.")
 
+    tes = TES if args.tes is None else np.array([float(t) * 1e-3 for t in args.tes.split(",")])
+    se_tes = SE_TES if args.se_tes is None else np.array([float(t) * 1e-3 for t in args.se_tes.split(",")])
+
     aniso = not args.isotropic
     data = str(args.qsmf_data)
     print(f"Building χ+/χ- (anisotropy={aniso})...")
+    # Register V1 to the segmentation (see V1 ORIENTATION) BEFORE it feeds anything — the χ-
+    # anisotropy ground truth, theta and fiber_angle must all use the same registered fibres.
+    v1_kw = {}
+    if not args.no_v1_flip:
+        v1_path = args.qsmf_data / "maps" / "V1.nii.gz"
+        if v1_path.exists():
+            v1_kw["v1"] = np.flip(nib.load(str(v1_path)).get_fdata().astype(np.float32), axis=0).copy()
+            print("  V1 registered to the segmentation: L-A-S -> R-A-S flip along axis 0")
     # Build whole-head χ so the simulated field/signal carry the background field; the derived maps
     # and ground truth are masked to the brain after packing (unless --full-head).
-    tp = q.TissueParams(root_dir=data, chisep_anisotropy=aniso, chisep_apply_brain_mask=False)
+    tp = q.TissueParams(root_dir=data, chisep_anisotropy=aniso, chisep_apply_brain_mask=False, **v1_kw)
     chi_pos = tp.chi_pos.get_fdata().astype(np.float32)
     chi_neg = tp.chi_neg.get_fdata().astype(np.float32)
     chi_total = (chi_pos + chi_neg).astype(np.float32)
@@ -143,8 +262,8 @@ def main() -> None:
     # Orientation-dependent relaxivity maps (Dr+ spherical, Dr- cylindrical sin^2(theta)).
     # dr_fixed anchors Dr+ at 137 Hz/ppm (field-independent); None keeps the field-scaled magnitudes.
     theta = q.generate_theta_from_v1(tp.v1.get_fdata(), B0_DIR) if tp.v1 is not None else None
-    dr_fixed = DR_FIXED_POS if args.dr_model == "fixed" else None
-    dr_pos_map, dr_neg_map = q.generate_dr_maps_ridani(seg, theta, B0=B0, anisotropic=aniso, dr_fixed=dr_fixed)
+    dr_fixed = args.dr_fixed if args.dr_model == "fixed" else None
+    dr_pos_map, dr_neg_map = q.generate_dr_maps_ridani(seg, theta, B0=args.b0, anisotropic=aniso, dr_fixed=dr_fixed)
     print(f"  Dr model={args.dr_model}: Dr+ = {dr_pos_map[dr_pos_map > 0].mean():.1f} Hz/ppm")
     r2prime = q.generate_r2prime(chi_pos, chi_neg, dr=dr_pos_map, dr_neg=dr_neg_map)
 
@@ -161,36 +280,109 @@ def main() -> None:
                               mask.shape, (mask if args.full_head else mask).astype(np.float32))
         print(f"--maps-only: wrote maps dataset to {args.out} (no field/signal sim).")
     else:
-        print("Simulating field + χ-separation GRE signal...")
-        # Write the built maps to files carrying the base 0.64 mm header/affine, so generate_bids
-        # downsamples to the requested voxel size (passing bare arrays would lose the zoom and skip it).
         tmpd = tempfile.mkdtemp()
-        def _w(name, arr):
+        # PSF-consistent design: downsample ALL maps to the scoring resolution ONCE (image-space,
+        # the same operator the ground truth has always used — the shipped GT is unchanged), then
+        # simulate field + signal NATIVELY at that resolution so no k-space crop happens anywhere.
+        # Every input and the GT then share a single (identity) PSF: the signal-derived
+        # R2' = R2*-R2 matches the shipped r2prime exactly in the noiseless limit (corr 1.000; the
+        # historical 0.64-mm-sim + k-space-crop design scored 0.24 — see STATUS.md, removed
+        # 2026-08-11), at the cost of sub-voxel partial-volume content in the signal (a scored
+        # phantom cannot have both — QSM.rs PSF lessons).
+        # --voxel 0 keeps the native grid (no resample at all — the Ridani presets, matching the
+        # reference's native-resolution outputs).
+        native = args.voxel <= 0
+        voxel = np.asarray(tp.voxel_size, float) if native else np.array([args.voxel] * 3, float)
+        print("Simulating at the native grid (no resample, no k-space crop)..." if native else
+              f"Downsampling maps to {voxel.tolist()} mm and simulating NATIVELY (no k-space crop)...")
+        def _ds(arr, interp="continuous"):
+            if native:
+                return np.asarray(arr, np.float32)
+            nii = nib.Nifti1Image(np.asarray(arr, np.float32), tp.nii_affine, tp.nii_header)
+            return q.resize(nii, voxel, interp).get_fdata().astype(np.float32)
+        chi_pos = _ds(chi_pos)
+        chi_neg = _ds(chi_neg)
+        chi_total = chi_pos + chi_neg
+        dr_pos_sim = _ds(dr_pos_map)
+        dr_neg_sim = _ds(dr_neg_map)
+        th1 = theta.astype(np.float32) if (theta is not None and native) else (
+            _ds_theta(theta, _ds) if theta is not None else None)
+        aff1 = tp.nii_affine if native else q.resize(
+            nib.Nifti1Image(chi_total, tp.nii_affine, tp.nii_header), voxel).affine
+        def _w1(name, arr):
             p = str(Path(tmpd) / name)
-            nib.save(nib.Nifti1Image(arr.astype(np.float32), tp.nii_affine, tp.nii_header), p)
+            nib.save(nib.Nifti1Image(np.asarray(arr, np.float32), aff1), p)
             return p
-        tp2 = q.TissueParams(root_dir=data,
-                             chi=_w("chi.nii.gz", chi_total),
-                             chi_pos=_w("chi_pos.nii.gz", chi_pos),
-                             chi_neg=_w("chi_neg.nii.gz", chi_neg))
-        rp = q.ReconParams(subject="1", B0=B0, TEs=TES, voxel_size=VOXEL, peak_snr=PEAK_SNR,
-                           random_seed=SEED, se_TR=SE_TR, se_TEs=SE_TES)
+        tp2 = q.TissueParams(
+            root_dir=data,
+            chi=_w1("chi.nii.gz", chi_total),
+            chi_pos=_w1("chi_pos.nii.gz", chi_pos),
+            chi_neg=_w1("chi_neg.nii.gz", chi_neg),
+            mask=_w1("mask.nii.gz", _ds(tp.mask.get_fdata(), "nearest")),
+            seg=_w1("seg.nii.gz", _ds(seg, "nearest")),
+            M0=_w1("M0.nii.gz", _ds(tp.M0.get_fdata())),
+            R1=_w1("R1.nii.gz", _ds(tp.R1.get_fdata())),
+            R2star=_w1("R2star.nii.gz", _ds(tp.R2star.get_fdata())),
+            # V1-derived fibre-to-B0 angle (degrees) on the 1 mm grid — the hollow-cylinder
+            # multicompartment WM signal reads it as tissue_params.angle_map. theta is NaN
+            # where V1 has no fibre direction, so downsample by normalized interpolation
+            # (values-with-NaN-zeroed over a validity indicator) and mark voxels with <50%
+            # fibre support as NaN — qsm-forward gives those no hollow-cylinder enrichment.
+            angle_map=_w1("theta.nii.gz", th1) if th1 is not None else None,
+        )
+        rp = q.ReconParams(subject="1", B0=args.b0, TEs=tes, voxel_size=voxel, peak_snr=args.peak_snr,
+                           random_seed=None if args.noiseless else SEED, se_TR=SE_TR, se_TEs=se_tes)
+        extra = {}
+        if args.hc_b0 is not None:
+            extra["chisep_hc_b0"] = args.hc_b0
         q.generate_bids(
             tp2, rp, str(args.bids),
             save_field=True, save_chi_pos=True, save_chi_neg=True, save_r2prime=True,
-            dr_pos_map=dr_pos_map, dr_neg_map=dr_neg_map, dr=DR_FIXED_POS,
-            chisep_signal=True, chisep_multicompartment=False, save_se=True,
+            dr_pos_map=dr_pos_sim, dr_neg_map=dr_neg_sim, dr=DR_FIXED_POS,
+            chisep_signal=True, chisep_multicompartment=args.multicompartment,
+            save_se=not args.no_se, save_r2=args.r2_input,
+            **extra,
         )
         pack = Path(__file__).with_name("pack_dataset.py")
         print(f"Packing {args.bids} -> {args.out} ...")
         subprocess.run([sys.executable, str(pack), str(args.bids), str(args.out), "--chisep"], check=True)
+        if args.r2_input:
+            r2s = sorted(Path(args.bids).glob("derivatives/**/*_R2map.nii*"))
+            if not r2s:
+                sys.exit("--r2-input: no *_R2map.nii* found in the BIDS derivatives")
+            r2n = nib.load(str(r2s[0]))
+            nib.save(r2n, str(args.out / "inputs" / "r2.nii.gz"))
+            print("  wrote inputs/r2.nii.gz (ground-truth R2; Ridani R2' convention = R2*_fit - R2_GT)")
+        if aniso and th1 is not None:  # ship θ (fibre-to-B0 angle) for the χ- orientation analysis (MEV)
+            ref = nib.load(str(args.out / "groundtruth" / "chi-dia.nii.gz"))
+            # clip to [0,90]: resize-path interpolation can overshoot slightly past 90° (cos²θ is
+            # symmetric so it's harmless, but keep the angle physical)
+            theta_out = np.clip(np.nan_to_num(th1), 0.0, 90.0).astype(np.float32)
+            nib.save(nib.Nifti1Image(theta_out, ref.affine, ref.header),
+                     str(args.out / "groundtruth" / "theta.nii.gz"))
+            print("  wrote groundtruth/theta.nii.gz (fibre-to-B0 angle; for the θ-binned MSPE + MEV)")
+        if args.wm_rois_src:  # ship the fibre-bundle WM sub-ROI atlas for the χ- per-ROI MSPE
+            src = nib.load(str(args.wm_rois_src))
+            ref = nib.load(str(args.out / "groundtruth" / "chi-dia.nii.gz"))
+            lab = src.get_fdata()
+            if src.shape != ref.shape:  # nearest-neighbour resample to the packed grid
+                lab = q.resize(nib.Nifti1Image(np.rint(lab).astype(np.float32), src.affine, src.header),
+                               np.asarray(ref.header.get_zooms()[:3], float), "nearest").get_fdata()
+            nib.save(nib.Nifti1Image(np.rint(lab).astype(np.int16), ref.affine, ref.header),
+                     str(args.out / "groundtruth" / "wm_rois.nii.gz"))
+            print(f"  wrote groundtruth/wm_rois.nii.gz (fibre-bundle atlas, {int((np.rint(lab)>0).sum())} WM vox)")
         if not args.full_head:
             mask_derived_to_brain(args.out)
             print("Masked derived maps + ground truth to the brain (raw phase/magnitude kept whole-head).")
-        if aniso and tp.v1 is not None:  # optional DTI-orientation input, on the packed (downsampled) grid
+        if aniso and th1 is not None and not args.no_fiber_angle:  # optional DTI-orientation input
+            # Reuse the SAME resize-path theta the signal uses, so the shipped fiber_angle is
+            # grid-consistent with the simulated anisotropy (an index-space zoom of V1 lands
+            # ~1 voxel off the affine-resized grid).
             mimg = nib.load(str(args.out / "inputs" / "mask.nii.gz"))
-            write_fiber_angle(args.out, tp.v1.get_fdata(), B0_DIR, mimg.affine, mimg.header,
-                              mimg.shape, mimg.get_fdata())
+            ang = (np.nan_to_num(th1) * (mimg.get_fdata() > 0)).astype(np.float32)
+            nib.save(nib.Nifti1Image(ang, mimg.affine, mimg.header),
+                     str(args.out / "inputs" / "fiber_angle.nii.gz"))
+            print("  wrote fiber_angle.nii.gz (resize-path; grid-consistent with the signal theta)")
         print("Done. Re-score methods after regenerating.")
 
     if args.validate:

--- a/scripts/gen_manifest.py
+++ b/scripts/gen_manifest.py
@@ -4,6 +4,10 @@
 The submission page fetches this manifest to show what each algorithm is — description, parameters,
 citation/DOI, source, and any `ci_notes` — and the leaderboard uses it to badge methods that carry
 notes on how QSM-CI runs them.
+
+It also embeds the dataset/phantom registry (scripts/datasets.json) as a `datasets` block, so the
+site can label runs by the phantom they were scored on (run rows carry a `phantom` field; absence
+means the track's default phantom) and offer per-phantom filtering where a track has several.
 """
 from __future__ import annotations
 
@@ -110,7 +114,10 @@ def build() -> dict:
         validate(d, meta, valid_stages)
         meta.setdefault("slug", d.name)
         algos.append(entry(meta))
-    return {"algorithms": algos}
+    # The dataset/phantom registry, verbatim — the web needs the label/track/default fields to name
+    # phantoms and pick each track's default (a run row without a `phantom` field is the default).
+    datasets = json.loads((ROOT / "scripts" / "datasets.json").read_text())
+    return {"algorithms": algos, "datasets": datasets}
 
 
 def render(manifest: dict) -> str:

--- a/scripts/mirror_ridani_osf.py
+++ b/scripts/mirror_ridani_osf.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Mirror the Ridani et al. OSF project 9xwhz (Susceptibility-Separation-Phantom
+paper data) to a local directory, preserving the folder structure.
+
+Resumable: files whose size already matches the OSF-reported size are skipped.
+Writes a manifest (path, size, md5-from-OSF) to <dest>/osf_manifest.tsv so the
+mirror can be integrity-checked and later cited as the bit-for-bit reference.
+
+Usage: python3 scripts/mirror_ridani_osf.py [dest]   (default data/ridani-osf)
+"""
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+PROJECT = "9xwhz"
+ROOT = f"https://api.osf.io/v2/nodes/{PROJECT}/files/osfstorage/?page%5Bsize%5D=100"
+
+
+def api(url):
+    with urllib.request.urlopen(url) as r:
+        return json.load(r)
+
+
+def walk(url):
+    while url:
+        d = api(url)
+        for f in d["data"]:
+            a = f["attributes"]
+            if a["kind"] == "folder":
+                yield from walk(
+                    f["relationships"]["files"]["links"]["related"]["href"]
+                    + "?page%5Bsize%5D=100"
+                )
+            else:
+                yield {
+                    "path": a["materialized_path"].lstrip("/"),
+                    "size": a["size"],
+                    "md5": (a.get("extra", {}).get("hashes") or {}).get("md5"),
+                    "download": f["links"]["download"],
+                }
+        url = d["links"].get("next")
+
+
+def main():
+    dest = Path(sys.argv[1] if len(sys.argv) > 1 else "data/ridani-osf")
+    dest.mkdir(parents=True, exist_ok=True)
+    files = list(walk(ROOT))
+    total = sum(f["size"] for f in files)
+    print(f"{len(files)} files, {total/1e9:.2f} GB total", flush=True)
+
+    with open(dest / "osf_manifest.tsv", "w") as m:
+        m.write("path\tsize\tmd5\n")
+        for f in files:
+            m.write(f"{f['path']}\t{f['size']}\t{f['md5']}\n")
+
+    done = 0
+    for f in files:
+        out = dest / f["path"]
+        out.parent.mkdir(parents=True, exist_ok=True)
+        if out.exists() and out.stat().st_size == f["size"]:
+            done += f["size"]
+            print(f"skip  {f['path']}", flush=True)
+            continue
+        tmp = out.with_suffix(out.suffix + ".part")
+        for attempt in range(5):
+            try:
+                with urllib.request.urlopen(f["download"]) as r, open(tmp, "wb") as w:
+                    h = hashlib.md5()
+                    while chunk := r.read(1 << 20):
+                        w.write(chunk)
+                        h.update(chunk)
+                ok = h.hexdigest() == f["md5"] if f["md5"] else tmp.stat().st_size == f["size"]
+                if ok:
+                    break
+                print(f"retry {f['path']} (bad hash/size, attempt {attempt+1})", flush=True)
+            except OSError as e:
+                print(f"retry {f['path']} ({e}, attempt {attempt+1})", flush=True)
+        else:
+            raise RuntimeError(f"failed after retries: {f['path']}")
+        tmp.rename(out)
+        done += f["size"]
+        print(f"ok    {f['path']} ({done/total*100:.0f}%)", flush=True)
+    print("MIRROR COMPLETE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -14,6 +14,7 @@ Modes (see stages.yml):
 
 Usage:
   python scripts/pipeline.py --dataset data/sim/dev [--mode isolated|composed|both] [--track sim]
+                             [--phantom <scripts/datasets.json key>]
 """
 
 from __future__ import annotations
@@ -198,6 +199,40 @@ def _emit_composed_resources(run_id: str, stages: list, emit_volumes_on: bool) -
         pass
 
 
+# ---------------------------------------------------------------------------------------------------
+# Dataset / phantom registry (scripts/datasets.json) — the single source of truth for every scoring
+# dataset. Keyed by phantom id; each entry carries the TRACK whose method family runs on it
+# (sim = the QSM pipeline, chisep = χ-separation, invivo = the 2016 dipole challenge), how to locate
+# its OSF zip (osf_file literal id and/or osf_env secret name), its local path, a human label, an
+# `active` flag (only active phantoms get CI matrix entries), and `default: true` on exactly one
+# phantom per track (the default keeps the legacy run-id namespace; the others get a -<phantom>
+# suffix so their runs never collide in results/index.json).
+# ---------------------------------------------------------------------------------------------------
+
+def load_datasets() -> dict:
+    """Load the phantom registry. QSMCI_DATASETS_FILE points it at a fixture registry in tests."""
+    p = Path(os.environ.get("QSMCI_DATASETS_FILE") or (ROOT / "scripts" / "datasets.json"))
+    return json.loads(p.read_text())
+
+
+def default_phantom(track: str) -> "str | None":
+    """The registry key of `track`'s default phantom (the one that keeps legacy run ids)."""
+    for k, v in load_datasets().items():
+        if v.get("track") == track and v.get("default"):
+            return k
+    return None
+
+
+def phantom_suffix(phantom: "str | None") -> str:
+    """Run-id namespace for a phantom: a track's DEFAULT phantom keeps the historical bare ids
+    (backward compatible — a re-score overwrites the existing leaderboard entry in place), while a
+    non-default phantom of the same track appends `-<phantom-id>` so its runs live in a disjoint id
+    space. No phantom given (legacy invocation) means the default phantom: no suffix."""
+    if not phantom:
+        return ""
+    return "" if load_datasets()[phantom].get("default") else f"-{phantom}"
+
+
 def _yaml_scalar(v) -> str:
     """Render a parsed YAML scalar as the bare token the old regex captured (`\\S+`).
 
@@ -209,13 +244,19 @@ def _yaml_scalar(v) -> str:
     return str(v)
 
 
-def _tuned_overrides(doc: dict, dataset: str = "sim") -> dict:
+def _tuned_overrides(doc: dict, dataset: str = "sim", phantom: "str | None" = None) -> dict:
     """Extract `{param: tuned_value}` for a dataset (`sim` / `invivo` / `chisep`) from a parsed
     algorithm.yml `parameters:` block — the settings optimised on that dataset (each parameter may
     carry a `tuned:` alongside its `default:`). `tuned` is either a per-dataset MAP
     (`tuned: {sim: .., invivo: .., chisep: ..}`) or a legacy SCALAR (which applies to the in-silico/sim
     dataset only). So sim keeps reading the existing scalar tunings, and a method only gets an
     in-vivo / chi-sep tuned variant once it declares `tuned.invivo` / `tuned.chisep`.
+
+    With multiple phantoms per track, the map may ALSO be keyed by a specific phantom id
+    (`tuned: {chisep: .., ridani-3t-aniso: ..}`). Lookup order per parameter: the exact `phantom` id
+    key -> the track-family `dataset` key -> the legacy scalar (sim only). So a method tuned on the
+    default chisep phantom keeps applying that tuning to every chisep-track phantom until it declares
+    a phantom-specific value.
 
     Values are returned as strings (they flow into `overrides` -> config.json / `--set`, which expect
     the raw token). YAML handles the unindented list items (`- name:` at column 0, as the MATLAB ymls
@@ -228,17 +269,24 @@ def _tuned_overrides(doc: dict, dataset: str = "sim") -> dict:
         if not isinstance(item, dict) or "name" not in item or "tuned" not in item:
             continue
         t = item["tuned"]
-        val = t.get(dataset) if isinstance(t, dict) else (t if dataset == "sim" else None)
+        if isinstance(t, dict):
+            val = t.get(phantom) if phantom is not None else None
+            if val is None:
+                val = t.get(dataset)
+        else:
+            val = t if dataset == "sim" else None
         if val is None:
             continue
         out[_yaml_scalar(item["name"])] = _yaml_scalar(val)
     return out
 
 
-def discover_algorithms(track: str = "sim") -> list[dict]:
+def discover_algorithms(track: str = "sim", phantom: "str | None" = None) -> list[dict]:
     # `track` selects which dataset's tuned params each method carries: a chi-separation method is only
-    # ever scored on the chisep dataset (→ "chisep"), otherwise the in-vivo run uses "invivo" and
+    # ever scored on a chisep-track phantom (→ "chisep"), otherwise the in-vivo run uses "invivo" and
     # everything else "sim". So the tuned variant a run expands is the one optimised on ITS dataset.
+    # `phantom` (a scripts/datasets.json key) further narrows that: a `tuned:` map keyed with the exact
+    # phantom id wins over the track-family key (see _tuned_overrides).
     algos = []
     # QSMCI_ALGORITHMS_DIR lets a harness test point discovery at a fixture method set (tests/methods)
     # instead of the real algorithms/ tree — so the orchestration (discover -> isolated/composed ->
@@ -285,7 +333,7 @@ def discover_algorithms(track: str = "sim") -> list[dict]:
             "image": _yaml_scalar(image) if image is not None else None,
             "consumes": consumes, "produces": STAGES[s]["produces"],
             "tuned": _tuned_overrides(doc, "chisep" if s == "chi-separation"
-                                      else ("invivo" if track == "invivo" else "sim")),
+                                      else ("invivo" if track == "invivo" else "sim"), phantom),
             # Optional per-method smoke-crop size (voxels): a slow per-voxel method (e.g. DECOMPOSE)
             # can shrink the --smoke gate's central box so the PR check stays fast; None = CLI default.
             "smoke_box": doc.get("smoke_box"),
@@ -378,11 +426,19 @@ def score(recon: Path, artifact: str, gt_dir: Path, mask: Path, out_json: Path, 
     # be meaningless. Withhold the seg for that track → the scorer's no-seg chi branch (global
     # NRMSE/HFEN/correlation/XSIM only), which is exactly the in-vivo metric set.
     use_seg = kind in ("chi", "chisep") and seg.exists() and meta["track"] != "invivo"
+    # χ− per-ROI MSPE + orientation analysis (MEV) need the fibre-bundle WM sub-ROI atlas and the
+    # fibre-to-B0 angle map, shipped in groundtruth as wm_rois.nii.gz / theta.nii.gz (the Ridani
+    # reproduction datasets carry them; others don't → those χ− metrics are simply omitted).
+    dia = kind == "chisep" and component == "dia"
+    wm_rois = gt_dir / "wm_rois.nii.gz"
+    theta = gt_dir / "theta.nii.gz"
     cmd = eval_argv(sys.executable, EVAL, recon, gt_dir / ARTIFACT_FILE[artifact], kind, mask,
                     artifact, out_json, stage=meta["stage"], name=meta["name"], track=meta["track"],
                     runtime=meta.get("runtime"),
                     seg=seg if use_seg else None,
-                    component=component)
+                    component=component,
+                    wm_rois=wm_rois if (dia and wm_rois.exists()) else None,
+                    theta=theta if (dia and theta.exists()) else None)
     subprocess.run(cmd, check=True)
     result = json.loads(out_json.read_text())
     # A scorable recon yields finite metrics; an all-NaN / empty output makes the scorer emit
@@ -445,6 +501,16 @@ def dnf(rid, slug, name, stage, mode, track, combo=None, variant="default"):
     if combo:
         e["combo"] = combo
     return e
+
+
+def _stamp_phantom(rows: list, phantom: "str | None") -> list:
+    """Record which phantom (scripts/datasets.json key) each run row was scored on. Only stamped when
+    --phantom was given; older index entries (and legacy invocations) carry no field, and consumers
+    treat absence as the track's default phantom."""
+    if phantom:
+        for r in rows:
+            r["phantom"] = phantom
+    return rows
 
 
 def _stamp_resource_summary(run):
@@ -622,7 +688,9 @@ def do_isolated(task, args, gt_sources, gt, mask):
     never raises, so _pmap can't be sunk."""
     a, variant, overrides = task
     sfx = "" if variant == "default" else "-tuned"          # variant suffix (work paths)
-    idsfx = sfx + id_suffix(args.track)                     # + track namespace (run ids)
+    # + track namespace + phantom namespace (run ids): the track's default phantom adds nothing
+    # (legacy ids preserved); a non-default phantom appends -<phantom-id>.
+    idsfx = sfx + id_suffix(args.track) + getattr(args, "phantom_sfx", "")
     idir = args.work / f"iso_{a['slug']}{idsfx}_in"
     odir = args.work / f"iso_{a['slug']}{idsfx}_out"
     try:
@@ -679,7 +747,7 @@ def run_isolated(args, algos, gt_sources, gt, mask, iso_target, runs: list) -> N
     iso_tasks = [t for a in iso_algos for t in iso_variants(a)]
     iso_tasks = shard_partition(iso_tasks, args.shard)  # --shard: round-robin over a stable order
     for out in _pmap(iso_tasks, lambda task: do_isolated(task, args, gt_sources, gt, mask)):
-        runs.extend(out)
+        runs.extend(_stamp_phantom(out, getattr(args, "phantom", None)))
     if not args.runs_out:
         flush_index(runs)
 
@@ -735,7 +803,7 @@ def do_dipole(task, args, gt_sources, gt, mask, lf_cache):
     (or a DNF row on failure)."""
     tfk, b, d = task
     combo = f"{b['slug']}+{d['slug']}" if tfk == "gt" else f"{tfk}+{b['slug']}+{d['slug']}"
-    cid = f"{tfk}~{b['slug']}~{d['slug']}-cmp"
+    cid = f"{tfk}~{b['slug']}~{d['slug']}-cmp" + getattr(args, "phantom_sfx", "")
     cinfo = {"field_mapping": tfk, "bfr": b["slug"], "dipole": d["slug"]}
     try:
         lf, bfr_mask, upstream_rt, upstream_trace = lf_cache[(tfk, b["slug"])]
@@ -793,6 +861,7 @@ def do_span(task, args, gt_sources, gt, mask, tf_sources):
         cid = f"{s['slug']}-cmp" if tfk == "gt" else f"{tfk}~{s['slug']}-cmp"
     else:                                       # end-to-end: from GT phase, its own field-mapping
         stage, combo, cid = s["stage"], None, f"{s['slug']}-cmp"
+    cid += getattr(args, "phantom_sfx", "")     # non-default phantom -> disjoint id space
     idir, odir = args.work / f"cmp_{cid}_in", args.work / f"cmp_{cid}_out"
     try:
         prepare_input(s["consumes"], src, idir)
@@ -905,7 +974,7 @@ def run_composed(args, algos, gt_sources, gt, mask, shard_i, shard_n, runs: list
     dip_tasks = [(tfk, b, d) for tfk in tf_sources for b in bfr
                  if (tfk, b["slug"]) in lf_cache for d in dipole]
     for r in _pmap(dip_tasks, lambda task: do_dipole(task, args, gt_sources, gt, mask, lf_cache)):
-        runs.append(r)
+        runs.extend(_stamp_phantom([r], getattr(args, "phantom", None)))
     if not args.runs_out:
         flush_index(runs)
 
@@ -914,12 +983,19 @@ def run_composed(args, algos, gt_sources, gt, mask, shard_i, shard_n, runs: list
     span_tasks = [(s, tfk) for tfk in tf_sources for s in tf_spans if owns_span(tfk, s["slug"])]
     span_tasks += [(s, "gt") for s in e2e_spans]
     for r in _pmap(span_tasks, lambda t: do_span(t, args, gt_sources, gt, mask, tf_sources)):
-        runs.append(r)
+        runs.extend(_stamp_phantom([r], getattr(args, "phantom", None)))
 
 
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--dataset", type=Path, default=ROOT / "data/sim/dev")
+    ap.add_argument("--dataset", type=Path, default=None,
+                    help="dataset dir with inputs/ + groundtruth/. Default: the --phantom's registry "
+                         "path when --phantom is given, else data/sim/dev")
+    ap.add_argument("--phantom", default=None,
+                    help="which phantom (scripts/datasets.json key) this run scores on. The track's "
+                         "default phantom keeps legacy run ids; a non-default phantom namespaces its "
+                         "run ids with -<phantom-id> and its rows carry a `phantom` field. Omitted = "
+                         "the track's default phantom (legacy behaviour, no field stamped).")
     ap.add_argument("--mode", choices=["isolated", "composed", "both"], default="both")
     ap.add_argument("--runner", choices=["local", "docker", "apptainer"], default="local",
                     help="local runs run.sh directly; docker/apptainer run each submission's image")
@@ -962,11 +1038,25 @@ def main() -> None:
     # over a stable ordering, so the n shards partition the work with no overlap and no gaps.
     shard_i, shard_n = parse_shard(args.shard)
 
+    # --phantom: validate against the registry and derive its run-id namespace ("" for the track's
+    # default phantom, "-<phantom-id>" otherwise) + the dataset path when --dataset wasn't given.
+    if args.phantom:
+        reg = load_datasets()
+        if args.phantom not in reg:
+            raise SystemExit(f"unknown phantom '{args.phantom}' — add it to scripts/datasets.json")
+        args.phantom_sfx = phantom_suffix(args.phantom)
+        if args.dataset is None:
+            args.dataset = ROOT / reg[args.phantom]["path"]
+    else:
+        args.phantom_sfx = ""
+    if args.dataset is None:
+        args.dataset = ROOT / "data/sim/dev"
+
     inputs, gt = args.dataset / "inputs", args.dataset / "groundtruth"
     mask, params = inputs / "mask.nii.gz", inputs / "params.json"
     # GT-backed source map: inputs for raw artifacts, groundtruth for stage boundaries (shared helper).
     gt_sources = _gt_sources(args.dataset)
-    algos = discover_algorithms(args.track)
+    algos = discover_algorithms(args.track, args.phantom)
     if args.include:
         keep = set(args.include.split(","))
         algos = [a for a in algos if a["slug"] in keep]

--- a/scripts/verify_ridani_gt.py
+++ b/scripts/verify_ridani_gt.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Verify qsm-forward-generated Ridani chi-sep ground truth against the authors'
+canonical OSF uploads (project 9xwhz, mirrored by scripts/mirror_ridani_osf.py).
+
+Compares, on the shared native grid (256x320x320 @ 0.64 mm):
+  1. voxelwise agreement (Pearson r, mean/p95 |diff|) whole-head / brain / WM
+  2. per-ROI means vs (a) the OSF reference maps and (b) paper Table 2
+     (Ridani et al., MRM doi:10.1002/mrm.70468)
+
+The reference generator adds UNSEEDED Gaussian texture noise (WM weighting
+sigma=0.01 x3 iterations; anisotropic modulation eta ~ N(-0.04, 0.05)), so
+voxelwise identity is impossible by construction — the acceptance criteria are
+high correlation + ROI means matching Table 2 within the noise floor.
+
+Usage:
+  python3 scripts/verify_ridani_gt.py --ours data/ridani-ver --osf data/ridani-osf
+"""
+import argparse
+import json
+from pathlib import Path
+
+import nibabel as nib
+import numpy as np
+
+# Paper Table 2: ROI-averaged GT susceptibilities (ppm).
+# name -> (chi_pos, chi_neg, chi_neg_aniso or None)
+TABLE2_MAIN = {
+    "Gray matter":       (0.0342, -0.0195, None),
+    "Caudate nucleus":    (0.0489, -0.0095, None),
+    "Globus pallidus":    (0.1381, -0.0137, None),
+    "Putamen":            (0.0455, -0.0099, None),
+    "Red nucleus":        (0.1061, -0.0095, None),
+    "Dentate nucleus":    (0.1584, -0.0163, None),
+    "Substantia nigra":   (0.1145, -0.0124, None),
+    "Thalamus":           (0.0473, -0.0316, None),
+    "White matter":       (0.0063, -0.0363, -0.0337),
+}
+TABLE2_WM_SUB = {
+    "Body corpus callosum":        (0.0036, -0.0424, -0.0437),
+    "Splenium CC":                 (0.0037, -0.0380, -0.0500),
+    "Genu CC":                     (0.0010, -0.0413, -0.0466),
+    "Ant. limb internal capsule":  (0.0085, -0.0312, -0.0465),
+    "Post. limb internal capsule": (0.0008, -0.0354, -0.0655),
+    "Superior corona radiata":     (0.0024, -0.0464, -0.0420),
+    "Posterior corona radiata":    (0.0023, -0.0440, -0.0530),
+    "Anterior corona radiata":     (0.0004, -0.0425, -0.0541),
+    "Post. thalamic radiations":   (0.0068, -0.0388, -0.0472),
+    "Sup. longitudinal fascicle":  (0.0005, -0.0374, -0.0438),
+}
+
+
+def load(p):
+    return np.asarray(nib.load(str(p)).get_fdata(), dtype=np.float64)
+
+
+def stats(a, b, m):
+    a, b = a[m], b[m]
+    d = a - b
+    r = np.corrcoef(a, b)[0, 1] if a.std() > 0 and b.std() > 0 else np.nan
+    return r, d.mean(), np.percentile(np.abs(d), 95)
+
+
+def roi_means(vol, seg, labels):
+    return {lab: float(vol[seg == lab].mean()) for lab in labels if (seg == lab).any()}
+
+
+def match_labels(ref_vol, seg, table_col, labels):
+    """Greedy-match integer labels to named ROIs by nearest reference-map ROI mean
+    to the Table 2 value (validates the assumed label order instead of trusting it)."""
+    means = roi_means(ref_vol, seg, labels)
+    out = {}
+    used = set()
+    for name, target in table_col.items():
+        best = min((l for l in means if l not in used),
+                   key=lambda l: abs(means[l] - target), default=None)
+        if best is not None:
+            out[name] = best
+            used.add(best)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ours", type=Path, default=Path("data/ridani-ver"))
+    ap.add_argument("--osf", type=Path, default=Path("data/ridani-osf"))
+    ap.add_argument("--json", type=Path, default=None, help="also dump results as JSON")
+    args = ap.parse_args()
+
+    res = args.osf / "Susceptibility_Separation_Results"
+    ref = {
+        "chi_pos": load(res / "Chi_positive.nii.gz"),
+        "chi_neg_iso": load(res / "Chi_negative.nii.gz"),
+        "chi_neg_aniso": load(res / "Chi_negative_with_anisotropy.nii.gz"),
+    }
+    seg = load(args.osf / "Masks" / "SegmentedModel.nii.gz").round().astype(int)
+    brain = load(args.osf / "Masks" / "BrainMask.nii.gz") > 0.5
+    fib = load(args.osf / "Masks" / "WM_fibers_seg.nii.gz").round().astype(int)
+    wm = seg == 8
+
+    # our maps: gen_chisep --maps-only writes groundtruth/{chi-para,chi-dia}.nii.gz
+    # (chi-dia may be stored as a positive magnitude — detect and restore sign).
+    def load_ours(variant, name):
+        for rel in (f"{variant}/groundtruth/{name}.nii.gz", f"{variant}/{name}.nii.gz",
+                    f"{variant}/inputs/{name}.nii.gz"):
+            p = args.ours / rel
+            if p.exists():
+                return load(p), p
+        raise FileNotFoundError(f"{name} under {args.ours}/{variant}")
+
+    report = {}
+    print(f"{'map':28s} {'scope':6s} {'r':>7s} {'mean diff':>10s} {'p95|diff|':>10s}")
+    for variant, ref_key, ours_name in [
+        ("aniso", "chi_pos", "chi-para"),
+        ("aniso", "chi_neg_aniso", "chi-dia"),
+        ("iso", "chi_pos", "chi-para"),
+        ("iso", "chi_neg_iso", "chi-dia"),
+    ]:
+        ours, path = load_ours(variant, ours_name)
+        if "dia" in ours_name and ours.min() >= 0 and ref[ref_key].min() < 0:
+            ours = -ours  # stored-as-magnitude convention
+        for scope, m in [("head", np.abs(ref[ref_key]) + np.abs(ours) > 0),
+                         ("brain", brain), ("WM", wm)]:
+            r, md, p95 = stats(ours, ref[ref_key], m)
+            key = f"{variant}/{ours_name}"
+            report.setdefault(key, {})[scope] = {"r": r, "mean_diff": md, "p95_absdiff": p95}
+            print(f"{key:28s} {scope:6s} {r:7.4f} {md:10.5f} {p95:10.5f}")
+
+    # ROI means: main ROIs on SegmentedModel (brain labels), WM sub-ROIs on WM_fibers_seg
+    main_labels = sorted(set(np.unique(seg[brain])) - {0})
+    sub_labels = sorted(set(np.unique(fib)) - {0})
+    lab_main = match_labels(ref["chi_pos"], seg, {k: v[0] for k, v in TABLE2_MAIN.items()}, main_labels)
+    lab_sub = match_labels(ref["chi_neg_iso"], fib, {k: v[1] for k, v in TABLE2_WM_SUB.items()}, sub_labels)
+
+    ours_pos, _ = load_ours("aniso", "chi-para")
+    ours_neg_iso, _ = load_ours("iso", "chi-dia")
+    ours_neg_ani, _ = load_ours("aniso", "chi-dia")
+    if ours_neg_iso.min() >= 0:
+        ours_neg_iso = -ours_neg_iso
+    if ours_neg_ani.min() >= 0:
+        ours_neg_ani = -ours_neg_ani
+
+    def table(title, table2, labmap, segvol):
+        print(f"\n== {title} (ppm; ours vs OSF ref vs paper Table 2) ==")
+        print(f"{'ROI':28s} {'lab':>3s} | {'χ+ ours':>8s} {'ref':>8s} {'tab2':>8s} | "
+              f"{'χ- ours':>8s} {'ref':>8s} {'tab2':>8s} | {'χ-a ours':>8s} {'ref':>8s} {'tab2':>8s}")
+        rows = {}
+        for name, (t_pos, t_neg, t_ani) in table2.items():
+            lab = labmap.get(name)
+            if lab is None:
+                continue
+            m = segvol == lab
+            row = {
+                "pos": (ours_pos[m].mean(), ref["chi_pos"][m].mean(), t_pos),
+                "neg": (ours_neg_iso[m].mean(), ref["chi_neg_iso"][m].mean(), t_neg),
+                "ani": (ours_neg_ani[m].mean(), ref["chi_neg_aniso"][m].mean(), t_ani),
+            }
+            rows[name] = {k: tuple(None if x is None else float(x) for x in v)
+                          for k, v in row.items()}
+            f = lambda v: "     ---" if v is None else f"{v:8.4f}"
+            print(f"{name:28s} {lab:3d} | {f(row['pos'][0])} {f(row['pos'][1])} {f(row['pos'][2])} | "
+                  f"{f(row['neg'][0])} {f(row['neg'][1])} {f(row['neg'][2])} | "
+                  f"{f(row['ani'][0])} {f(row['ani'][1])} {f(row['ani'][2])}")
+        return rows
+
+    report["roi_main"] = table("Main ROIs", TABLE2_MAIN, lab_main, seg)
+    report["roi_wm_sub"] = table("WM sub-ROIs", TABLE2_WM_SUB, lab_sub, fib)
+    report["label_maps"] = {"main": {k: int(v) for k, v in lab_main.items()},
+                            "wm_sub": {k: int(v) for k, v in lab_sub.items()}}
+
+    if args.json:
+        args.json.write_text(json.dumps(report, indent=2))
+        print(f"\nwrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,110 @@
+"""The dataset/phantom registry (scripts/datasets.json) and its pipeline.py consumers.
+
+The registry is the single source of truth for every scoring dataset: score.yml's plan job expands
+chi-separation methods across its active chisep-track phantoms, fetch_dataset.sh resolves OSF
+files/pack flags from it, pipeline.py namespaces run ids by phantom with it, and gen_manifest.py
+embeds it in web/algorithms.json for the site. These tests pin its shape (so a malformed entry fails
+here, not mid-rescore) and the id-suffix / tuned-parameter fallback semantics that keep existing
+published run ids stable.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location("pipeline", ROOT / "scripts" / "pipeline.py")
+pipeline = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pipeline)
+
+
+def _registry() -> dict:
+    return json.loads((ROOT / "scripts" / "datasets.json").read_text())
+
+
+# ---- registry shape --------------------------------------------------------------------------
+
+def test_registry_entries_are_well_formed():
+    reg = _registry()
+    assert reg, "registry is empty"
+    for ph, d in reg.items():
+        assert d.get("track"), f"{ph}: missing track"
+        assert d.get("label"), f"{ph}: missing label"
+        assert d.get("path"), f"{ph}: missing path"
+        assert d.get("osf_file") or d.get("osf_env"), \
+            f"{ph}: needs osf_file (literal id) and/or osf_env (secret name)"
+
+
+def test_exactly_one_default_phantom_per_track():
+    reg = _registry()
+    tracks = {d["track"] for d in reg.values()}
+    for t in tracks:
+        defaults = [k for k, d in reg.items() if d["track"] == t and d.get("default")]
+        assert len(defaults) == 1, f"track {t}: expected exactly one default phantom, got {defaults}"
+        assert reg[defaults[0]].get("active"), f"track {t}: default phantom {defaults[0]} is inactive"
+
+
+def test_legacy_track_args_are_registry_keys():
+    # sim/invivo are both a track name AND their track's default phantom id, so callers that pass
+    # the bare track name keep working. (The chisep track's default is a named phantom, chisep-mc,
+    # since the original single 'chisep' phantom was retired.)
+    reg = _registry()
+    for legacy in ("sim", "invivo"):
+        assert legacy in reg, f"legacy phantom id '{legacy}' missing from the registry"
+        assert reg[legacy]["track"] == legacy
+
+
+# ---- pipeline.py: id namespacing ------------------------------------------------------------
+
+def test_default_phantoms_keep_legacy_ids():
+    # The default phantom of every track adds NO id suffix — existing published run ids survive.
+    reg = _registry()
+    assert pipeline.phantom_suffix(None) == ""
+    for ph, d in reg.items():
+        if d.get("default"):
+            assert pipeline.phantom_suffix(ph) == "", f"default phantom {ph} must not suffix ids"
+
+
+def test_non_default_phantom_suffixes_ids(tmp_path, monkeypatch):
+    reg = _registry()
+    reg["ridani-3t-iso"] = {"track": "chisep", "label": "Ridani 3T iso",
+                            "osf_env": "OSF_FILE_RIDANI_3T_ISO",
+                            "path": "data/ridani-3t-iso/scoring", "active": True}
+    f = tmp_path / "datasets.json"
+    f.write_text(json.dumps(reg))
+    monkeypatch.setenv("QSMCI_DATASETS_FILE", str(f))
+    assert pipeline.phantom_suffix("ridani-3t-iso") == "-ridani-3t-iso"
+    assert pipeline.phantom_suffix("chisep-mc") == ""       # the chisep-track default keeps bare ids
+    assert pipeline.default_phantom("chisep") == "chisep-mc"  # default phantom of the chisep track
+
+
+def test_unknown_phantom_raises():
+    with pytest.raises(KeyError):
+        pipeline.phantom_suffix("nope-not-a-phantom")
+
+
+# ---- pipeline.py: tuned-parameter fallback ---------------------------------------------------
+
+DOC = {"parameters": [
+    {"name": "lam", "default": 1, "tuned": {"chisep": 2, "ridani-3t-iso": 3}},
+    {"name": "mu", "default": 4, "tuned": 5},                       # legacy scalar = sim only
+    {"name": "tol", "default": 6, "tuned": {"sim": 7, "invivo": 8}},
+]}
+
+
+def test_tuned_exact_phantom_key_wins():
+    assert pipeline._tuned_overrides(DOC, "chisep", "ridani-3t-iso") == {"lam": "3"}
+
+
+def test_tuned_falls_back_to_track_key():
+    # A phantom with no tuned entry of its own inherits the track-family tuning.
+    assert pipeline._tuned_overrides(DOC, "chisep", "ridani-7t-aniso") == {"lam": "2"}
+    assert pipeline._tuned_overrides(DOC, "chisep") == {"lam": "2"}
+
+
+def test_tuned_legacy_scalar_is_sim_only():
+    assert pipeline._tuned_overrides(DOC, "sim") == {"mu": "5", "tol": "7"}
+    assert pipeline._tuned_overrides(DOC, "sim", "sim") == {"mu": "5", "tol": "7"}
+    assert pipeline._tuned_overrides(DOC, "invivo") == {"tol": "8"}

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -40,12 +40,13 @@ def _dataset(root: Path, *, sti: bool = False) -> Path:
     return root
 
 
-def _run(dataset: Path, runs_out: Path, work: Path, *, mode: str, track: str, include: str) -> list:
-    env = {**os.environ, "QSMCI_ALGORITHMS_DIR": str(METHODS)}
+def _run(dataset: Path, runs_out: Path, work: Path, *, mode: str, track: str, include: str,
+         extra: tuple = (), env_extra: "dict | None" = None) -> list:
+    env = {**os.environ, "QSMCI_ALGORITHMS_DIR": str(METHODS), **(env_extra or {})}
     subprocess.run(
         [sys.executable, str(ROOT / "scripts" / "pipeline.py"),
          "--dataset", str(dataset), "--mode", mode, "--runner", "local", "--track", track,
-         "--include", include, "--runs-out", str(runs_out), "--work", str(work)],
+         "--include", include, "--runs-out", str(runs_out), "--work", str(work), *extra],
         cwd=str(ROOT), env=env, check=True)
     return json.loads(runs_out.read_text())
 
@@ -69,6 +70,34 @@ def test_composed_matrix_runs(tmp_path):
     composed = [r for r in runs if r.get("mode") == "composed" and r.get("artifact") == "chimap"]
     assert composed, "no composed chimap run produced"
     assert any(r["metrics"].get("correlation", 0) > 0.99 for r in composed)
+
+
+def test_phantom_namespacing(tmp_path):
+    """--phantom on a NON-default phantom must suffix run ids with -<phantom-id> and stamp the rows
+    with a `phantom` field, while the track's default phantom keeps the bare legacy ids — the
+    contract that lets several phantoms of one track coexist in results/index.json."""
+    reg = json.loads((ROOT / "scripts" / "datasets.json").read_text())
+    reg["sim-alt"] = {"track": "sim", "label": "Alt phantom", "osf_file": "x",
+                      "path": "data/sim-alt/scoring", "active": True}
+    regfile = tmp_path / "datasets.json"
+    regfile.write_text(json.dumps(reg))
+    env = {"QSMCI_DATASETS_FILE": str(regfile)}
+    ds = _dataset(tmp_path / "ds")
+
+    # non-default phantom: namespaced ids + phantom field
+    runs = _run(ds, tmp_path / "runs-alt.json", tmp_path / "work-alt",
+                mode="isolated", track="sim", include="cp-method",
+                extra=("--phantom", "sim-alt"), env_extra=env)
+    r = next(r for r in runs if r["slug"] == "cp-method")
+    assert r["id"].endswith("-sim-alt") and r["phantom"] == "sim-alt"
+    assert r["metrics"]["correlation"] > 0.99
+
+    # default phantom: legacy bare ids, but the phantom field is still stamped
+    runs = _run(ds, tmp_path / "runs-def.json", tmp_path / "work-def",
+                mode="isolated", track="sim", include="cp-method",
+                extra=("--phantom", "sim"), env_extra=env)
+    r = next(r for r in runs if r["slug"] == "cp-method")
+    assert r["id"] == "cp-method-iso" and r["phantom"] == "sim"
 
 
 def test_invivo_two_reference_scoring(tmp_path):

--- a/web/algorithms.json
+++ b/web/algorithms.json
@@ -1746,6 +1746,32 @@
       "ci_notes": []
     },
     {
+      "slug": "r2star-qsm",
+      "name": "R2*-QSM",
+      "stage": "chi-separation",
+      "inputs": [
+        "chimap",
+        "magnitude",
+        "mask",
+        "params"
+      ],
+      "domain": "chisep",
+      "engine": "Independent",
+      "language": "Python",
+      "family": "direct",
+      "learning": "none",
+      "description": "Susceptibility source separation from gradient-echo data alone (Dimov et al. 2022). R2* is fit from the multi-echo GRE magnitude and combined with the QSM (\u03c7_total) under a single-relaxometric- constant model, R2* = \ud835\udcc7\u00b7(|\u03c7+| + |\u03c7\u2212|) with \u03c7_total = \u03c7+ + \u03c7\u2212, solved per voxel in closed form (\u03c7+ = (\u03c7_total + R2*/\ud835\udcc7)/2, |\u03c7\u2212| = (R2*/\ud835\udcc7 \u2212 \u03c7_total)/2) with the physical constraints \u03c7+ \u2265 0, \u03c7\u2212 \u2264 0. Unlike the R2'-based methods it needs no separate R2/R2' measurement \u2014 the trade-off is that R2* carries the irreversible tissue R2 baseline, which the single constant \ud835\udcc7 absorbs (Dimov's empirical \ud835\udcc7 = 274 Hz/ppm at 3 T is below the theoretic 321 for this reason). \ud835\udcc7 is field-scaled to the acquisition (274\u00b7B0/3 Hz/ppm), the method's own assumption rather than a fit to this phantom. This reference implementation is the paper's voxel-level solve; the full method adds a field data-consistency term (auto-satisfied when \u03c7_total is provided) and an edge-masked L1 regularisation, omitted here. Pure Python on CPU \u2014 no weights, no network.",
+      "citation": "Dimov A.V. et al., \"Magnetic Susceptibility Source Separation Solely from Gradient Echo Data: Histological Validation\", Tomography 2022;8(3):1544-1551 (and J Neuroimaging 2022, doi:10.1111/jon.13014). R2* susceptibility model: Yablonskiy & Haacke, Magn Reson Med 1994.\n",
+      "doi": "10.1111/jon.13014",
+      "code_url": "https://github.com/QSMxT/QSM-CI",
+      "license": "MIT",
+      "authors": [
+        "QSM-CI (implementation of Dimov et al. 2022)"
+      ],
+      "parameters": [],
+      "ci_notes": []
+    },
+    {
       "slug": "resharp-qsmrs",
       "name": "RESHARP",
       "stage": "bfr",
@@ -1786,6 +1812,32 @@
           "description": "Tikhonov regularization"
         }
       ],
+      "ci_notes": []
+    },
+    {
+      "slug": "ridani-null-qsmci",
+      "name": "Ridani null baseline (region-disjoint closed-form)",
+      "stage": "chi-separation",
+      "inputs": [
+        "r2prime",
+        "chimap",
+        "mask",
+        "params"
+      ],
+      "domain": "chisep",
+      "engine": "Independent",
+      "language": "Python",
+      "family": "direct",
+      "learning": "none",
+      "description": "The closed-form analytic null baseline for the Ridani et al. (2026) phantom family. It inverts the phantom's own region-disjoint, theoretical field-scaled forward model: paramagnetic relaxivity Dr+ = (2\u03c0)\u00b2\u00b7\u03b3\u00b7B0/(9\u221a3) (~107.84\u00b7B0 Hz/ppm) applied outside white matter, diamagnetic relaxivity Dr-(\u03b8) = \u00bd\u00b7\u03b3\u00b72\u03c0\u00b7B0\u00b7sin\u00b2\u03b8 (~133.77\u00b7B0\u00b7sin\u00b2\u03b8) inside white matter (a field-scaled constant when no fibre orientation is available). The white-matter region is read from the provided segmentation (dseg, label 8), and each region is solved with its own closed form (\u03c7+ = R2'/Dr+ outside WM; |\u03c7-| = R2'/Dr- inside WM), so on the isotropic phantom it is EXACT. On the anisotropic phantom, lacking per-voxel \u03b8, it assumes a constant WM Dr- and mis-estimates WM \u03c7- by the orientation modulation \u2014 that residual is the anisotropy signal the benchmark measures. Where an optional fibre-angle input (fiber_angle.nii.gz) is shipped, it uses the orientation-dependent Dr-(\u03b8) and its WM \u03c7- becomes near-exact, quantifying how much that DTI input gives away. Its score is the honest floor for this dataset family: a real method demonstrates separation skill only by beating it without the held-out segmentation. Distinct from chisep-null (which inverts the co-located single-kernel Dr+=137\u00b7B0/3 model); this baseline pairs with the Ridani datasets, as chisep-null pairs with the fixed-Dr \u03c7-sep dataset.",
+      "citation": "Stewart A., \"ridani-null: the region-disjoint closed-form null baseline for the Ridani susceptibility-separation phantom\", QSM-CI, 2026. Forward model: Ridani D., De Leener B., Alonso-Ortiz E., Magn Reson Med 2026, doi:10.1002/mrm.70468; relaxivities Yablonskiy & Haacke, Magn Reson Med 1994, doi:10.1002/mrm.1910320610.\n",
+      "doi": null,
+      "code_url": "https://github.com/QSMxT/QSM-CI",
+      "license": "MIT",
+      "authors": [
+        "Ashley Stewart"
+      ],
+      "parameters": [],
       "ci_notes": []
     },
     {
@@ -2471,5 +2523,61 @@
       "parameters": [],
       "ci_notes": []
     }
-  ]
+  ],
+  "datasets": {
+    "sim": {
+      "track": "sim",
+      "label": "In silico (2019)",
+      "osf_file": "698ac9aecae88916d1e24f69",
+      "path": "data/sim/scoring",
+      "active": true,
+      "default": true
+    },
+    "invivo": {
+      "track": "invivo",
+      "label": "In vivo (2016)",
+      "osf_env": "OSF_FILE_INVIVO",
+      "osf_file": "hw9rn",
+      "path": "data/invivo/scoring",
+      "prepacked": true,
+      "active": true,
+      "default": true
+    },
+    "ridani-3t-iso": {
+      "track": "chisep",
+      "label": "Ridani 3T isotropic",
+      "osf_env": "OSF_FILE_RIDANI_3T_ISO",
+      "prepacked": true,
+      "path": "data/ridani-3t-iso/scoring",
+      "active": true,
+      "default": false
+    },
+    "ridani-3t-aniso": {
+      "track": "chisep",
+      "label": "Ridani 3T anisotropic",
+      "osf_env": "OSF_FILE_RIDANI_3T_ANISO",
+      "prepacked": true,
+      "path": "data/ridani-3t-aniso/scoring",
+      "active": true,
+      "default": false
+    },
+    "ridani-7t-aniso": {
+      "track": "chisep",
+      "label": "Ridani 7T anisotropic",
+      "osf_env": "OSF_FILE_RIDANI_7T_ANISO",
+      "prepacked": true,
+      "path": "data/ridani-7t-aniso/scoring",
+      "active": true,
+      "default": false
+    },
+    "chisep-mc": {
+      "track": "chisep",
+      "label": "\u03c7-sep multicompartment (7T)",
+      "osf_env": "OSF_FILE_CHISEP_MC",
+      "prepacked": true,
+      "path": "data/chisep-mc/scoring",
+      "active": true,
+      "default": true
+    }
+  }
 }

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -124,6 +124,10 @@ const MOON = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor
 // Metric metadata: label, unit, better direction, decimals, and a plain-language description
 // (surfaced as hover tooltips). Descriptions mirror eval/qsm_eval.py (ported from QSM.rs).
 const METRICS = {
+  mspe:            { label: "MSPE",             unit: "%", better: "lower",  dp: 1,
+    desc: "Mean squared percentage error of ROI means (Ridani et al., MRM 2026): a per-region quantification-bias metric, comparable to the paper's published χ-separation numbers." },
+  mev:             { label: "MEV",              unit: "%", better: "lower",  dp: 1,
+    desc: "Maximum error variation (Ridani et al. 2026, Fig 5): the fractional drop in χ− error from fibres parallel to B0 to perpendicular. High = strongly orientation-dependent error; a diagnostic, not a ranking metric." },
   nrmse:           { label: "NRMSE",            unit: "%", better: "lower",  dp: 1,
     desc: "Normalized root-mean-square error within the mask, after demeaning both maps. 0 = perfect; ~100% ≈ a flat map (the do-nothing baseline)." },
   nrmse_detrend:   { label: "Detrended NRMSE",  unit: "%", better: "lower",  dp: 1,
@@ -178,12 +182,23 @@ async function loadRuns() {
   return (await res.json()).runs || [];
 }
 
-async function loadAlgos() {
-  try {
-    const res = await fetch("algorithms.json", { cache: "no-store" });
-    return (await res.json()).algorithms || [];
-  } catch (e) { return []; }
+// algorithms.json bundles the method manifest AND the dataset/phantom registry (a `datasets` block
+// mirroring scripts/datasets.json) — fetch it once and serve both from the same promise.
+let _algoManifest = null;
+async function loadAlgoManifest() {
+  if (_algoManifest) return _algoManifest;
+  _algoManifest = (async () => {
+    try {
+      const res = await fetch("algorithms.json", { cache: "no-store" });
+      return await res.json();
+    } catch (e) { return {}; }
+  })();
+  return _algoManifest;
 }
+async function loadAlgos() { return (await loadAlgoManifest()).algorithms || []; }
+// Phantom registry: { <phantom-id>: { track, label, default, … } }. A run row's `phantom` field is
+// one of these keys; a row WITHOUT the field was scored on its track's default phantom.
+async function loadDatasets() { return (await loadAlgoManifest()).datasets || {}; }
 
 // The Zenodo method registry (qsm_ci/registry.json), served alongside the site. Maps a method slug
 // to its concept DOI + published versions, so pages can show a citable DOI per method.
@@ -320,4 +335,4 @@ function injectChrome() {
 document.addEventListener("DOMContentLoaded", injectChrome);
 
 // Exposed for module scripts (e.g. the NiiVue viewer, which must be a module for `import`).
-window.QSM = { GH, METRICS, STAGE_LABEL, MEDALS, loadRuns, loadAlgos, loadRegistry, doiFor, val, fmt, fmtDuration, fmtBytes, metricCols, robustRange, heatScale };
+window.QSM = { GH, METRICS, STAGE_LABEL, MEDALS, loadRuns, loadAlgos, loadDatasets, loadRegistry, doiFor, val, fmt, fmtDuration, fmtBytes, metricCols, robustRange, heatScale };

--- a/web/js/viewer.js
+++ b/web/js/viewer.js
@@ -6,7 +6,7 @@ import { Niivue } from "https://unpkg.com/@niivue/niivue@0.57.0/dist/index.js";
 import { renderResources } from "./resourceChart.js";
 import { makeWindowControl, winControls } from "./windowControl.js";
 
-const { loadRuns, loadAlgos, loadRegistry, doiFor, METRICS, STAGE_LABEL, val, fmt, robustRange, heatScale } = window.QSM;
+const { loadRuns, loadAlgos, loadDatasets, loadRegistry, doiFor, METRICS, STAGE_LABEL, val, fmt, robustRange, heatScale } = window.QSM;
 
 const STAGE_COLOR = {
   "field-mapping": "bg-indigo-50 text-indigo-700 ring-indigo-100 dark:bg-indigo-500/10 dark:text-indigo-300 dark:ring-indigo-500/20",
@@ -152,7 +152,7 @@ function renderHowToRun() {
   }));
 }
 
-let allRuns = [], algos = [], registry = {};
+let allRuns = [], algos = [], registry = {}, datasetsReg = {};
 let nv = null, run, baseUrl, filter = "", navMode = "stages", domain = "qsm";
 let curBase = "recon";       // base map shown underneath: recon | truth
 let chisepComp = "para";     // χ-separation source shown: para (χ+) | dia (χ−)
@@ -175,6 +175,13 @@ const composedRuns = () => allRuns.filter((r) => r.mode === "composed" && r.comb
 const chisepRuns = () => allRuns.filter((r) => (r.domain === "chisep" || r.stage === "chi-separation")
   && (r.variant || "default") === "default");
 const hasChisep = () => chisepRuns().length > 0;
+// χ-separation phantoms (the chisep-track entries of the dataset registry, shipped in
+// algorithms.json's `datasets` block): a run row's `phantom` field names the phantom it was scored
+// on; absence (older rows) means the track's default phantom.
+const chisepPhantomIds = () => Object.keys(datasetsReg).filter((k) => datasetsReg[k].track === "chisep");
+const chisepDefaultPhantom = () => chisepPhantomIds().find((k) => datasetsReg[k].default) || "chisep";
+const chisepPhantomOf = (r) => (chisepPhantomIds().includes(r.phantom) ? r.phantom : chisepDefaultPhantom());
+const phantomLabel = (p) => (datasetsReg[p] || {}).label || p;
 // In-vivo (2016 challenge) runs: a distinct DATASET (not just a domain) — dipole-only, scored vs
 // COSMOS + STI χ33. One flat list, default variant only, like χ-separation.
 const isInvivo = (r) => r.track === "invivo";
@@ -241,11 +248,12 @@ function currentCombo() {
 }
 function runItem(r, activeId) {
   const active = r && r.id === activeId;
-  // χ-separation rows carry no plain xsim; headline the mean χ+/χ− detrended NRMSE (the leaderboard's
-  // ranking metric — scale-independent and, unlike xSIM, sensitive to the anisotropy magnitude error).
+  // χ-separation rows carry no plain xsim; headline the mean χ+/χ− per-ROI MSPE (the leaderboard's
+  // ranking metric, following Ridani et al. 2026), falling back to detrended NRMSE where MSPE is absent.
   const m = (r && r.metrics) || {};
   let hv, hk = "xsim";
   if (m.xsim != null) hv = m.xsim;
+  else if (m.para_mspe != null && m.dia_mspe != null) { hv = (m.para_mspe + m.dia_mspe) / 2; hk = "mspe"; }
   else if (m.para_nrmse_detrend != null && m.dia_nrmse_detrend != null) { hv = (m.para_nrmse_detrend + m.dia_nrmse_detrend) / 2; hk = "nrmse_detrend"; }
   else if (m.para_xsim != null && m.dia_xsim != null) hv = (m.para_xsim + m.dia_xsim) / 2;
   else hv = r ? val(r, "xsim") : null;
@@ -300,8 +308,15 @@ function chisepHTML() {
   const f = filter.toLowerCase();
   const rs = chisepRuns().filter((r) => !f || r.name.toLowerCase().includes(f));
   if (!rs.length) return `<p class="p-3 text-sm text-gray-400">No χ-separation methods yet.</p>`;
-  const rows = rs.map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("");
-  return `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">χ-separation</div>${rows}</div>`;
+  // Group by the phantom each run was scored on (default phantom first). With a single phantom this
+  // renders the one historical "χ-separation" section unchanged.
+  const d = chisepDefaultPhantom();
+  const phs = uniq(rs.map(chisepPhantomOf)).sort((a, b) => (a === d ? -1 : b === d ? 1 : a < b ? -1 : 1));
+  return phs.map((p) => {
+    const rows = rs.filter((r) => chisepPhantomOf(r) === p).map((r) => runItem(r, run?.id).replace("%NAME%", r.name)).join("");
+    const head = phs.length > 1 ? `χ-separation · ${phantomLabel(p)}` : "χ-separation";
+    return `<div class="mb-3"><div class="px-2.5 pt-1 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">${head}</div>${rows}</div>`;
+  }).join("");
 }
 function invivoHTML() {
   const f = filter.toLowerCase();
@@ -459,8 +474,11 @@ async function loadRun() {
   $("sub-title").textContent = run.name;
   const stageCls = STAGE_COLOR[run.stage] || "bg-gray-100 text-gray-600 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700";
   const ds = DATASET_BADGE[datasetOf(run)];
+  // A χ-separation run on a non-default phantom names that phantom (registry label) in its badge.
+  const dsLabel = (datasetOf(run) === "chisep" && chisepPhantomOf(run) !== chisepDefaultPhantom())
+    ? phantomLabel(chisepPhantomOf(run)) : ds[0];
   $("sub-badges").innerHTML =
-    badge(ds[0], ds[1]) +
+    badge(dsLabel, ds[1]) +
     badge(STAGE_LABEL[run.stage] || run.stage, stageCls) +
     badge(run.mode === "composed" ? "Composed pipeline" : "Isolated", "bg-gray-100 text-gray-600 ring-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-700") +
     (run.status === "DNF" ? badge("DNF", "bg-red-50 text-red-600 ring-red-100 dark:bg-red-500/10 dark:text-red-400 dark:ring-red-500/20") : "") +
@@ -573,6 +591,10 @@ function renderChisepMetrics() {
     const p = r.metrics ? r.metrics.para_xsim : null, d = r.metrics ? r.metrics.dia_xsim : null;
     return (p != null && d != null) ? (p + d) / 2 : null;
   };
+  const avgMspeAcc = (r) => {
+    const p = r.metrics ? r.metrics.para_mspe : null, d = r.metrics ? r.metrics.dia_mspe : null;
+    return (p != null && d != null) ? (p + d) / 2 : null;
+  };
   const rtAcc = (r) => (r.runtime_s == null ? null : r.runtime_s);
   const memAcc = (r) => (r.mem_peak_bytes == null ? null : r.mem_peak_bytes);
   const cpuAcc = (r) => (r.cpu_cores_avg == null ? null : r.cpu_cores_avg);
@@ -583,23 +605,26 @@ function renderChisepMetrics() {
   // rows: [label, accessor, formatKey, arrow, tip]: accessor(r) yields the value for run r (so peers
   // can be ranked the same way), arrow "↑" = higher-is-better.
   const groups = [
-    [null, [["Avg xSIM", avgAcc, "xsim", "↑", "Mean of the χ+ and χ− xSIM: the headline combined score."]]],
+    [null, [["Avg MSPE", avgMspeAcc, "pct", "↓", "Mean of the χ+ and χ− per-ROI MSPE: the headline combined score (Ridani et al. 2026)."]]],
     ["χ+ paramagnetic (iron, veins)", [
+      ["MSPE", mv("para_mspe"), "pct", "↓", "Per-ROI MSPE of χ+ over the iron nuclei + GM (mean squared %-error of ROI means). WM excluded (χ+ ~1 ppb → unstable %)."],
       ["xSIM", mv("para_xsim"), "xsim", "↑", "Structural similarity of χ+ vs ground truth."],
       ["NRMSE", mv("para_nrmse"), "pct", "↓", "Normalised RMS error of χ+ (%)."],
       ["DGM NRMSE", mv("para_nrmse_dgm"), "pct", "↓", "χ+ error in deep gray matter (iron)."],
       ["DGM linearity", mv("para_dgm_linearity"), "num", "↓", "|1 − slope| of χ+ across DGM iron regions; 0 = perfect iron quantification."],
       ["Vein NRMSE", mv("para_nrmse_blood"), "pct", "↓", "χ+ error in venous blood."],
       ["Ca leak", mv("para_calc_leak"), "num", "↓", "Mean |χ+| in the calcification (should be ~0): calcium wrongly bleeding into the paramagnetic map."],
-      ["χ−→χ+ leak", mv("para_leak"), "num", "↓", "Whole-brain regression slope of χ+ on the χ− ground truth: the fraction of diamagnetic signal bleeding into the paramagnetic map (0 = clean). Unlike xSIM it isn't fooled by the shared R2' common mode."],
+      ["χ−→χ+ leak", mv("para_leak"), "num", "↓", "Regression slope of χ+ on the χ− ground truth: how much diamagnetic signal bleeds into the paramagnetic map. 0 = clean; positive = leakage; negative = over-separation (χ+ suppressed where χ− is strong)."],
     ]],
     ["χ− diamagnetic (calcium, myelin)", [
+      ["MSPE", mv("dia_mspe"), "pct", "↓", "Per-ROI MSPE of χ− over the fibre-bundle atlas WM sub-ROIs (Ridani et al. 2026, Fig 3) — the metric anisotropy makes hardest."],
       ["xSIM", mv("dia_xsim"), "xsim", "↑", "Structural similarity of χ− vs ground truth."],
       ["NRMSE", mv("dia_nrmse"), "pct", "↓", "Normalised RMS error of χ− (%)."],
       ["Ca dev", mv("dia_calc_moment_dev"), "num", "↓", "Deviation of the recovered calcification's susceptibility moment."],
       ["Streaking", mv("dia_calc_streak"), "num", "↓", "Streaking-artifact level around the calcification."],
+      ["MEV", mv("dia_mev"), "pct", "↓", "Maximum error variation (Ridani et al. 2026, Fig 5): fractional drop in χ− error from fibres parallel to B0 to perpendicular. A diagnostic of orientation-dependent error, not a ranking metric."],
       ["Fe leak", mv("dia_iron_leak"), "num", "↓", "Mean |χ−| in DGM/veins (should be ~0): iron wrongly bleeding into the diamagnetic map."],
-      ["χ+→χ− leak", mv("dia_leak"), "num", "↓", "Whole-brain regression slope of χ− on the χ+ ground truth: the fraction of paramagnetic signal bleeding into the diamagnetic map (0 = clean). The whole-map counterpart to the DGM iron leakage above; unlike xSIM it isn't fooled by the shared R2' common mode."],
+      ["χ+→χ− leak", mv("dia_leak"), "num", "↓", "Regression slope of χ− on the χ+ ground truth: how much paramagnetic signal bleeds into the diamagnetic map. 0 = clean; positive = leakage; negative = over-separation (χ− suppressed where χ+ is strong)."],
     ]],
     ["Resources", [
       ["Runtime", rtAcc, "sec", "↓", "Wall-clock runtime."],
@@ -613,7 +638,7 @@ function renderChisepMetrics() {
     for (const [label, acc, fk, arrow, tip] of rows) {
       const v = acc(run);
       if (v == null) continue;
-      const hero = label === "Avg xSIM";
+      const hero = label === "Avg MSPE";
       const rk = rankBy(acc, arrow === "↑");
       const rankCell = rk
         ? `<span class="inline-block rounded-md px-1.5 py-0.5 text-xs font-semibold text-white shadow-sm" style="background:${heatScale(rk.t)}" data-tip="Rank ${rk.rank} of ${rk.n} χ-separation methods for ${label}">#${rk.rank}<span class="opacity-70"> / ${rk.n}</span></span>`
@@ -868,7 +893,7 @@ function setErrorColormap() {
 
 // ---- boot -------------------------------------------------------------------
 async function init() {
-  [allRuns, algos, registry] = await Promise.all([loadRuns(), loadAlgos(), loadRegistry()]);
+  [allRuns, algos, registry, datasetsReg] = await Promise.all([loadRuns(), loadAlgos(), loadRegistry(), loadDatasets()]);
   // Accept ?run=<run-id> (e.g. ismv-iso), or a bare slug via ?run= / ?method= (e.g. ?method=ismv,
   // the form Zenodo records link to) → resolve to that algorithm's isolated run.
   const q = new URLSearchParams(location.search);

--- a/web/results.html
+++ b/web/results.html
@@ -626,8 +626,16 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
 
       <div x-show="chisepView==='board'" x-cloak>
 
-      <!-- table controls (filter + metric columns) -->
+      <!-- table controls (phantom selector + variant toggle + filter + metric columns) -->
       <div class="mt-6 flex flex-wrap items-center gap-3">
+        <!-- phantom selector: shown only when more than one chisep-track phantom has runs -->
+        <template x-if="chisepPhantoms().length > 1">
+          <span class="seg">
+            <template x-for="p in chisepPhantoms()" :key="p">
+              <button class="seg-btn" :class="{'seg-on': chisepPhantom===p}" @click="chisepPhantom=p" x-text="phantomLabel(p)" data-tip="Which χ-separation phantom the leaderboard shows — each is scored independently."></button>
+            </template>
+          </span>
+        </template>
         <template x-if="hasChisepTuned()">
           <span class="seg">
             <button class="seg-btn" :class="{'seg-on': variant==='default'}" @click="variant='default'">Defaults</button>
@@ -685,7 +693,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
                   <span x-show="r.status==='DNF'" class="ml-2 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold text-gray-500">DNF</span>
                 </td>
                 <template x-for="c in chisepDisplayCols()" :key="c.key">
-                  <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="(chisepSort===c.key || c.key==='avg_ndt') ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="chiFmt(chiVal(r, c.key), c.key)"></td>
+                  <td class="px-4 py-3 text-right tabular-nums group-hover:bg-emerald-50/40" :class="(chisepSort===c.key || c.key==='avg_mspe') ? 'font-semibold text-gray-900' : 'text-gray-600'" x-text="chiFmt(chiVal(r, c.key), c.key)"></td>
                 </template>
               </tr>
             </template>
@@ -716,11 +724,25 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       <div x-show="chisepView==='info'" x-cloak class="info mt-6 space-y-8">
         <div>
           <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">&chi;-separation (2026)</h2>
-          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">Susceptibility source separation splits the net susceptibility &chi; into a paramagnetic part &chi;&#8314; (iron) and a diamagnetic part &chi;&#8315; (myelin, calcium). Plain QSM measures only their signed sum, &chi;<sub>total</sub> = &chi;&#8314; + &chi;&#8315;, in which the two partly cancel, so it cannot tell them apart. The reversible relaxation rate R2&prime; responds instead to their combined magnitude, |&chi;&#8314;| + |&chi;&#8315;|. Having both the signed sum and the magnitude gives two independent constraints per voxel, which is what makes the sources recoverable. Each method is given &chi;<sub>total</sub>, R2&prime; and the local field, and must produce &chi;&#8314; and &chi;&#8315;, which are scored separately.</p>
+          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">Susceptibility source separation splits the net susceptibility &chi; into a paramagnetic part &chi;&#8314; (iron) and a diamagnetic part &chi;&#8315; (myelin, calcium). Plain QSM measures only their signed sum, &chi;<sub>total</sub> = &chi;&#8314; + &chi;&#8315;, in which the two partly cancel, so it cannot tell them apart. The reversible relaxation rate R2&prime; responds instead to their combined magnitude, |&chi;&#8314;| + |&chi;&#8315;|. Having both the signed sum and the magnitude gives two independent constraints per voxel, which is what makes the sources recoverable. Each method is given &chi;<sub>total</sub>, R2&prime;, the local field and the multi-echo signals, and must produce &chi;&#8314; and &chi;&#8315;, which are scored separately.</p>
         </div>
         <div>
-          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">The phantom</h3>
-          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">The &chi;-separation phantom implements the Susceptibility-Separation-Phantom of <a href="https://doi.org/10.64898/2026.04.07.716972" class="text-emerald-600 hover:underline">Ridani et&nbsp;al. (2026)</a> on the Challenge&nbsp;2.0 head model (<a href="https://doi.org/10.1002/mrm.28716" class="text-emerald-600 hover:underline">Marques et&nbsp;al., 2021</a>), via <a href="https://github.com/astewartau/qsm-forward" class="text-emerald-600 hover:underline">qsm-forward</a>. It adds the &chi;&#8314;/&chi;&#8315; source maps (the scoring targets) and an R2&prime; map, and simulates the multi-echo GRE and spin-echo signals from them. &chi;&#8314; and &chi;&#8315; are built per tissue and summed to give &chi;<sub>total</sub>, so the net susceptibility comes from the same anatomy as the In&nbsp;silico dataset.</p>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">The phantoms</h3>
+          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">Four phantoms are scored independently, all built on the Challenge&nbsp;2.0 head model (<a href="https://doi.org/10.1002/mrm.28716" class="text-emerald-600 hover:underline">Marques et&nbsp;al., 2021</a>) via <a href="https://github.com/astewartau/qsm-forward" class="text-emerald-600 hover:underline">qsm-forward</a>, and switchable with the leaderboard&rsquo;s phantom selector. The first three reproduce the Susceptibility-Separation-Phantom of <a href="https://doi.org/10.1002/mrm.70468" class="text-emerald-600 hover:underline">Ridani et&nbsp;al. (2026)</a> &mdash; verified voxelwise against the authors&rsquo; own ground truth (isotropic &chi;&#8315; matches to &lt;&nbsp;10&#8315;&#8309;&nbsp;ppm; per-ROI means to &le;&nbsp;5&times;10&#8315;&#8308;&nbsp;ppm) &mdash; and the fourth is a QSM-CI extension that makes white-matter anisotropy recoverable from the signal itself.</p>
+          <div class="mt-3 overflow-x-auto">
+            <table class="w-full text-sm text-left text-gray-600 dark:text-gray-400">
+              <thead class="text-xs uppercase text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                <tr><th class="py-2 pr-4">Phantom</th><th class="py-2 pr-4">Field / echoes</th><th class="py-2 pr-4">&chi;&#8315; anisotropy</th><th class="py-2 pr-4">D<sub>r</sub></th><th class="py-2 pr-4">Signal</th></tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+                <tr><td class="py-2 pr-4 font-medium text-gray-800 dark:text-gray-200">Ridani 3T isotropic</td><td class="py-2 pr-4">3&nbsp;T / 6</td><td class="py-2 pr-4">none (constant D<sub>r</sub>&#8315;)</td><td class="py-2 pr-4">scaled (theoretical)</td><td class="py-2 pr-4">mono-exponential</td></tr>
+                <tr><td class="py-2 pr-4 font-medium text-gray-800 dark:text-gray-200">Ridani 3T anisotropic</td><td class="py-2 pr-4">3&nbsp;T / 6</td><td class="py-2 pr-4">D<sub>r</sub>&#8315;(&theta;) &prop; sin&sup2;&theta;</td><td class="py-2 pr-4">scaled (theoretical)</td><td class="py-2 pr-4">mono-exponential</td></tr>
+                <tr><td class="py-2 pr-4 font-medium text-gray-800 dark:text-gray-200">Ridani 7T anisotropic</td><td class="py-2 pr-4">7&nbsp;T / 4</td><td class="py-2 pr-4">D<sub>r</sub>&#8315;(&theta;) &prop; sin&sup2;&theta;</td><td class="py-2 pr-4">scaled (theoretical)</td><td class="py-2 pr-4">mono-exponential</td></tr>
+                <tr><td class="py-2 pr-4 font-medium text-gray-800 dark:text-gray-200">&chi;-sep multicompartment</td><td class="py-2 pr-4">7&nbsp;T / 8</td><td class="py-2 pr-4">&theta;-encoded in the signal</td><td class="py-2 pr-4">fixed (D<sub>r</sub>&#8314;&nbsp;=&nbsp;320)</td><td class="py-2 pr-4">hollow-cylinder 3-pool</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">The Ridani sets are noiseless and gradient-echo-only at native 0.64&nbsp;mm; they deliberately omit a fibre-orientation input so orientation cannot be handed to methods (a closed-form solver given the fibre angle separates the anisotropic phantom almost exactly). The multicompartment phantom is 1&nbsp;mm with a matched spin-echo and &mdash; uniquely &mdash; a non-mono-exponential white-matter GRE decay, so the fibre angle can be recovered from the signal beat rather than needing DTI. &chi;&#8314; and &chi;&#8315; are built per tissue and summed to give &chi;<sub>total</sub>, so the net susceptibility shares the same anatomy as the In&nbsp;silico dataset.</p>
         </div>
         <div>
           <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">The forward model</h3>
@@ -741,41 +763,52 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">The true relaxivity is source-dependent, so R2&prime; is built as</p>
           <div class="mt-3 overflow-x-auto text-gray-800 dark:text-gray-100">$$R_2' = D_r^+\,|\chi^+| + D_r^-(\theta)\,|\chi^-|, \qquad D_r^-(\theta) \propto \sin^2\!\theta$$</div>
           <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">D<sub>r</sub> comes from the static-dephasing model (<a href="https://doi.org/10.1002/mrm.1910320610" class="text-emerald-600 hover:underline">Yablonskiy &amp; Haacke, 1994</a>): spheres for &chi;&#8314;, cylinders for &chi;&#8315;, giving D<sub>r</sub>&#8314; = 107.84&middot;B&#8320; for iron and D<sub>r</sub>&#8315; = 133.77&middot;sin&sup2;&theta;&middot;B&#8320; for myelin (755 and 936&middot;sin&sup2;&theta; Hz/ppm at 7&nbsp;T). These grow with field and run about 5&times; higher than measured in&nbsp;vivo &mdash; not an error, but the idealisation the model makes: static dephasing assumes perfectly static spins around ideal spheres/cylinders, whereas real tissue has diffusion averaging and heterogeneous microstructure that lower the <em>effective</em> relaxivity, so empirical calibrations (e.g. Shin&nbsp;et&nbsp;al.) land well below the theoretical value.</p>
-          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">The <em>fixed</em> setting (default) rescales both by a single factor so the iron value matches the measured D<sub>r</sub>&#8314; = 137&nbsp;Hz/ppm (<a href="https://doi.org/10.1016/j.neuroimage.2021.118371" class="text-emerald-600 hover:underline">Shin et&nbsp;al., 2021</a>); the same factor puts the myelin value at D<sub>r</sub>&#8315; = 170&middot;sin&sup2;&theta; (0 to 170 across fibre angles). These are field-independent. The <em>scaled</em> setting keeps the static-dephasing values above instead. Both share the same &chi;&#8314;/&chi;&#8315; ground truth.</p>
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed"><strong>Why fixed?</strong> Methods assume D<sub>r</sub>&nbsp;&asymp;&nbsp;137, so this scores separation rather than D<sub>r</sub> calibration; the scaled 755 would penalise methods on scale alone. <em>Scaled</em> is field-physical and matches the reference, but is less comparable across methods.</p>
+          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">The three Ridani phantoms use the <em>scaled</em> setting &mdash; the static-dephasing values above, field-consistent and matching the reference exactly. The multicompartment phantom uses a <em>fixed</em> setting: both relaxivities are rescaled by a single factor so the iron value is D<sub>r</sub>&#8314; = 320&nbsp;Hz/ppm (the field-scaled empirical calibration of <a href="https://doi.org/10.1016/j.neuroimage.2021.118371" class="text-emerald-600 hover:underline">Shin et&nbsp;al., 2021</a> at 7&nbsp;T), field-independent, with the same &chi;&#8314;/&chi;&#8315; ground truth.</p>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed"><strong>Scaled vs fixed.</strong> <em>Scaled</em> is field-physical and reproduces Ridani; on such a phantom, methods that assume a lower empirical D<sub>r</sub> carry a scale offset (an informative, real model error). <em>Fixed</em> anchors D<sub>r</sub>&#8314; to the empirical value so the score reflects separation rather than D<sub>r</sub> calibration.</p>
           <h4 class="mt-5 font-semibold text-gray-900 dark:text-gray-100">The signal</h4>
           <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">The simulated multi-echo GRE magnitude carries the separated sources through R2&prime; rather than a single lumped R2*, so its decay is written directly in terms of &chi;&#8314; and &chi;&#8315;:</p>
           <div class="mt-3 overflow-x-auto text-gray-800 dark:text-gray-100">$$S(\mathrm{TE}) = M_0\,\exp\!\big[-\mathrm{TE}\,\big(\underbrace{R_2}_{\text{irreversible}} + \underbrace{D_r^+|\chi^+| + D_r^-(\theta)\,|\chi^-|}_{R_2'}\big)\big]$$</div>
-          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">so the effective decay rate is R2* = R2 + R2&prime;. A matched spin-echo removes the reversible term and decays with R2 alone (\(S(\mathrm{TE}) = M_0\,e^{-\mathrm{TE}\,R_2}\)), letting a signal-domain method estimate R2&prime; = R2* &minus; R2 itself instead of relying on the provided R2&prime; map.</p>
+          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">so the effective decay rate is R2* = R2 + R2&prime;. On the multicompartment phantom the matched spin-echo removes the reversible term and decays with R2 alone (\(S(\mathrm{TE}) = M_0\,e^{-\mathrm{TE}\,R_2}\)), letting a signal-domain method estimate R2&prime; = R2* &minus; R2 itself instead of relying on the provided R2&prime; map.</p>
+          <h4 class="mt-5 font-semibold text-gray-900 dark:text-gray-100">The multicompartment signal (χ-sep MC)</h4>
+          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">On the Ridani phantoms the fibre angle &theta; enters only as a scalar that modulates the white-matter R2&prime; &mdash; so &theta; is <em>not</em> recoverable from a single-orientation acquisition, and white-matter &chi;&#8315; is unbeatable without an external DTI input. The multicompartment phantom removes that ceiling: white matter is modelled as three water pools (myelin, axonal, extra-axonal) with orientation-dependent frequency offsets (a hollow-cylinder model, <a href="https://doi.org/10.1073/pnas.1211075109" class="text-emerald-600 hover:underline">Wharton &amp; Bowtell, 2012</a>). The pools beat against each other, giving a non-mono-exponential magnitude whose shape encodes &theta; and the myelin-water fraction &mdash; so a method can recover both from the GRE signal alone. This makes it the only phantom where anisotropy-aware separation can win without being handed the fibre orientation.</p>
+        </div>
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Scoring</h3>
+          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">The headline metric is the <strong>per-ROI MSPE</strong> (mean squared percentage error of ROI means) of <a href="https://doi.org/10.1002/mrm.70468" class="text-emerald-600 hover:underline">Ridani et&nbsp;al. (2026)</a>, so the numbers are directly comparable to the paper: &chi;&#8314; is averaged over the deep-gray-matter iron nuclei and cortical gray matter, &chi;&#8315; over the white-matter fibre bundles of a co-registered atlas. Detrended NRMSE (scale-independent, voxelwise) and xSIM are also reported per source. For the anisotropic phantoms a <strong>MEV</strong> diagnostic (maximum error variation) reports how much the &chi;&#8315; error falls from fibres parallel to B&#8320; to perpendicular. Each phantom also carries a <em>null</em> baseline &mdash; the closed-form solve with the phantom&rsquo;s own assumptions &mdash; that any real method must beat.</p>
         </div>
         <div>
           <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Differences from the reference phantom</h3>
-          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">The &chi;&#8314;/&chi;&#8315; construction and white-matter anisotropy (including the seeded R1-weighted noise) reproduce <a href="https://doi.org/10.64898/2026.04.07.716972" class="text-emerald-600 hover:underline">Ridani et&nbsp;al. (2026)</a>. Three aspects differ:</p>
+          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">The three Ridani phantoms reproduce the &chi;&#8314;/&chi;&#8315; construction, white-matter anisotropy and acquisition of <a href="https://doi.org/10.1002/mrm.70468" class="text-emerald-600 hover:underline">Ridani et&nbsp;al. (2026)</a>, and their ground truth is verified voxelwise against the authors&rsquo; own OSF data. A few implementation choices differ:</p>
           <ul class="mt-2 list-disc pl-5 space-y-1 text-gray-600 dark:text-gray-400 leading-relaxed">
-            <li><strong>Dr magnitude.</strong> The <em>fixed</em> D<sub>r</sub>&#8314; = 137&nbsp;Hz/ppm (above), not the reference&rsquo;s field-scaled &asymp;&nbsp;755 at 7&nbsp;T. Only R2&prime; / signal magnitude change; the &chi;&#8314;/&chi;&#8315; ground truth is identical.</li>
-            <li><strong>Provided maps masked to the brain.</strong> The &chi;<sub>total</sub>, R2&prime; and local-field <em>inputs</em> and the ground truth are restricted to the brain (a real QSM is brain-masked); the raw phase, magnitude and spin-echo keep the whole-head background field, so full pipelines can still unwrap and remove it. The reference ships every map whole-head.</li>
-            <li><strong>Sign enforced.</strong> &chi;&#8314; is clamped &ge;&nbsp;0 and &chi;&#8315; &le;&nbsp;0 (a source map cannot flip sign); this nudges ~7% of &chi;&#8314; voxels by &le;&nbsp;0.03&nbsp;ppm.</li>
+            <li><strong>Orientation withheld.</strong> No fibre-angle (DTI) input is shipped, so a method cannot be handed the orientation that would make the anisotropic phantom nearly closed-form solvable. It must recover white-matter &chi;&#8315; from the field and R2&prime; alone (or, on the multicompartment phantom, from the signal beat).</li>
+            <li><strong>Seeded noise.</strong> The reference&rsquo;s white-matter texture noise is seeded here for reproducibility, so the ground truth is bit-reproducible; the authors&rsquo; unseeded realisation is matched only in distribution.</li>
+            <li><strong>Sign enforced.</strong> &chi;&#8314; is clamped &ge;&nbsp;0 and &chi;&#8315; &le;&nbsp;0 (a source map cannot flip sign).</li>
+            <li><strong>Multicompartment (&chi;-sep MC only).</strong> The 7&nbsp;T fixed-D<sub>r</sub> phantom additionally simulates the hollow-cylinder white-matter signal and a matched spin-echo &mdash; a QSM-CI extension beyond the reference&rsquo;s mono-exponential model.</li>
           </ul>
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">The diffusion V1 eigenvector is stored mirrored (L-A-S) relative to the segmentation; qsm-forward flips it to register the fibres, which reproduces the reference&rsquo;s published fibre-angle map exactly. The public reference code omits this flip.</p>
         </div>
         <div>
-          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Reproduce the phantom</h3>
-          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">qsm-forward builds the phantom from a data directory holding the Challenge&nbsp;2.0 tissue-property maps and diffusion V1 eigenvector. Request those from the Donders repository (<a href="https://data.ru.nl/collections/di/dccn/DSC_3015069.02_542" class="text-emerald-600 hover:underline break-words">data.ru.nl/&hellip;/DSC_3015069.02_542</a>, DOI <a href="https://doi.org/10.34973/m20r-jt17" class="text-emerald-600 hover:underline">10.34973/m20r-jt17</a>), and add the white-matter tract mask from the <a href="https://github.com/neuropoly/Susceptibility-Separation-Phantom" class="text-emerald-600 hover:underline">Susceptibility-Separation-Phantom</a> repository (Ridani et&nbsp;al.). Then generate (7&nbsp;T, 4 echoes, 1&nbsp;mm):</p>
-          <pre class="mt-3 overflow-x-auto rounded-xl bg-gray-900 p-4 text-sm text-gray-100"><code class="language-bash">qsm-forward chi-sep data/ bids/
-# --dr-model scaled   field-scaled static-dephasing relaxivity (default: fixed)
-# --isotropic         disable white-matter anisotropy
-# --no-brain-mask     keep every map whole-head</code></pre>
-          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">This writes a standard BIDS tree (the &chi;&#8314;/&chi;&#8315; targets, &chi;<sub>total</sub>, R2&prime;, local field, and the multi-echo GRE and spin-echo signals). QSM-CI wraps it with <a href="https://github.com/astewartau/qsm-ci" class="text-emerald-600 hover:underline"><code>scripts/gen_chisep.py</code></a>, which applies the brain-masking of the provided maps and flattens the tree into the dataset layout; point <a href="running.html" class="text-emerald-600 hover:underline"><code>qsm-ci run</code></a> straight at the NIfTIs.</p>
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Reproduce the phantoms</h3>
+          <p class="mt-2 text-gray-600 dark:text-gray-400 leading-relaxed">qsm-forward builds the phantoms from a data directory holding the Challenge&nbsp;2.0 tissue-property maps and diffusion V1 eigenvector. Request those from the Donders repository (<a href="https://data.ru.nl/collections/di/dccn/DSC_3015069.02_542" class="text-emerald-600 hover:underline break-words">data.ru.nl/&hellip;/DSC_3015069.02_542</a>, DOI <a href="https://doi.org/10.34973/m20r-jt17" class="text-emerald-600 hover:underline">10.34973/m20r-jt17</a>), and add the white-matter tract mask from the <a href="https://github.com/neuropoly/Susceptibility-Separation-Phantom" class="text-emerald-600 hover:underline">Susceptibility-Separation-Phantom</a> repository (Ridani et&nbsp;al.). QSM-CI&rsquo;s <a href="https://github.com/astewartau/qsm-ci" class="text-emerald-600 hover:underline"><code>scripts/gen_chisep.py</code></a> then generates each phantom from a preset:</p>
+          <pre class="mt-3 overflow-x-auto rounded-xl bg-gray-900 p-4 text-sm text-gray-100"><code class="language-bash">gen_chisep.py --preset ridani-3t-iso    --out data/ridani-3t-iso
+gen_chisep.py --preset ridani-3t-aniso  --out data/ridani-3t-aniso
+gen_chisep.py --preset ridani-7t-aniso  --out data/ridani-7t-aniso
+gen_chisep.py --multicompartment --dr-model fixed --dr-fixed 320 \
+    --tes 3,9,15,21,27,33,39,45 --out data/chisep-mc   # χ-sep MC</code></pre>
+          <p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">Each preset sets the field, echo train, isotropy and relaxivity, simulates the signals and flattens the result into the dataset layout (public <code>inputs/</code>, held-out <code>groundtruth/</code>); point <a href="running.html" class="text-emerald-600 hover:underline"><code>qsm-ci run</code></a> straight at the NIfTIs.</p>
         </div>
         <div>
           <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Citations</h3>
           <ul class="mt-2 list-disc pl-5 space-y-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-            <li><strong>Separation phantom:</strong> Ridani S., De&nbsp;Leener B., Alonso-Ortiz E. &ldquo;A realistic in-silico brain phantom for quantifying susceptibility anisotropy-induced error in susceptibility separation.&rdquo; <em>bioRxiv</em> 2026. <a href="https://doi.org/10.64898/2026.04.07.716972" class="text-emerald-600 hover:underline">doi:10.64898/2026.04.07.716972</a>.</li>
+            <li><strong>Separation phantom:</strong> Ridani D., De&nbsp;Leener B., Alonso-Ortiz E. &ldquo;A realistic in-silico brain phantom for quantifying susceptibility anisotropy-induced error in susceptibility separation.&rdquo; <em>Magn Reson Med</em> 2026. <a href="https://doi.org/10.1002/mrm.70468" class="text-emerald-600 hover:underline">doi:10.1002/mrm.70468</a>.</li>
             <li><strong>Head model:</strong> Marques J.P., Meineke J., Milovic C., et&nbsp;al. &ldquo;QSM reconstruction challenge 2.0: a realistic in silico head phantom for MRI data simulation and evaluation of susceptibility mapping procedures.&rdquo; <em>Magn Reson Med</em> 2021;86(1):526&ndash;542. <a href="https://doi.org/10.1002/mrm.28716" class="text-emerald-600 hover:underline">doi:10.1002/mrm.28716</a>.</li>
             <li><strong>&chi;-separation model &amp; D<sub>r</sub>:</strong> Shin H.G., Lee J., Yun Y.H., et&nbsp;al. &ldquo;&chi;-separation: Magnetic susceptibility source separation toward iron and myelin mapping in the brain.&rdquo; <em>NeuroImage</em> 2021;240:118371. <a href="https://doi.org/10.1016/j.neuroimage.2021.118371" class="text-emerald-600 hover:underline">doi:10.1016/j.neuroimage.2021.118371</a>.</li>
             <li><strong>Static-dephasing regime:</strong> Yablonskiy D.A., Haacke E.M. &ldquo;Theory of NMR signal behavior in magnetically inhomogeneous tissues: the static dephasing regime.&rdquo; <em>Magn Reson Med</em> 1994;32(6):749&ndash;763. <a href="https://doi.org/10.1002/mrm.1910320610" class="text-emerald-600 hover:underline">doi:10.1002/mrm.1910320610</a>.</li>
             <li><strong>DECOMPOSE:</strong> Chen J., et&nbsp;al. &ldquo;Decompose QSM to sub-voxel diamagnetic and paramagnetic components based on gradient-echo MRI data.&rdquo; <em>NeuroImage</em> 2021. <a href="https://doi.org/10.1016/j.neuroimage.2021.118735" class="text-emerald-600 hover:underline">doi:10.1016/j.neuroimage.2021.118735</a>.</li>
             <li><strong>SUSEP-Net:</strong> Li, Gao, Sun, et&nbsp;al. &ldquo;SUSEP-Net: simulation-supervised contrastive learning for susceptibility source separation via a sub-voxel QSM network.&rdquo; arXiv:2506.13293, 2025. <a href="https://doi.org/10.48550/arXiv.2506.13293" class="text-emerald-600 hover:underline">doi:10.48550/arXiv.2506.13293</a>.</li>
             <li><strong>WaveSep:</strong> Fang Z., Shin H.G., van&nbsp;Zijl P., Li X., Sulam J. &ldquo;WaveSep: A Flexible Wavelet-Based Approach for Source Separation in Susceptibility Imaging.&rdquo; <em>MLCN, MICCAI</em> 2023. <a href="https://doi.org/10.1007/978-3-031-44858-4_6" class="text-emerald-600 hover:underline">doi:10.1007/978-3-031-44858-4_6</a>.</li>
+            <li><strong>R2*-QSM:</strong> Dimov A.V., et&nbsp;al. &ldquo;Magnetic Susceptibility Source Separation Solely from Gradient Echo Data: Histological Validation.&rdquo; <em>Tomography / J Neuroimaging</em> 2022. <a href="https://doi.org/10.1111/jon.13014" class="text-emerald-600 hover:underline">doi:10.1111/jon.13014</a>.</li>
+            <li><strong>Multicompartment white-matter signal:</strong> Wharton S., Bowtell R. &ldquo;Fiber orientation-dependent white matter contrast in gradient echo MRI.&rdquo; <em>PNAS</em> 2012;109(45):18559&ndash;18564. <a href="https://doi.org/10.1073/pnas.1211075109" class="text-emerald-600 hover:underline">doi:10.1073/pnas.1211075109</a>.</li>
           </ul>
         </div>
       </div>
@@ -959,7 +992,10 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
     // χ-separation metric catalog (para_*/dia_* aren't in the global METRICS registry). Drives the
     // customisable column picker + table. `f` is the formatter kind: xsim / pct / num / sec.
     const CHISEP_COLS = [
-      { key: "avg_ndt",             label: "Avg detr. NRMSE", better: "lower",  f: "pct",  tip: "Mean of the χ+ and χ− linearly-detrended NRMSE: the headline source-separation error, scale-independent (fair to a method's assumed Dr) and — unlike xSIM — sensitive to the magnitude error white-matter anisotropy induces. Lower is better." },
+      { key: "avg_mspe",            label: "Avg MSPE",        better: "lower",  f: "pct",  tip: "Mean of the χ+ and χ− per-ROI MSPE (Ridani et al. 2026) — the headline metric, comparable to the paper's published numbers. Lower is better." },
+      { key: "para_mspe",           label: "χ+ MSPE",         better: "lower",  f: "pct",  tip: "χ+ per-ROI MSPE over the iron nuclei + GM. WM excluded (χ+ ~1 ppb → unstable %). Lower is better." },
+      { key: "dia_mspe",            label: "χ− MSPE",         better: "lower",  f: "pct",  tip: "χ− per-ROI MSPE over the fibre-bundle atlas WM sub-ROIs (Ridani et al. 2026, Fig 3). Lower is better." },
+      { key: "avg_ndt",             label: "Avg detr. NRMSE", better: "lower",  f: "pct",  tip: "Mean of the χ+ and χ− linearly-detrended NRMSE: a voxelwise source-separation error, scale-independent (fair to a method's assumed Dr) and — unlike xSIM — sensitive to the magnitude error white-matter anisotropy induces. Lower is better." },
       { key: "avg",                 label: "Avg xSIM",        better: "higher", f: "xsim", tip: "Mean of the χ+ and χ− xSIM. Structural similarity only: lenient to the magnitude error anisotropy causes (the do-nothing null solve scores ~0.75 here), so it is not the ranking metric. Higher is better." },
       { key: "para_xsim",           label: "χ+ xSIM",         better: "higher", f: "xsim", tip: "Structural similarity of the χ+ (paramagnetic, iron) map vs ground truth. Higher is better." },
       { key: "para_nrmse",          label: "χ+ NRMSE",        better: "lower",  f: "pct",  tip: "Demeaned normalised RMS error of χ+ vs ground truth (%). Lower is better." },
@@ -968,14 +1004,15 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
       { key: "para_dgm_linearity",  label: "χ+ DGM linearity", better: "lower", f: "num",  tip: "|1 − slope| of χ+ across DGM iron regions; 0 = perfect iron quantification. Lower is better." },
       { key: "para_nrmse_blood",    label: "χ+ vein NRMSE",   better: "lower",  f: "pct",  tip: "χ+ error in venous blood (%). Lower is better." },
       { key: "para_calc_leak",      label: "χ+ Ca leak",      better: "lower",  f: "num",  tip: "Mean |χ+| in the calcification (should be ~0): calcium wrongly bleeding into the paramagnetic map. Lower is better." },
-      { key: "para_leak",           label: "χ−→χ+ leak",      better: "lower",  f: "num",  tip: "Whole-brain leakage: fraction of χ− (diamagnetic) signal bleeding into the χ+ map. 0 = clean. Lower is better." },
+      { key: "para_leak",           label: "χ−→χ+ leak",      better: "lower",  f: "num",  tip: "Whole-brain leakage: regression slope of χ+ on the χ− ground truth. 0 = clean; positive = χ− bleeds into χ+; negative = over-separation (χ+ suppressed where χ− is strong)." },
       { key: "dia_xsim",            label: "χ− xSIM",         better: "higher", f: "xsim", tip: "Structural similarity of the χ− (diamagnetic, myelin/calcium) map vs ground truth. Higher is better." },
       { key: "dia_nrmse",           label: "χ− NRMSE",        better: "lower",  f: "pct",  tip: "Demeaned normalised RMS error of χ− vs ground truth (%). Lower is better." },
       { key: "dia_nrmse_detrend",   label: "χ− detr. NRMSE",  better: "lower",  f: "pct",  tip: "χ− NRMSE after correcting a global linear scale (independent of a method's assumed Dr). The map anisotropy makes hardest. Lower is better." },
       { key: "dia_calc_moment_dev", label: "χ− Ca dev",       better: "lower",  f: "num",  tip: "Deviation of the recovered calcification's susceptibility moment. Lower is better." },
       { key: "dia_calc_streak",     label: "χ− streak",       better: "lower",  f: "num",  tip: "Streaking-artifact level around the calcification. Lower is better." },
+      { key: "dia_mev",             label: "χ− MEV",          better: "lower",  f: "pct",  tip: "Maximum error variation (Ridani et al. 2026, Fig 5): fractional drop in χ− error from fibres parallel to B0 to perpendicular. High = strongly orientation-dependent. A diagnostic, not a ranking metric." },
       { key: "dia_iron_leak",       label: "χ− Fe leak",      better: "lower",  f: "num",  tip: "Mean |χ−| in DGM/veins (should be ~0): iron wrongly bleeding into the diamagnetic map. Lower is better." },
-      { key: "dia_leak",            label: "χ+→χ− leak",      better: "lower",  f: "num",  tip: "Whole-brain leakage: fraction of χ+ (paramagnetic/iron) signal bleeding into the χ− map. 0 = clean. Lower is better." },
+      { key: "dia_leak",            label: "χ+→χ− leak",      better: "lower",  f: "num",  tip: "Whole-brain leakage: regression slope of χ− on the χ+ ground truth. 0 = clean; positive = χ+ bleeds into χ−; negative = over-separation (χ− suppressed where χ+ is strong)." },
       { key: "runtime_s",           label: "Runtime",         better: "lower",  f: "sec",  tip: "Wall-clock runtime." },
     ];
     const CHISEP_COL = Object.fromEntries(CHISEP_COLS.map((c) => [c.key, c]));
@@ -1018,7 +1055,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
 
       return {
         METRICS, STAGE_LABEL, MEDALS, fmt, val, INVIVO_COLS,
-        runs: [], registry: {}, algos: [], loading: true, _ready: false,
+        runs: [], registry: {}, algos: [], datasetsReg: {}, loading: true, _ready: false,
         // dataset (top level) + section tab state
         dataset: "sim",
         tab: "leaderboard", lbView: "pipelines", pipeView: "matrix", findView: "pipelines", view: "composed",
@@ -1027,8 +1064,9 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         stage: "dipole", fmap: "gt", variant: "default",
         metric: "xsim", sortKey: "xsim", sortDir: "desc", filter: "",
         colMenu: false, stageMenu: false, fmapMenu: false, metricMenu: false, selectedCols: ["nrmse", "correlation", "xsim", "runtime_s"],
-        chisepSort: "avg_ndt", chisepDir: "asc", chisepColMenu: false, chisepCols: CHISEP_COLS,
-        chisepSelectedCols: ["avg_ndt", "avg", "para_nrmse_detrend", "para_leak", "dia_nrmse_detrend", "dia_leak", "runtime_s"],
+        chisepPhantom: "chisep",   // which chisep-track phantom the board/findings show (re-derived in init)
+        chisepSort: "avg_mspe", chisepDir: "asc", chisepColMenu: false, chisepCols: CHISEP_COLS,
+        chisepSelectedCols: ["avg_mspe", "para_mspe", "dia_mspe", "avg_ndt", "para_nrmse_detrend", "dia_nrmse_detrend", "runtime_s"],
         invivoSortKey: "nrmse", invivoDir: "asc",   // in-vivo default sort: COSMOS NRMSE (2016 headline)
         invivoColMenu: false, invivoSelectedCols: INVIVO_COLS.map((c) => c.key),   // in-vivo metric column picker (all shown by default)
         // findings state
@@ -1101,10 +1139,14 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
             // the big reactive trigger, and name-dependent getters (matrix, findings) cache by
             // runs.length — if algos isn't loaded yet when they first compute, algoName() falls back to
             // raw slugs and the cache never refreshes. Assigning algos first avoids that.
-            const [algos, registry, runs] = await Promise.all([loadAlgos(), loadRegistry(), loadRuns()]);
+            const [algos, registry, runs, datasetsReg] = await Promise.all([loadAlgos(), loadRegistry(), loadRuns(), loadDatasets()]);
             this.algos = algos;
             this.registry = registry;
             this.runs = runs;
+            this.datasetsReg = datasetsReg;
+            // default phantom selection (deep-linkable via ?phantom=<id>)
+            this.chisepPhantom = this.chisepDefaultPhantom();
+            if (this.chisepPhantoms().includes(q.get("phantom"))) this.chisepPhantom = q.get("phantom");
             const st = this.stages();
             const sp = q.get("stage");
             if (sp === "pipelines") this.lbView = "pipelines";
@@ -1136,8 +1178,24 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         ciNotes(slug) { const a = this.algos.find((x) => x.slug === slug); return (a && a.ci_notes) || []; },
         algoName(slug) { const a = this.algos.find((x) => x.slug === slug); return (a && a.name) || slug; },
         _isChisep(r) { return r.domain === "chisep" || r.stage === "chi-separation"; },
-        _chisep() { return this.runs.filter((r) => this._isChisep(r)); },
-        hasChiSep() { return this._chisep().length > 0; },
+        _chisepAll() { return this.runs.filter((r) => this._isChisep(r)); },
+        // ---- χ-separation phantoms: several phantoms can share the chisep track (registry in
+        // datasetsReg, from algorithms.json's `datasets` block). A run row's `phantom` field names
+        // the one it was scored on; absence (older rows) means the track's default phantom. The
+        // board/findings show ONE phantom at a time (chisepPhantom, default = the registry default).
+        chisepPhantomIds() { const g = this.datasetsReg || {}; return Object.keys(g).filter((k) => g[k].track === "chisep"); },
+        chisepDefaultPhantom() { const g = this.datasetsReg || {}; return this.chisepPhantomIds().find((k) => g[k].default) || "chisep"; },
+        chisepPhantomOf(r) { return this.chisepPhantomIds().includes(r.phantom) ? r.phantom : this.chisepDefaultPhantom(); },
+        // phantoms that actually have runs, default phantom first — drives the selector (hidden when
+        // only one phantom has runs).
+        chisepPhantoms() {
+          const d = this.chisepDefaultPhantom();
+          return [...new Set(this._chisepAll().map((r) => this.chisepPhantomOf(r)))]
+            .sort((a, b) => (a === d ? -1 : b === d ? 1 : a < b ? -1 : 1));
+        },
+        phantomLabel(p) { return ((this.datasetsReg || {})[p] || {}).label || p; },
+        _chisep() { return this._chisepAll().filter((r) => this.chisepPhantomOf(r) === this.chisepPhantom); },
+        hasChiSep() { return this._chisepAll().length > 0; },
         // In-vivo (2016 challenge) dipole runs share stage==='dipole' with the sim leaderboard, so
         // every SIM-facing table/matrix/finding must exclude them (track==='invivo'); they live only
         // on their own In-vivo tab. Sim runs carry track==='sim' or (legacy) no track field.
@@ -1148,6 +1206,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
           const m = r.metrics || {};
           if (k === "avg") return (m.para_xsim != null && m.dia_xsim != null) ? (m.para_xsim + m.dia_xsim) / 2 : null;
           if (k === "avg_ndt") return (m.para_nrmse_detrend != null && m.dia_nrmse_detrend != null) ? (m.para_nrmse_detrend + m.dia_nrmse_detrend) / 2 : null;
+          if (k === "avg_mspe") return (m.para_mspe != null && m.dia_mspe != null) ? (m.para_mspe + m.dia_mspe) / 2 : null;
           return val(r, k);
         },
         chiFmt(v, key) {
@@ -1158,7 +1217,7 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         },
         chisepDisplayCols() {
           const sel = CHISEP_COLS.filter((c) => this.chisepSelectedCols.includes(c.key));
-          return sel.length ? sel : CHISEP_COLS.filter((c) => c.key === "avg_ndt");
+          return sel.length ? sel : CHISEP_COLS.filter((c) => c.key === "avg_mspe");
         },
         toggleChisepCol(k) {
           this.chisepSelectedCols = this.chisepSelectedCols.includes(k)
@@ -2001,9 +2060,9 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         },
 
         get chisepSVG() {
-          return _cache("cs", this.runs.length, () => {
+          return _cache("cs", this.runs.length + "|" + this.chisepPhantom, () => {
             const E = this._esc;
-            const rows = this.runs.filter((r) => this._isChisep(r) && r.metrics && r.metrics.para_xsim != null && r.metrics.dia_xsim != null)
+            const rows = this._chisep().filter((r) => r.metrics && r.metrics.para_xsim != null && r.metrics.dia_xsim != null)
               .map((r) => ({ id: r.id, name: r.name, para: r.metrics.para_xsim, dia: r.metrics.dia_xsim }));
             const w = 560, h = 300, padT = 34, padB = 34, xL = 155, xR = 405;
             if (!rows.length) return "<svg></svg>";
@@ -2027,9 +2086,9 @@ qsm-forward head ./qsm-challenge-2.0 bids_qsm --save-field</code></pre>
         },
 
         get leakSVG() {
-          return _cache("leak", this.runs.length, () => {
+          return _cache("leak", this.runs.length + "|" + this.chisepPhantom, () => {
             const E = this._esc;
-            const rows = this.runs.filter((r) => this._isChisep(r) && r.metrics && r.metrics.para_leak != null && r.metrics.dia_leak != null)
+            const rows = this._chisep().filter((r) => r.metrics && r.metrics.para_leak != null && r.metrics.dia_leak != null)
               .map((r) => ({ id: r.id, name: r.name, px: r.metrics.para_leak, py: r.metrics.dia_leak }));
             const w = 540, h = 380, pad = 46;
             if (!rows.length) return "<svg></svg>";


### PR DESCRIPTION
Turns the single χ-separation phantom into **four independently-scored phantoms**, adds the paper's evaluation metrics, and closes two algorithm gaps. Built on current `main` (cleanly reconciled with the recent chisep merges #137–#147).

## Datasets & registry
- **`scripts/datasets.json`** — a phantom registry (id → track / label / OSF file / path / `active` / `default`). `pipeline.py`, `score.yml`, `evaluate.yml`, `fetch_dataset.sh`, `gen_manifest.py` and the web are all driven by it. A track's *default* phantom keeps the legacy unsuffixed run ids; others are namespaced (`<id>-<phantom>`).
- Four χ-sep phantoms:
  - **ridani-3t-iso / ridani-3t-aniso / ridani-7t-aniso** — faithful reproductions of Ridani et al. (MRM 2026, doi:10.1002/mrm.70468), verified voxelwise against the authors' own OSF ground truth (isotropic χ− to <1e-5 ppm; per-ROI means to ≤5e-4 ppm).
  - **chisep-mc** — a QSM-CI multicompartment extension (hollow-cylinder WM signal) where white-matter anisotropy is recoverable from the GRE beat rather than needing DTI.
- **chisep-mc is the chisep-track default**; the original single `chisep` phantom is **retired** (mirrored-fibre; superseded).

## Metrics (paper-comparable)
- **Per-ROI MSPE** (Ridani Fig 3) is the new headline χ-sep metric — reproduces the paper's published algorithm numbers. χ+ over the DGM iron nuclei + GM; χ− over the fibre-bundle atlas WM sub-ROIs (`--wm-rois`).
- **θ-binned MSPE profile + MEV** orientation diagnostic (Ridani Fig 5; `--theta`).
- Detrended NRMSE / xSIM remain as columns; xSIM is no longer headlined.

## Submissions
- **r2star-qsm** — Dimov et al. 2022 (χ− MSPE 14.6 ≈ the paper's 15.5).
- **ridani-null-qsmci** — closed-form region-disjoint null baseline for the Ridani phantom family (exact on the isotropic phantom; honest floor on the anisotropic).

Both images are public on GHCR.

## Generator (`scripts/gen_chisep.py`)
- `--preset ridani-{3t-iso,3t-aniso,7t-aniso}`, `--voxel` (native-res), `--no-fiber-angle` (orientation withheld so it can't be handed to methods), `--no-se`/`--r2-input`, `--wm-rois-src`; ships `groundtruth/theta.nii.gz` + `wm_rois.nii.gz` for the metrics.
- **V1 L-A-S→R-A-S flip** — reproduces the reference's published fibre-angle map exactly (the public reference code omits this), replacing the earlier registration shift.

## Web
Phantom selector on the χ-sep tab (deep-linkable via `?phantom=`); MSPE headline + MSPE/MEV columns on the leaderboard and submission detail; Info-tab rewrite documenting all four phantoms.

## Depends on
qsm-forward ≥ v0.32 (multicompartment signal + 3T fidelity), already released.

## Activation
The four OSF datasets are uploaded and their secrets (`OSF_FILE_RIDANI_*`, `OSF_FILE_CHISEP_MC`) are set; registry entries are `active`. On merge, `score.yml` fans each χ-sep method out across all four phantoms.

Tests: 133 pass (the 13 `test_interfaces` failures are a pre-existing local-env `ImportError`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)